### PR TITLE
goodix53x5: Validate command ACKs

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -32,6 +32,7 @@
 #define GOODIX_PROTO_CMD_FDT_UP       0x02
 #define GOODIX_PROTO_CATEGORY_ACK     0x0B
 #define GOODIX_PROTO_CMD_ACK          0x00
+#define GOODIX_PROTO_ACK_FLAG_VALID   0x01
 #define GOODIX_PROTO_CMD_BYTE(category, command) \
   (((category) << 4) | ((command) << 1))
 
@@ -65,7 +66,7 @@ goodix_validate_ack_for_cmd (FpDevice        *dev,
     }
 
   if (payload[0] != expected_cmd_byte ||
-      (payload[1] & 0x01) == 0)
+      (payload[1] & GOODIX_PROTO_ACK_FLAG_VALID) == 0)
     {
       g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
                    "Unexpected ACK: expected cmd_byte=0x%02x, got ack_cmd=0x%02x flags=0x%02x",

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -30,6 +30,51 @@
 #define GOODIX_PROTO_CATEGORY_FDT     0x03
 #define GOODIX_PROTO_CMD_FDT_DOWN     0x01
 #define GOODIX_PROTO_CMD_FDT_UP       0x02
+#define GOODIX_PROTO_CATEGORY_ACK     0x0B
+#define GOODIX_PROTO_CMD_ACK          0x00
+#define GOODIX_PROTO_CMD_BYTE(category, command) \
+  (((category) << 4) | ((command) << 1))
+
+static gboolean
+goodix_validate_ack_for_cmd (FpDevice        *dev,
+                             const GoodixCmd *cmd,
+                             GError         **error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  guint8 category, command;
+  const guint8 *payload;
+  gsize payload_len;
+  guint8 expected_cmd_byte = GOODIX_PROTO_CMD_BYTE (cmd->category, cmd->command);
+
+  if (!goodix_proto_rx_parse (&self->rx, &category, &command,
+                              &payload, &payload_len))
+    {
+      g_set_error_literal (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                           "Failed to parse ACK");
+      return FALSE;
+    }
+
+  if (category != GOODIX_PROTO_CATEGORY_ACK ||
+      command != GOODIX_PROTO_CMD_ACK ||
+      payload_len < 2)
+    {
+      g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                   "Unexpected ACK: expected cmd_byte=0x%02x, got cat=0x%02x cmd=0x%02x len=%zu",
+                   expected_cmd_byte, category, command, payload_len);
+      return FALSE;
+    }
+
+  if (payload[0] != expected_cmd_byte ||
+      (payload[1] & 0x01) == 0)
+    {
+      g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                   "Unexpected ACK: expected cmd_byte=0x%02x, got ack_cmd=0x%02x flags=0x%02x",
+                   expected_cmd_byte, payload[0], payload[1]);
+      return FALSE;
+    }
+
+  return TRUE;
+}
 
 /* All-zero PSK */
 static const guint8 goodix_psk[GOODIX_PSK_LEN] = { 0 };
@@ -301,6 +346,20 @@ goodix_cmd_ssm_handler (FpiSsm   *ssm,
 
     case GOODIX_CMD_RECV_ACK:
       goodix_recv_start (ssm, dev, GOODIX_ACK_TIMEOUT, NULL);
+      break;
+
+    case GOODIX_CMD_VALIDATE_ACK:
+      {
+        g_autoptr(GError) error = NULL;
+
+        if (!goodix_validate_ack_for_cmd (dev, cmd, &error))
+          {
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
+            return;
+          }
+
+        fpi_ssm_next_state (ssm);
+      }
       break;
 
     case GOODIX_CMD_RECV_DATA:

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -136,6 +136,7 @@ typedef struct
 typedef enum {
   GOODIX_CMD_SEND = 0,
   GOODIX_CMD_RECV_ACK,
+  GOODIX_CMD_VALIDATE_ACK,
   GOODIX_CMD_RECV_DATA,
   GOODIX_CMD_NUM_STATES,
 } GoodixCmdState;


### PR DESCRIPTION
## Summary

Validate the Goodix ACK received after each command before advancing the command SSM.

The driver already waits for an ACK after sending a command, but previously accepted the next received message without checking that it was the ACK for the command just sent. This change verifies that the reply is a Goodix ACK, that it echoes the expected command byte, and that the ACK valid marker is set.

## Why

Goodix protocol traces show that commands are ACKed before any optional data response. The ACK payload includes the command byte being acknowledged.

Without validating that ACK, the command SSM can advance while the protocol stream is out of sync. We observed failures where the driver was waiting for an FDT event but received an ACK-shaped message instead:

```text
Unexpected FDT down event: cat=0x0b cmd=0x00 len=2
```

Validating the ACK at the command boundary catches this kind of protocol desynchronization earlier and prevents later states from parsing the wrong message type.

## Changes

- Add Goodix ACK protocol constants.
- Add ACK validation after the ACK receive state.
- Check that ACK payload byte 0 matches the command byte for the command just sent.
- Check that ACK payload flags include the valid marker bit.
- Report a protocol error if the ACK is malformed, for a different command, or not successful.

## Testing

- Built locally with `./scripts/build-local.sh`.
- Installed locally and validated normal verify/identify usage.
- Confirmed no recurrence of ACK-shaped messages being parsed as FDT events during local testing.
