### PR TITLE
Goodix 53x5: retry obviously weak captures instead of scoring them

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -1387,6 +1387,24 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
 
     case GOODIX_ENROLL_PROCESS:
       {
+        SigfmImgInfo *info;
+        int keypoints;
+
+        info = sigfm_extract (self->captured_image,
+                              GOODIX_SENSOR_WIDTH,
+                              GOODIX_SENSOR_HEIGHT);
+        keypoints = sigfm_keypoints_count (info);
+        sigfm_free_info (info);
+
+        if (keypoints < GOODIX_MIN_CAPTURE_KEYPOINTS)
+          {
+            g_clear_pointer (&self->captured_image, g_free);
+            fpi_device_enroll_progress (dev, self->enroll_stage, NULL,
+                                        fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
+            fpi_ssm_next_state (ssm);
+            return;
+          }
+
         /* Store captured image in enrollment array */
         g_ptr_array_add (self->enroll_images, self->captured_image);
         self->captured_image = NULL;
@@ -1510,7 +1528,21 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                                      GOODIX_SENSOR_WIDTH,
                                      GOODIX_SENSOR_HEIGHT);
         keypoints = sigfm_keypoints_count (probe_info);
-        fp_dbg ("SIGFM probe keypoints: %d", keypoints);
+
+        if (keypoints < GOODIX_MIN_CAPTURE_KEYPOINTS)
+          {
+            if (action == FPI_DEVICE_ACTION_IDENTIFY)
+              fpi_device_identify_report (dev, NULL, NULL,
+                                          fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
+            else
+              fpi_device_verify_report (dev, FPI_MATCH_ERROR, NULL,
+                                        fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
+
+            sigfm_free_info (probe_info);
+            g_clear_pointer (&self->captured_image, g_free);
+            fpi_ssm_next_state (ssm);
+            return;
+          }
 
         if (action == FPI_DEVICE_ACTION_IDENTIFY)
           {

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -55,6 +55,9 @@ G_DECLARE_FINAL_TYPE (FpiDeviceGoodix53x5, fpi_device_goodix53x5, FPI,
 #define GOODIX_SIGFM_BEST_MIN     40   /* minimum best score from any single sample */
 #define GOODIX_SIGFM_MIN_SAMPLES  2    /* minimum enrolled samples above threshold */
 
+/* Captures below this feature count are effectively blank/failed touches. */
+#define GOODIX_MIN_CAPTURE_KEYPOINTS 20
+
 /* Sensor warmup parameters */
 #define GOODIX_WARMUP_CAPTURES      5    /* pre-touch captures after resume */
 


### PR DESCRIPTION
# Goodix 53x5: retry obviously weak captures instead of scoring them

## Summary

This PR rejects obviously weak captures early and asks the user to retry, instead of passing those captures through normal SIGFM matching.

## What Changed

Weak captures with too few extracted SIGFM keypoints are now treated as retry conditions.

This applies to both:

- enrollment captures
- verify / identify probe captures

The retry used is `FP_DEVICE_RETRY_REMOVE_FINGER`, which matches the usual libfprint pattern of asking the user to lift and try again when the current sample is not usable.

## Why

Other libfprint drivers already return retry errors when the current sample is clearly not usable. Doing the same here is better than forcing a very weak probe through the normal match path and turning capture-quality problems into plain no-match results.

For Goodix 53x5 specifically, very weak probes usually mean the user needs to lift and place again, not that the enrolled print is wrong.

