### PR TITLE
Validate Goodix init replies

### DIFF
--- a/drivers/goodix53x5/goodix53x5-device.c
+++ b/drivers/goodix53x5/goodix53x5-device.c
@@ -211,7 +211,7 @@ goodix_device_parse_otp (const guint8      *otp,
       params->delta_nav = tmp * 4;
     }
 
-  if (otp[17] == 0 || otp[22] == 0 || otp_len > 31 ? otp[31] == 0 : TRUE)
+  if (otp[17] == 0 || otp[22] == 0 || (otp_len > 31 ? otp[31] == 0 : TRUE))
     {
       params->dac_h = 0x97;
       params->dac_l = 0xD0;

--- a/drivers/goodix53x5/goodix53x5-proto.c
+++ b/drivers/goodix53x5/goodix53x5-proto.c
@@ -146,35 +146,9 @@ goodix_proto_rx_feed_chunk (GoodixReassembly *rx,
 
       guint16 msg_size = chunk[1] | ((guint16) chunk[2] << 8);
 
-      /* Total expected: 1(cmd) + 2(size) + msg_size(payload+checksum)
-       * But the size field already accounts for payload + checksum,
-       * and the header (cmd+size) is 3 bytes.
-       * Actually, looking at the Python: data = data[:message_size + 3]
-       * So total = message_size + 3 where message_size is the 2-byte LE field.
-       * BUT len(data) - 1 < message_size is the condition, and data includes
-       * the cmd_byte. So total bytes to collect = message_size + 3.
-       * Wait: the Python code: message_size = struct.unpack("<H", data[1:3])[0]
-       * then: while len(data) - 1 < message_size: ...
-       * then: data = data[:message_size + 3]
-       * So total = message_size + 3 bytes (cmd + size_field(2) is already 3,
-       * plus message_size more, minus the fact that len(data)-1 < message_size
-       * means we need message_size+1 total data bytes... let me recheck.
-       *
-       * Actually: data starts with one chunk. Then for continued chunks,
-       * the first byte is the continued cmd_byte (stripped), rest appended.
-       * data[0] = cmd_byte, data[1:3] = size field, data[3:] = payload+checksum
-       * message_size = size field value = payload_len + 1 (checksum)
-       * Total message bytes: 3 + message_size = 3 + payload_len + 1
-       *
-       * The loop: while len(data) - 1 < message_size
-       *   i.e. len(data) < message_size + 1
-       * After trimming: data = data[:message_size + 3]
-       * So total expected = message_size + 3.
-       *
-       * But the reassembly buffer stores everything linearly.
-       * First chunk: all bytes go into buffer.
-       * Continuation chunks: skip byte 0 (continued cmd_byte), rest goes in.
-       */
+      /* size_field stores payload + checksum, so the full message length is
+       * 3-byte header plus size_field bytes. Continuation chunks contribute
+       * only bytes after their leading continuation marker. */
       rx->expected = (gsize) msg_size + 3;
 
       /* Copy the entire first chunk */

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -94,14 +94,8 @@ goodix_send_message (FpiSsm   *ssm,
                                     use_checksum, &msg_len);
   cmd_byte = msg[0];
 
-  /* We need to send chunks of 64 bytes. The protocol pads writes to 64.
-   * For the first chunk, send the message bytes.
-   * For continuation chunks, prepend cmd_byte | 1. */
-  /* Since libfprint transfers handle padding, we send the whole thing
-   * as one bulk write if it fits, or chain if not.
-   * Actually, looking at the Python: each chunk is exactly 64 bytes, padded.
-   * The USB protocol.py write() pads to 64 bytes.
-   * Let's build a single contiguous padded buffer with proper chunking. */
+  /* The transport uses 64-byte USB writes. Continuation chunks prepend
+   * cmd_byte | 1 and carry up to 63 more bytes of message data. */
 
   gsize total_chunks = 0;
   gsize padded_len = 0;
@@ -346,6 +340,50 @@ goodix_run_cmd (FpiSsm       *parent_ssm,
   fpi_ssm_start_subsm (parent_ssm, cmd_ssm);
 }
 
+static gboolean
+goodix_parse_reply (FpDevice      *dev,
+                    guint8        *out_category,
+                    guint8        *out_command,
+                    const guint8 **out_payload,
+                    gsize         *out_payload_len,
+                    GError       **error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  if (goodix_proto_rx_parse (&self->rx, out_category, out_command,
+                             out_payload, out_payload_len))
+    return TRUE;
+
+  g_set_error_literal (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                       "Failed to parse device reply");
+  return FALSE;
+}
+
+static gboolean
+goodix_parse_reply_exact (FpDevice      *dev,
+                          guint8         expected_category,
+                          guint8         expected_command,
+                          const guint8 **out_payload,
+                          gsize         *out_payload_len,
+                          GError       **error)
+{
+  guint8 category, command;
+
+  if (!goodix_parse_reply (dev, &category, &command, out_payload,
+                           out_payload_len, error))
+    return FALSE;
+
+  if (category != expected_category || command != expected_command)
+    {
+      g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                   "Unexpected reply: cat=0x%02x cmd=0x%02x",
+                   category, command);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
 /**
  * Launch a command sub-SSM with a specific ACK timeout.
  * For FDT operations that need a long timeout, we handle it slightly
@@ -481,43 +519,89 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
       break;
 
     case GOODIX_OPEN_RESET:
-      /* reset type 0, irq_status=false: msg = 0b001 | (20<<8) = 0x1401 */
       {
-        guint16 msg = 0x01 | (20 << 8);
-        payload[0] = msg & 0xFF;
-        payload[1] = (msg >> 8) & 0xFF;
-        goodix_run_cmd (ssm, dev, 0xA, 0x1, payload, 2, FALSE);
+        g_autoptr(GError) error = NULL;
+        const guint8 *pl;
+        gsize pl_len;
+
+        if (!goodix_parse_reply_exact (dev, 0xA, 0x4, &pl, &pl_len, &error))
+          {
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
+            return;
+          }
+
+        g_clear_pointer (&self->fw_version, g_free);
+        self->fw_version = g_strndup ((const gchar *) pl,
+                                      strnlen ((const gchar *) pl, pl_len));
+
+        /* reset type 0, irq_status=false: msg = 0b001 | (20<<8) = 0x1401 */
+        {
+          guint16 msg = 0x01 | (20 << 8);
+          payload[0] = msg & 0xFF;
+          payload[1] = (msg >> 8) & 0xFF;
+          goodix_run_cmd (ssm, dev, 0xA, 0x1, payload, 2, FALSE);
+        }
       }
       break;
 
     case GOODIX_OPEN_READ_CHIP_ID:
-      /* read_data(addr=0, size=4): category=0x8, command=0x1 */
-      payload[0] = 0x00;                /* \x00 */
-      payload[1] = 0x00; payload[2] = 0x00; /* addr LE */
-      payload[3] = 0x04; payload[4] = 0x00; /* size LE */
-      goodix_run_cmd (ssm, dev, 0x8, 0x1, payload, 5, TRUE);
+      {
+        /* read_data(addr=0, size=4): category=0x8, command=0x1 */
+        payload[0] = 0x00;                /* \x00 */
+        payload[1] = 0x00; payload[2] = 0x00; /* addr LE */
+        payload[3] = 0x04; payload[4] = 0x00; /* size LE */
+        goodix_run_cmd (ssm, dev, 0x8, 0x1, payload, 5, TRUE);
+      }
       break;
 
     case GOODIX_OPEN_READ_OTP:
-      /* read_otp: category=0xA, command=0x3, payload=\x00\x00 */
-      payload[0] = 0x00;
-      payload[1] = 0x00;
-      goodix_run_cmd (ssm, dev, 0xA, 0x3, payload, 2, TRUE);
+      {
+        g_autoptr(GError) error = NULL;
+        const guint8 *pl;
+        gsize pl_len;
+        guint32 chip_id;
+
+        if (!goodix_parse_reply_exact (dev, 0x8, 0x1, &pl, &pl_len, &error))
+          {
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
+            return;
+          }
+
+        if (pl_len != 4)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "Unexpected chip ID reply length: %zu",
+                                                           pl_len));
+            return;
+          }
+
+        chip_id = goodix_crypto_decode_u32 (pl);
+        fp_dbg ("Chip ID: 0x%08x", chip_id);
+
+        /* read_otp: category=0xA, command=0x3, payload=\x00\x00 */
+        payload[0] = 0x00;
+        payload[1] = 0x00;
+        goodix_run_cmd (ssm, dev, 0xA, 0x3, payload, 2, TRUE);
+      }
       break;
 
     case GOODIX_OPEN_PARSE_OTP:
       {
-        guint8 cat, cmd;
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len))
+        if (!goodix_parse_reply_exact (dev, 0xA, 0x3, &pl, &pl_len, NULL))
           {
             fpi_ssm_mark_failed (ssm,
-                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse OTP response"));
+                                  fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                            "Failed to parse OTP response"));
             return;
           }
+
+        g_clear_pointer (&self->otp_data, g_free);
+        self->otp_data = g_memdup2 (pl, pl_len);
+        self->otp_len = pl_len;
 
         if (!goodix_device_verify_otp (pl, pl_len))
           {
@@ -548,11 +632,10 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
       {
         /* Check if PSK hash matches our all-zero PSK.
          * Parse the production_read response. */
-        guint8 cat, cmd;
         const guint8 *pl, *psk_data;
         gsize pl_len, psk_data_len;
 
-        if (!goodix_proto_rx_parse (&self->rx, &cat, &cmd, &pl, &pl_len) ||
+        if (!goodix_parse_reply_exact (dev, 0xE, 0x2, &pl, &pl_len, NULL) ||
             !goodix_proto_parse_production_read (pl, pl_len, 0xB003,
                                                  &psk_data, &psk_data_len))
           {
@@ -574,13 +657,15 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
           if (psk_data_len >= 32 && memcmp (psk_data, expected_hash, 32) == 0)
             {
               fp_dbg ("PSK hash matches, no need to write");
-              fpi_ssm_next_state (ssm);
+              self->psk_write_verify_pending = FALSE;
+              fpi_ssm_jump_to_state (ssm, GOODIX_OPEN_GTLS_CLIENT_HELLO);
               return;
             }
         }
 
         /* Need to write PSK white box */
         fp_info ("Writing PSK white box");
+        self->psk_write_verify_pending = TRUE;
         {
           gsize wb_payload_len = 4 + 4 + GOODIX_PSK_WHITE_BOX_LEN;
           g_autofree guint8 *wb_payload = g_malloc (wb_payload_len);
@@ -604,8 +689,72 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
       }
       break;
 
+    case GOODIX_OPEN_VERIFY_PSK_WRITE:
+      {
+        const guint8 *pl;
+        gsize pl_len;
+        guint32 read_type = 0xB003;
+
+        if (!goodix_parse_reply_exact (dev, 0xE, 0x1, &pl, &pl_len, NULL) ||
+            pl_len < 1)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "Failed to parse PSK write reply"));
+            return;
+          }
+
+        if (pl[0] != 0)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "PSK write failed: %u",
+                                                           pl[0]));
+            return;
+          }
+
+        payload[0] = read_type & 0xFF;
+        payload[1] = (read_type >> 8) & 0xFF;
+        payload[2] = (read_type >> 16) & 0xFF;
+        payload[3] = (read_type >> 24) & 0xFF;
+        goodix_run_cmd (ssm, dev, 0xE, 0x2, payload, 4, TRUE);
+      }
+      break;
+
     case GOODIX_OPEN_GTLS_CLIENT_HELLO:
       {
+        if (self->psk_write_verify_pending)
+          {
+            const guint8 *pl, *psk_data;
+            gsize pl_len, psk_data_len;
+            g_autoptr(GChecksum) sha = g_checksum_new (G_CHECKSUM_SHA256);
+            guint8 expected_hash[32];
+            gsize hash_len = 32;
+
+            if (!goodix_parse_reply_exact (dev, 0xE, 0x2, &pl, &pl_len, NULL) ||
+                !goodix_proto_parse_production_read (pl, pl_len, 0xB003,
+                                                     &psk_data, &psk_data_len))
+              {
+                fpi_ssm_mark_failed (ssm,
+                                     fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                               "Failed to re-read PSK hash"));
+                return;
+              }
+
+            g_checksum_update (sha, goodix_psk, GOODIX_PSK_LEN);
+            g_checksum_get_digest (sha, expected_hash, &hash_len);
+
+            if (psk_data_len < 32 || memcmp (psk_data, expected_hash, 32) != 0)
+              {
+                fpi_ssm_mark_failed (ssm,
+                                     fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                               "PSK hash mismatch after write"));
+                return;
+              }
+
+            self->psk_write_verify_pending = FALSE;
+          }
+
         /* Generate client_random and send via MCU */
         RAND_bytes (self->gtls.client_random, 32);
         goodix_crypto_gtls_init (&self->gtls, goodix_psk);
@@ -738,6 +887,19 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
 
     case GOODIX_OPEN_FDT_TX_ON:
       {
+        const guint8 *cfg_reply;
+        gsize cfg_reply_len;
+
+        if (!goodix_parse_reply_exact (dev, 0x9, 0x0, &cfg_reply, &cfg_reply_len,
+                                       NULL) ||
+            cfg_reply_len == 0 || cfg_reply[0] != 1)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "Config upload failed"));
+            return;
+          }
+
         /* FDT manual operation with TX enabled: op_code=0x0D */
         guint8 manual_payload[1 + GOODIX_FDT_BASE_LEN];
         manual_payload[0] = 0x0D;
@@ -1081,12 +1243,30 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
       }
       break;
 
+    case GOODIX_FINGER_WAIT_EC_POWER_ON_DONE:
+      {
+        const guint8 *pl;
+        gsize pl_len;
+
+        if (!goodix_parse_reply_exact (dev, 0xA, 0x7, &pl, &pl_len, NULL) ||
+            pl_len == 0 || pl[0] != 1)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "EC power-on failed"));
+            return;
+          }
+
+        fpi_ssm_next_state (ssm);
+      }
+      break;
+
     case GOODIX_FINGER_WAIT_WARMUP_CAPTURE:
       if (self->warmup_remaining > 0)
         {
           fp_dbg ("Warmup: capturing (%d remaining)", self->warmup_remaining);
           FpiSsm *sub = fpi_ssm_new (dev, goodix_capture_ssm_handler,
-                                       GOODIX_CAPTURE_NUM_STATES);
+                                     GOODIX_CAPTURE_NUM_STATES);
           fpi_ssm_start_subsm (ssm, sub);
         }
       else
@@ -1383,6 +1563,24 @@ goodix_finger_up_ssm_handler (FpiSsm   *ssm,
       {
         guint8 ec_payload[3] = { 0x00, 0x00, 0x00 };
         goodix_run_cmd (ssm, dev, 0xA, 0x7, ec_payload, 3, TRUE);
+      }
+      break;
+
+    case GOODIX_FINGER_UP_EC_POWER_OFF_DONE:
+      {
+        const guint8 *pl;
+        gsize pl_len;
+
+        if (!goodix_parse_reply_exact (dev, 0xA, 0x7, &pl, &pl_len, NULL) ||
+            pl_len == 0 || pl[0] != 1)
+          {
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                           "EC power-off failed"));
+            return;
+          }
+
+        fpi_ssm_mark_completed (ssm);
       }
       break;
     }

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -1711,12 +1711,6 @@ goodix_enroll_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
 
   fp_info ("Enrollment complete with %d samples", GOODIX_ENROLL_SAMPLES);
 
-  /* Flag to skip the next identify call — fprintd uses identify for
-   * duplicate detection after enrollment, but SIFT on this 108x88 sensor
-   * produces false cross-finger matches between adjacent fingers on the
-   * same hand.  Real security matching is unaffected. */
-  self->skip_next_identify = TRUE;
-
   fpi_device_enroll_complete (dev, g_object_ref (print), NULL);
 }
 
@@ -2033,19 +2027,6 @@ goodix_identify (FpDevice *dev)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   FpiSsm *ssm;
-
-  /* Skip post-enrollment duplicate detection entirely — avoids requiring
-   * an extra finger scan just to discard the result.  SIFT on 108x88
-   * produces false cross-finger matches between adjacent fingers on the
-   * same hand, making duplicate detection unreliable. */
-  if (self->skip_next_identify)
-    {
-      self->skip_next_identify = FALSE;
-      fp_dbg ("Identify: skipping post-enrollment duplicate check");
-      fpi_device_identify_report (dev, NULL, NULL, NULL);
-      fpi_device_identify_complete (dev, NULL);
-      return;
-    }
 
   g_clear_object (&self->cancel);
   self->cancel = g_cancellable_new ();

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -165,6 +165,7 @@ typedef enum {
   GOODIX_OPEN_PARSE_OTP,
   GOODIX_OPEN_READ_PSK_HASH,
   GOODIX_OPEN_WRITE_PSK,
+  GOODIX_OPEN_VERIFY_PSK_WRITE,
   GOODIX_OPEN_GTLS_CLIENT_HELLO,
   GOODIX_OPEN_GTLS_RECV_IDENTITY,
   GOODIX_OPEN_GTLS_SEND_VERIFY,
@@ -186,6 +187,7 @@ typedef enum {
 /* Finger-wait SSM (awaiting finger down) */
 typedef enum {
   GOODIX_FINGER_WAIT_EC_POWER_ON = 0,
+  GOODIX_FINGER_WAIT_EC_POWER_ON_DONE,
   GOODIX_FINGER_WAIT_WARMUP_CAPTURE,
   GOODIX_FINGER_WAIT_WARMUP_CHECK,
   GOODIX_FINGER_WAIT_FDT_DOWN_SETUP,
@@ -212,6 +214,7 @@ typedef enum {
   GOODIX_FINGER_UP_UPDATE_DOWN_BASE,
   GOODIX_FINGER_UP_SLEEP,
   GOODIX_FINGER_UP_EC_POWER_OFF,
+  GOODIX_FINGER_UP_EC_POWER_OFF_DONE,
   GOODIX_FINGER_UP_NUM_STATES,
 } GoodixFingerUpState;
 
@@ -281,6 +284,7 @@ struct _FpiDeviceGoodix53x5
   /* PSK hash for validation */
   guint8 *psk_hash;
   gsize   psk_hash_len;
+  gboolean psk_write_verify_pending;
 
   /* Current command (for sub-SSM) */
   GoodixCmd *cmd;

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -307,9 +307,6 @@ struct _FpiDeviceGoodix53x5
   GPtrArray *enroll_images; /* array of guint8* native images */
   gint       enroll_stage;
 
-  /* Skip post-enrollment duplicate detection (cleared after first identify) */
-  gboolean   skip_next_identify;
-
   /* Sensor warmup state */
   int        warmup_remaining;   /* pre-touch captures left */
   gboolean   warmup_done;        /* TRUE after first warmup cycle (per fprintd session) */


### PR DESCRIPTION
## Summary
- validate expected Goodix reply categories and commands during init and power transitions
- verify PSK/config/power-control replies instead of continuing on malformed responses
- remove the one-shot identify skip hack after enrollment

## Why
The init path was accepting replies with minimal validation, which made protocol drift and malformed responses harder to catch.

The post-enrollment identify skip used device-global state and could affect later real identify/auth flows instead of only the intended duplicate-detection case.

## Testing
- `./scripts/build-local.sh`
- `fp-enroll`
- `fprintd-verify`
- targeted finger verify with `fprintd-verify -f ...`
- exercised immediate post-enrollment verify flow successfully