### PR TITLE
Remove Goodix warmup captures

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -1204,13 +1204,6 @@ goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
       return;
     }
 
-  /* Warm up sensor on first open after fprintd start.  The open-time
-   * calibration captures use dac_l which doesn't exercise the dac_h analog
-   * path used for finger matching.  Subsequent opens (greeter retries)
-   * skip warmup since the sensor is already stabilized. */
-  if (!self->warmup_done)
-    self->warmup_remaining = GOODIX_WARMUP_CAPTURES;
-
   fp_info ("Device initialization complete");
   fpi_device_open_complete (dev, NULL);
 }
@@ -1261,30 +1254,6 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
       }
       break;
 
-    case GOODIX_FINGER_WAIT_WARMUP_CAPTURE:
-      if (self->warmup_remaining > 0)
-        {
-          fp_dbg ("Warmup: capturing (%d remaining)", self->warmup_remaining);
-          FpiSsm *sub = fpi_ssm_new (dev, goodix_capture_ssm_handler,
-                                     GOODIX_CAPTURE_NUM_STATES);
-          fpi_ssm_start_subsm (ssm, sub);
-        }
-      else
-        {
-          self->warmup_done = TRUE;
-          fpi_ssm_jump_to_state (ssm, GOODIX_FINGER_WAIT_FDT_DOWN_SETUP);
-        }
-      break;
-
-    case GOODIX_FINGER_WAIT_WARMUP_CHECK:
-      /* Discard the warmup image and loop */
-      g_clear_pointer (&self->captured_image, g_free);
-      self->warmup_remaining--;
-      fp_dbg ("Warmup: discarding capture (%d remaining)",
-              self->warmup_remaining);
-      fpi_ssm_jump_to_state (ssm, GOODIX_FINGER_WAIT_WARMUP_CAPTURE);
-      break;
-
     case GOODIX_FINGER_WAIT_FDT_DOWN_SETUP:
       {
         /* Set up finger-down detection (re-arms the sensor) */
@@ -1301,7 +1270,7 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
     case GOODIX_FINGER_WAIT_RECV_EVENT:
       /* Wait for FDT DOWN event with cancellable */
       self->blocking_ssm = ssm;
-      self->blocking_resume_state = GOODIX_FINGER_WAIT_WARMUP_CAPTURE;
+      self->blocking_resume_state = GOODIX_FINGER_WAIT_FDT_DOWN_SETUP;
       goodix_recv_start_cancellable (ssm, dev, self->cancel);
       break;
 
@@ -2081,11 +2050,10 @@ goodix_resume (FpDevice *dev)
     }
 
   self->suspended = FALSE;
-  self->warmup_remaining = GOODIX_WARMUP_CAPTURES;
   g_clear_object (&self->cancel);
   self->cancel = g_cancellable_new ();
 
-  /* Restart the SSM from the warmup/re-arm state (resubmits USB reads) */
+  /* Restart the SSM from the re-arm state (resubmits USB reads) */
   if (self->blocking_ssm)
     {
       fpi_ssm_jump_to_state (self->blocking_ssm, self->blocking_resume_state);

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -56,9 +56,6 @@ G_DECLARE_FINAL_TYPE (FpiDeviceGoodix53x5, fpi_device_goodix53x5, FPI,
 /* Captures below this feature count are effectively blank/failed touches. */
 #define GOODIX_MIN_CAPTURE_KEYPOINTS 20
 
-/* Sensor warmup parameters */
-#define GOODIX_WARMUP_CAPTURES      5    /* pre-touch captures after resume */
-
 /* Timeouts in ms */
 #define GOODIX_CMD_TIMEOUT    1000
 #define GOODIX_ACK_TIMEOUT    2000
@@ -188,8 +185,6 @@ typedef enum {
 typedef enum {
   GOODIX_FINGER_WAIT_EC_POWER_ON = 0,
   GOODIX_FINGER_WAIT_EC_POWER_ON_DONE,
-  GOODIX_FINGER_WAIT_WARMUP_CAPTURE,
-  GOODIX_FINGER_WAIT_WARMUP_CHECK,
   GOODIX_FINGER_WAIT_FDT_DOWN_SETUP,
   GOODIX_FINGER_WAIT_RECV_EVENT,
   GOODIX_FINGER_WAIT_GEN_UP_BASE,
@@ -306,10 +301,6 @@ struct _FpiDeviceGoodix53x5
   /* Enrollment tracking */
   GPtrArray *enroll_images; /* array of guint8* native images */
   gint       enroll_stage;
-
-  /* Sensor warmup state */
-  int        warmup_remaining;   /* pre-touch captures left */
-  gboolean   warmup_done;        /* TRUE after first warmup cycle (per fprintd session) */
 };
 
 /* --- Protocol functions (goodix53x5-proto.c) --- */


### PR DESCRIPTION
## Summary
We evaluated whether the Goodix 53x5 driver still needs pre-touch warmup captures before arming finger-down detection. The current implementation performs 5 throwaway `dac_h/is_finger=TRUE` captures on first open or resume.

The evaluation found no measurable cold-start settling in raw frames, no meaningful change after the current processing pipeline, and no accept-rate improvement in a short cold first-touch A/B match run. The current 5-frame warmup adds about 600 ms of user-visible delay before the sensor can accept a touch.

## Measurements
- Warmup capture latency: mean `119.7 ms`, median `118.2 ms`, range `115.0-135.2 ms`
- Current 5-capture warmup cost: about `599 ms` per cold open/resume path
- Raw blank settling test: first frame drift was `0.02 ADU` from the settled tail mean (`4045.03 ADU`), within the measured noise floor
- Processed/SIFT settling test: first 7 frames averaged `17.14` keypoints; last 7 averaged `17.71`; frame0->1 processed diff (`0.48`) was near steady-state (`0.44`)
- Cold first-touch A/B probes captured before stopping the run: warmup `20/20` accepted; no-warmup `20/20` accepted at `GOODIX_SIGFM_BEST_MIN=14`

## Finding
The warmup frames did not improve the matchable image or the match decision in the observed data. The inherited warmup assumption appears unsupported with the current preprocessing pipeline.

Removing warmup should save roughly `0.6 s` from the affected user path without reducing observed first-touch acceptance. Re-test after hibernate/resume if that path is suspected to behave differently from the forced cold-open test.