### PR TITLE
Validate Goodix FDT events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+builddir/
+*.pkg.tar.zst

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .build/
 builddir/
+results/
+tools/
 *.pkg.tar.zst

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ This automatically unbinds `cdc_acm` when it tries to attach to this device. Wit
 
 ## Installation
 
+### Local Build
+
+For development, build libfprint with this driver inside this repository:
+
+```bash
+./scripts/build-local.sh
+```
+
+This clones/prepares libfprint under `.build/libfprint`, copies the current driver and `sigfm` sources into that tree, applies `meson-integration.patch`, and runs `ninja`. Override the libfprint ref with `GOODIX_LIBFPRINT_REF`, for example:
+
+```bash
+GOODIX_LIBFPRINT_REF=v1.94.10 ./scripts/build-local.sh
+```
+
 ### Quick Start
 
 ```bash

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -27,6 +27,10 @@
 #include <string.h>
 #include <openssl/rand.h>
 
+#define GOODIX_PROTO_CATEGORY_FDT     0x03
+#define GOODIX_PROTO_CMD_FDT_DOWN     0x01
+#define GOODIX_PROTO_CMD_FDT_UP       0x02
+
 /* All-zero PSK */
 static const guint8 goodix_psk[GOODIX_PSK_LEN] = { 0 };
 
@@ -1129,12 +1133,22 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len) ||
+        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len))
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                            "Failed to parse FDT down event"));
+            return;
+          }
+
+        if (cat != GOODIX_PROTO_CATEGORY_FDT ||
+            cmd != GOODIX_PROTO_CMD_FDT_DOWN ||
             pl_len < 28)
           {
             fpi_ssm_mark_failed (ssm,
                                  fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse FDT event"));
+                                                           "Unexpected FDT down event: cat=0x%02x cmd=0x%02x len=%zu",
+                                                           cat, cmd, pl_len));
             return;
           }
 
@@ -1331,12 +1345,22 @@ goodix_finger_up_ssm_handler (FpiSsm   *ssm,
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len) ||
+        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len))
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                            "Failed to parse finger-up event"));
+            return;
+          }
+
+        if (cat != GOODIX_PROTO_CATEGORY_FDT ||
+            cmd != GOODIX_PROTO_CMD_FDT_UP ||
             pl_len < 4 + GOODIX_FDT_BASE_LEN)
           {
             fpi_ssm_mark_failed (ssm,
                                  fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse finger-up event"));
+                                                           "Unexpected finger-up event: cat=0x%02x cmd=0x%02x len=%zu",
+                                                           cat, cmd, pl_len));
             return;
           }
 

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build libfprint with this driver from inside the driver repository.
+
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="${GOODIX_LOCAL_BUILD_DIR:-$repo_dir/.build}"
+libfprint_dir="$work_dir/libfprint"
+libfprint_ref="${GOODIX_LIBFPRINT_REF:-v1.94.10}"
+build_dir="${GOODIX_MESON_BUILDDIR:-builddir}"
+
+mkdir -p "$work_dir"
+
+if [ ! -d "$libfprint_dir/.git" ]; then
+  git clone https://gitlab.freedesktop.org/libfprint/libfprint.git "$libfprint_dir"
+fi
+
+git -C "$libfprint_dir" fetch --tags --quiet
+git -C "$libfprint_dir" reset --hard --quiet
+git -C "$libfprint_dir" checkout --quiet "$libfprint_ref"
+git -C "$libfprint_dir" reset --hard --quiet "$libfprint_ref"
+
+rm -rf "$libfprint_dir/libfprint/drivers/goodix53x5"
+mkdir -p "$libfprint_dir/libfprint/drivers/goodix53x5"
+cp -R "$repo_dir/drivers/goodix53x5/." "$libfprint_dir/libfprint/drivers/goodix53x5/"
+
+rm -rf "$libfprint_dir/libfprint/sigfm"
+mkdir -p "$libfprint_dir/libfprint/sigfm"
+cp -R "$repo_dir/sigfm/." "$libfprint_dir/libfprint/sigfm/"
+
+if ! grep -q "'goodix53x5'" "$libfprint_dir/libfprint/meson.build"; then
+  patch -d "$libfprint_dir" -p1 < "$repo_dir/meson-integration.patch"
+fi
+
+if [ -d "$libfprint_dir/$build_dir" ]; then
+  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure
+else
+  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --prefix=/usr -Dinstalled-tests=false -Ddoc=false
+fi
+
+ninja -C "$libfprint_dir/$build_dir"


### PR DESCRIPTION
## Summary
- validate received FDT down/up event category and command before changing finger state
- add detailed protocol errors for unexpected FDT event packets
- add a repo-local build helper and ignore local build/analysis artifacts

## Testing
- ./scripts/build-local.sh
- installed locally with ninja from .build/libfprint/builddir and restarted fprintd
- user reported no issues observed after local testing