### PR TITLE
Goodix 53x5: report finger status changes during capture flow

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -1070,6 +1070,9 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
       {
         /* Power on sensor (idempotent if already on) */
         guint8 payload[3] = { 0x01, 0x01, 0x00 };
+        fpi_device_report_finger_status_changes (dev,
+                                                 FP_FINGER_STATUS_NEEDED,
+                                                 FP_FINGER_STATUS_PRESENT);
         goodix_run_cmd (ssm, dev, 0xA, 0x7, payload, 3, TRUE);
       }
       break;
@@ -1197,6 +1200,9 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
 
         /* Real finger detected! */
         fp_dbg ("Finger detected");
+        fpi_device_report_finger_status_changes (dev,
+                                                 FP_FINGER_STATUS_PRESENT,
+                                                 FP_FINGER_STATUS_NEEDED);
         fpi_ssm_mark_completed (ssm);
       }
       break;
@@ -1336,6 +1342,9 @@ goodix_finger_up_ssm_handler (FpiSsm   *ssm,
 
         goodix_device_generate_fdt_base (pl + 4, GOODIX_FDT_BASE_LEN,
                                          self->calib.fdt_base_down);
+        fpi_device_report_finger_status_changes (dev,
+                                                 FP_FINGER_STATUS_NONE,
+                                                 FP_FINGER_STATUS_PRESENT | FP_FINGER_STATUS_NEEDED);
         fpi_ssm_next_state (ssm);
       }
       break;


### PR DESCRIPTION
# Goodix 53x5: report finger status changes during capture flow

## Summary

This PR updates the Goodix 53x5 driver to report finger status transitions more accurately during the capture flow.

## What Changed

- report `finger-needed` while waiting for touch
- report `finger-present` once touch is confirmed
- clear both states after finger-up is processed

## Why

This gives libfprint and fprintd a more accurate view of the interaction state, bringing the driver closer to the behavior expected from other libfprint drivers during enrollment and verification.

## Scope

Included in this PR:

- finger status reporting updates during wait / present / finger-up transitions

Not included:

- retry handling for weak captures
- preprocessing changes
- matcher threshold tuning
