### PR TITLE
Reset Goodix USB device before protocol open

### DIFF
--- a/91-goodix-fingerprint.rules
+++ b/91-goodix-fingerprint.rules
@@ -1,6 +1,10 @@
 # Goodix HTK32 fingerprint sensor (27c6:5335, 27c6:5385, 27c6:5395)
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="27c6", ATTR{idProduct}=="5335", ENV{ID_AUTOSUSPEND}="0", ATTR{power/control}="on"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="27c6", ATTR{idProduct}=="5385", ENV{ID_AUTOSUSPEND}="0", ATTR{power/control}="on"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="27c6", ATTR{idProduct}=="5395", ENV{ID_AUTOSUSPEND}="0", ATTR{power/control}="on"
+
 # Prevent cdc_acm from claiming the interfaces — the device exposes a CDC
 # descriptor that makes the kernel bind cdc_acm, blocking libfprint.
-ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5335", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
-ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5385", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
-ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="cdc_acm", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5395", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
+ACTION=="add|bind", SUBSYSTEM=="usb", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5335", DRIVER=="cdc_acm", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
+ACTION=="add|bind", SUBSYSTEM=="usb", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5385", DRIVER=="cdc_acm", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"
+ACTION=="add|bind", SUBSYSTEM=="usb", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5395", DRIVER=="cdc_acm", RUN+="/bin/sh -c 'echo %k > /sys/bus/usb/drivers/cdc_acm/unbind 2>/dev/null || true'"

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -418,6 +418,20 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
 
   switch (fpi_ssm_get_cur_state (ssm))
     {
+    case GOODIX_OPEN_USB_RESET:
+      {
+        GError *error = NULL;
+
+        if (!g_usb_device_reset (fpi_device_get_usb_device (dev), &error))
+          {
+            fpi_ssm_mark_failed (ssm, error);
+            return;
+          }
+
+        fpi_ssm_next_state (ssm);
+      }
+      break;
+
     case GOODIX_OPEN_CLAIM_INTERFACE:
       {
         GError *error = NULL;
@@ -429,6 +443,8 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
             fpi_ssm_mark_failed (ssm, error);
             return;
           }
+
+        self->usb_interface_claimed = TRUE;
         fpi_ssm_next_state (ssm);
       }
       break;
@@ -980,6 +996,29 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
 }
 
 static void
+goodix_cleanup_failed_open (FpDevice *dev)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  GUsbDevice *usb_dev = fpi_device_get_usb_device (dev);
+  g_autoptr(GError) cleanup_error = NULL;
+
+  if (self->usb_interface_claimed)
+    {
+      if (!g_usb_device_release_interface (usb_dev, GOODIX_USB_INTERFACE, 0,
+                                           &cleanup_error))
+        fp_warn ("Failed to release USB interface after open failure: %s",
+                 cleanup_error->message);
+
+      self->usb_interface_claimed = FALSE;
+      g_clear_error (&cleanup_error);
+    }
+
+  if (!g_usb_device_close (usb_dev, &cleanup_error))
+    fp_warn ("Failed to close USB device after open failure: %s",
+             cleanup_error->message);
+}
+
+static void
 goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
@@ -994,6 +1033,7 @@ goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
   if (error)
     {
       fp_warn ("Device open failed: %s", error->message);
+      goodix_cleanup_failed_open (dev);
       fpi_device_open_complete (dev, error);
       return;
     }
@@ -1702,6 +1742,7 @@ goodix_close (FpDevice *dev)
 
   g_usb_device_release_interface (fpi_device_get_usb_device (dev),
                                   GOODIX_USB_INTERFACE, 0, &error);
+  self->usb_interface_claimed = FALSE;
 
   fpi_device_close_complete (dev, error);
 }

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -153,7 +153,8 @@ typedef enum {
 
 /* Open SSM — full device initialization */
 typedef enum {
-  GOODIX_OPEN_CLAIM_INTERFACE = 0,
+  GOODIX_OPEN_USB_RESET = 0,
+  GOODIX_OPEN_CLAIM_INTERFACE,
   GOODIX_OPEN_EMPTY_BUFFER,
   GOODIX_OPEN_PING,
   GOODIX_OPEN_READ_FW_VERSION,
@@ -282,6 +283,9 @@ struct _FpiDeviceGoodix53x5
 
   /* Current command (for sub-SSM) */
   GoodixCmd *cmd;
+
+  /* USB interface state */
+  gboolean usb_interface_claimed;
 
   /* Task SSM tracking */
   FpiSsm *task_ssm;


### PR DESCRIPTION
## Summary

Move recovery for a wedged Goodix HTK32 USB reader into the driver open path by resetting the `GUsbDevice` before claiming the interface or sending any Goodix protocol traffic.

The udev rule is also tightened so supported Goodix 53x5 devices stay powered and are consistently released from `cdc_acm` when the kernel binds the ACM driver. This keeps the USB device available to libfprint after enumeration and resume.

## Problem Observed

After S4 hibernate/resume, the Goodix `27c6:5335` reader can re-enumerate successfully and `cdc_acm` can be unbound, but libfprint still times out during Goodix driver open.

The important observed behavior was:

- the USB device was visible after resume
- `cdc_acm` was no longer bound after the udev rule ran
- restarting `fprintd` did not recover the reader
- later authentication attempts could continue to fail
- running a USB device reset against `27c6:5335` immediately recovered the reader

That pointed away from fprintd ownership as the remaining root cause. The device was present, but its USB/protocol state was not usable by the Goodix initialization sequence.

## Separate Bug Fixed By Cleanup

During debugging, a separate failed-open cleanup bug was identified.

When Goodix open timed out, libfprint had already opened the underlying `GUsbDevice`, but the driver did not release its claimed interface or close the USB device on open failure. That left subsequent attempts failing with errors like:

```text
Device is already open
```

This PR tracks whether the Goodix USB interface was claimed and explicitly releases it on open failure. It also closes the `GUsbDevice` during failed-open cleanup. This keeps the libfprint process state consistent after a timeout and avoids compounding the resume problem with a stale local USB handle.

This cleanup does not by itself recover the post-resume hardware/protocol state; it prevents failed opens from poisoning later attempts in the same process.

## Root Cause Direction

The remaining failure after the cleanup looked like device or USB transport state after resume, not fprintd ownership.

The key evidence was that a USB reset fixed the device immediately, whereas restarting fprintd did not. That means the recovery action needed to happen below the fprintd service layer and before the Goodix protocol initialization sequence expects the device to answer.

The previous workaround used external system integration to reset or wait for the reader around sleep/resume. That helped prove the recovery mechanism, but it was the wrong long-term layer:

- it depended on host systemd policy rather than driver initialization
- it made resume behavior depend on out-of-tree service hooks
- it did not address normal open recovery after any other USB-level wedged state
- it left future users with several moving parts outside libfprint

## Fix

Add a new first open state:

```c
GOODIX_OPEN_USB_RESET
```

The driver now calls:

```c
g_usb_device_reset (fpi_device_get_usb_device (dev), &error)
```

before:

- claiming the Goodix USB interface
- draining stale endpoint data
- sending `ping`
- reading firmware version
- sending the Goodix protocol reset
- starting GTLS/config/FDT initialization

This ensures that the USB endpoints and device-side transport state are clean before the protocol open sequence begins.

The existing Goodix protocol reset remains later in the open SSM. That reset is still useful because it resets the Goodix MCU/protocol state after the lower-level USB transport has already been recovered. The two resets operate at different layers:

- `g_usb_device_reset()` recovers USB device/endpoint/transport state
- Goodix command `0xA/0x1` recovers sensor MCU/protocol state

## Why This Is Better Than The Sleep Hook

This places recovery in the component that owns the initialization sequence: the libfprint driver.

Benefits:

- no systemd sleep hook required
- no fprintd drop-in required
- no external `usbreset` command required
- works for any open attempt, not just resume-triggered starts
- keeps recovery close to the protocol state machine it protects
- matches how other libfprint USB drivers recover hardware state before protocol initialization

## Prior Art In libfprint

Several upstream libfprint USB/MOC drivers reset the USB device during probe or open before claiming the interface and initializing their protocol, including patterns in drivers such as:

- `goodixmoc`
- `fpcmoc`
- `focaltech_moc`
- `realtek`

Those drivers reset first, then claim the interface, then run protocol-specific initialization. This PR moves the Goodix 53x5 driver toward that same model.

## Udev Rule Updates

The udev rule now keeps supported Goodix 53x5 devices powered by disabling autosuspend and forcing `power/control=on` for `27c6:5335`, `27c6:5385`, and `27c6:5395`.

The `cdc_acm` unbind rule now runs on both `add` and `bind` events. This makes the rule more robust when the kernel binds `cdc_acm` during enumeration or after resume, and keeps the data interface available for libfprint.

## Testing

Local testing performed before opening this PR:

- built patched libfprint successfully with `ninja -C builddir`
- installed and tested the driver locally
- verified no active systemd sleep reset hook was installed
- verified no active fprintd drop-in was installed
- verified the active fprintd unit does not call the old wait helper
- verified current testing uses the udev power/cdc_acm rule but not the removed systemd reset workaround
- hibernate/resume behavior has been stable so far with the driver-level reset in place


## Follow-Up Work

There are likely kernel-side improvements that should be considered separately:

- adding `27c6:5335` and `27c6:5385` to the kernel `cdc_acm` ignore list, similar to the existing Goodix fingerprint `27c6:5395` ignore entry
- testing whether `USB_QUIRK_RESET_RESUME` is needed for any of these PIDs on affected machines

Those are not included here because this PR is scoped to the libfprint driver and packaged udev behavior.




