### PR TITLE
Fix libfprint hwdb metadata integration

### DIFF
--- a/meson-integration.patch
+++ b/meson-integration.patch
@@ -76,3 +76,53 @@ index 14fb11f..b4f6101 100644
      'elanspi' : [ 'udev' ],
      'virtual_image'          : [ 'virtual' ],
      'virtual_device'         : [ 'virtual' ],
+diff --git a/data/autosuspend.hwdb b/data/autosuspend.hwdb
+index 6c15fb9..2bc8a69 100644
+--- a/data/autosuspend.hwdb
++++ b/data/autosuspend.hwdb
+@@ -201,6 +201,13 @@ usb:v10A5pC844*
+  ID_AUTOSUSPEND=1
+  ID_PERSIST=0
+ 
++# Supported by libfprint driver goodix53x5
++usb:v27C6p5335*
++usb:v27C6p5385*
++usb:v27C6p5395*
++ ID_AUTOSUSPEND=1
++ ID_PERSIST=0
++
+ # Supported by libfprint driver goodixmoc
+ usb:v27C6p5840*
+ usb:v27C6p6014*
+@@ -453,13 +460,10 @@ usb:v27C6p521D*
+ usb:v27C6p5301*
+ usb:v27C6p530C*
+ usb:v27C6p532D*
+-usb:v27C6p5335*
+ usb:v27C6p533C*
+ usb:v27C6p5381*
+-usb:v27C6p5385*
+ usb:v27C6p538C*
+ usb:v27C6p538D*
+-usb:v27C6p5395*
+ usb:v27C6p5503*
+ usb:v27C6p550A*
+ usb:v27C6p550C*
+diff --git a/libfprint/fprint-list-udev-hwdb.c b/libfprint/fprint-list-udev-hwdb.c
+index 0527db1..097ddfb 100644
+--- a/libfprint/fprint-list-udev-hwdb.c
++++ b/libfprint/fprint-list-udev-hwdb.c
+@@ -133,13 +133,10 @@ static const FpIdEntry allowlist_id_table[] = {
+   { .vid = 0x27c6, .pid = 0x5301 },
+   { .vid = 0x27c6, .pid = 0x530c },
+   { .vid = 0x27c6, .pid = 0x532d },
+-  { .vid = 0x27c6, .pid = 0x5335 },
+   { .vid = 0x27c6, .pid = 0x533c },
+   { .vid = 0x27c6, .pid = 0x5381 },
+-  { .vid = 0x27c6, .pid = 0x5385 },
+   { .vid = 0x27c6, .pid = 0x538c },
+   { .vid = 0x27c6, .pid = 0x538d },
+-  { .vid = 0x27c6, .pid = 0x5395 },
+   { .vid = 0x27c6, .pid = 0x5503 },
+   { .vid = 0x27c6, .pid = 0x550a },
+   { .vid = 0x27c6, .pid = 0x550c },


### PR DESCRIPTION
## Summary
- update `meson-integration.patch` so the Goodix 53x5 USB IDs are removed from libfprint v1.94.10's unsupported-device hwdb allowlist
- add the regenerated `autosuspend.hwdb` block that places `27c6:5335`, `27c6:5385`, and `27c6:5395` under the `goodix53x5` driver
- keep this metadata-only: no driver behavior changes

## Why
A clean libfprint v1.94.10 checkout with our current integration patch builds, but `meson test` fails in `data+no-valgrind - libfprint:udev-hwdb`. The hwdb generator warns that `27c6:5335` is implemented by `goodix53x5` while the same IDs are still listed as known unsupported devices. Since Meson runs this test with `G_DEBUG=fatal-warnings`, that warning aborts the test.

This was probably missed earlier because the driver had been build/run tested, but the full libfprint Meson test suite had not been run against the integration patch.

## Testing
Fresh libfprint v1.94.10 checkout, copied in current `drivers/goodix53x5` and `sigfm`, applied updated `meson-integration.patch`:
- `meson setup builddir`
- `ninja -C builddir`
- `meson test -C builddir`

Result: `5 OK`, `0 FAIL`, `28 SKIP`. The skips are from missing `umockdev-run` on this machine.

## Hardware impact
No driver code or matching/enroll/verify behavior changes. The hwdb values for these IDs remain `ID_AUTOSUSPEND=1` and `ID_PERSIST=0`; only their generated classification changes from unsupported to supported by `goodix53x5`.