### PR TITLE
Add support for Goodix 27c6:5335

### DIFF
--- a/91-goodix-fingerprint.rules
+++ b/91-goodix-fingerprint.rules
@@ -1,5 +1,6 @@
-# Goodix HTK32 fingerprint sensor (27c6:5385, 27c6:5395)
+# Goodix HTK32 fingerprint sensor (27c6:5335, 27c6:5385, 27c6:5395)
 # Prevent cdc_acm from claiming the interfaces — the device exposes a CDC
 # descriptor that makes the kernel bind cdc_acm, blocking libfprint.
+ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5335", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
 ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5385", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
 ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5395", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Goodix HTK32 (27c6:5385 / 27c6:5395) libfprint Driver
+# Goodix HTK32 (27c6:5335 / 27c6:5385 / 27c6:5395) libfprint Driver
 
-A libfprint driver for the Goodix HTK32 fingerprint sensor found in the **Dell XPS 13 7390**, the **Dell XPS 15 9570** and possibly other laptops using the `27c6:5385` or `27c6:5395` USB device.
+A libfprint driver for the Goodix HTK32 fingerprint sensor found in the **Dell XPS 13 9305**, the **Dell XPS 13 7390**, the **Dell XPS 15 9570** and possibly other laptops using the `27c6:5335`, `27c6:5385` or `27c6:5395` USB device.
 
 ## Hardware
 
 - **Vendor ID:** `0x27c6`
-- **Product IDs:** `0x5385`, `0x5395`
+- **Product IDs:** `0x5335`, `0x5385`, `0x5395`
 - **Sensor:** 108 x 88 pixels, capacitive press-type
-- **Known devices:** Dell XPS 13 7390 2-in-1, Dell XPS 15 9570
+- **Known devices:** Dell XPS 13 9305, Dell XPS 13 7390 2-in-1, Dell XPS 15 9570
 
 Check if you have this sensor:
 ```
-lsusb | grep -E '27c6:(5385|5395)'
+lsusb | grep -E '27c6:(5335|5385|5395)'
 ```
 
 ## How It Works

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -1846,6 +1846,7 @@ fpi_device_goodix53x5_init (FpiDeviceGoodix53x5 *self)
 }
 
 static const FpIdEntry goodix53x5_id_table[] = {
+  { .vid = 0x27c6, .pid = 0x5335, },
   { .vid = 0x27c6, .pid = 0x5385, },
   { .vid = 0x27c6, .pid = 0x5395, },
   { .vid = 0, .pid = 0, .driver_data = 0 },


### PR DESCRIPTION
Adds the Goodix HTK32 27c6:5335 USB product ID used by the Dell XPS 13 9305.\n\nThis updates the driver ID table, README device list, and udev cdc_acm unbind rule so the device is detected and the kernel ACM driver does not keep the data interface claimed.