### PR TITLE
Store serialized SIGFM templates

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -36,6 +36,21 @@
 #define GOODIX_PROTO_CMD_BYTE(category, command) \
   (((category) << 4) | ((command) << 1))
 
+/* Driver-owned wrapper for serialized SIGFM features. Bump the version when
+ * preprocessing, extraction, or matching semantics make old templates unsafe
+ * to compare against newly enrolled templates. */
+#define GOODIX_SIGFM_TEMPLATE_MAGIC      "G53S"
+#define GOODIX_SIGFM_TEMPLATE_MAGIC_LEN  4
+#define GOODIX_SIGFM_TEMPLATE_VERSION    1
+#define GOODIX_SIGFM_TEMPLATE_HEADER_LEN \
+  (GOODIX_SIGFM_TEMPLATE_MAGIC_LEN + sizeof (guint16))
+
+typedef enum {
+  GOODIX_SIGFM_TEMPLATE_OK,
+  GOODIX_SIGFM_TEMPLATE_INCOMPATIBLE,
+  GOODIX_SIGFM_TEMPLATE_INVALID,
+} GoodixSigfmTemplateStatus;
+
 static gboolean
 goodix_validate_ack_for_cmd (FpDevice        *dev,
                              const GoodixCmd *cmd,
@@ -1620,6 +1635,73 @@ goodix_deactivate_ssm_handler (FpiSsm   *ssm,
     }
 }
 
+static GBytes *
+goodix_serialize_sigfm_template (SigfmImgInfo *info)
+{
+  guint8 *feature;
+  guint8 *template;
+  guint16 version;
+  int feature_len;
+
+  feature = sigfm_serialize_binary (info, &feature_len);
+  if (feature == NULL || feature_len <= 0)
+    {
+      g_free (feature);
+      return NULL;
+    }
+
+  template = g_malloc (GOODIX_SIGFM_TEMPLATE_HEADER_LEN + feature_len);
+  memcpy (template, GOODIX_SIGFM_TEMPLATE_MAGIC,
+          GOODIX_SIGFM_TEMPLATE_MAGIC_LEN);
+  version = GUINT16_TO_LE (GOODIX_SIGFM_TEMPLATE_VERSION);
+  memcpy (template + GOODIX_SIGFM_TEMPLATE_MAGIC_LEN, &version,
+          sizeof (version));
+  memcpy (template + GOODIX_SIGFM_TEMPLATE_HEADER_LEN, feature, feature_len);
+  g_free (feature);
+
+  return g_bytes_new_take (template,
+                           GOODIX_SIGFM_TEMPLATE_HEADER_LEN + feature_len);
+}
+
+static SigfmImgInfo *
+goodix_deserialize_sigfm_template (const guint8 *template,
+                                   gsize         template_len,
+                                   GoodixSigfmTemplateStatus *status)
+{
+  SigfmImgInfo *info;
+  guint16 version;
+  gsize feature_len;
+
+  *status = GOODIX_SIGFM_TEMPLATE_INVALID;
+
+  if (template_len <= GOODIX_SIGFM_TEMPLATE_HEADER_LEN ||
+      memcmp (template, GOODIX_SIGFM_TEMPLATE_MAGIC,
+              GOODIX_SIGFM_TEMPLATE_MAGIC_LEN) != 0)
+    {
+      *status = GOODIX_SIGFM_TEMPLATE_INCOMPATIBLE;
+      return NULL;
+    }
+
+  memcpy (&version, template + GOODIX_SIGFM_TEMPLATE_MAGIC_LEN,
+          sizeof (version));
+  if (GUINT16_FROM_LE (version) != GOODIX_SIGFM_TEMPLATE_VERSION)
+    {
+      *status = GOODIX_SIGFM_TEMPLATE_INCOMPATIBLE;
+      return NULL;
+    }
+
+  feature_len = template_len - GOODIX_SIGFM_TEMPLATE_HEADER_LEN;
+  if (feature_len > G_MAXINT)
+    return NULL;
+
+  info = sigfm_deserialize_binary (template + GOODIX_SIGFM_TEMPLATE_HEADER_LEN,
+                                   (int) feature_len);
+  if (info != NULL)
+    *status = GOODIX_SIGFM_TEMPLATE_OK;
+
+  return info;
+}
+
 /* ========================================================================
  * Enroll SSM
  * ======================================================================== */
@@ -1659,6 +1741,7 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
     case GOODIX_ENROLL_PROCESS:
       {
         SigfmImgInfo *info;
+        GBytes *feature;
         int keypoints;
 
         /* Partial-contact captures make weak templates: the clipped
@@ -1682,10 +1765,10 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
                               GOODIX_SENSOR_WIDTH,
                               GOODIX_SENSOR_HEIGHT);
         keypoints = sigfm_keypoints_count (info);
-        sigfm_free_info (info);
 
         if (keypoints < GOODIX_MIN_CAPTURE_KEYPOINTS)
           {
+            sigfm_free_info (info);
             g_clear_pointer (&self->captured_image, g_free);
             fpi_device_enroll_progress (dev, self->enroll_stage, NULL,
                                         fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
@@ -1693,9 +1776,19 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
             return;
           }
 
-        /* Store captured image in enrollment array */
-        g_ptr_array_add (self->enroll_images, self->captured_image);
-        self->captured_image = NULL;
+        feature = goodix_serialize_sigfm_template (info);
+        sigfm_free_info (info);
+        if (feature == NULL)
+          {
+            g_clear_pointer (&self->captured_image, g_free);
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_GENERAL,
+                                                           "Failed to serialize SIGFM features"));
+            return;
+          }
+
+        g_ptr_array_add (self->enroll_features, feature);
+        g_clear_pointer (&self->captured_image, g_free);
         self->enroll_stage++;
 
         fp_dbg ("Enrollment stage %d/%d complete",
@@ -1733,14 +1826,14 @@ goodix_enroll_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
 
   if (error)
     {
-      g_clear_pointer (&self->enroll_images, g_ptr_array_unref);
+      g_clear_pointer (&self->enroll_features, g_ptr_array_unref);
       g_clear_pointer (&self->reference_image, g_free);
       g_clear_pointer (&self->captured_image, g_free);
       fpi_device_enroll_complete (dev, NULL, error);
       return;
     }
 
-  /* Build print from enrollment images */
+  /* Build print from serialized enrollment features */
   FpPrint *print = NULL;
 
   fpi_device_get_enroll_data (dev, &print);
@@ -1754,13 +1847,16 @@ goodix_enroll_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("aay"));
 
-  for (guint i = 0; i < self->enroll_images->len; i++)
+  for (guint i = 0; i < self->enroll_features->len; i++)
     {
-      guint8 *img = g_ptr_array_index (self->enroll_images, i);
+      GBytes *feature = g_ptr_array_index (self->enroll_features, i);
+      gsize feature_len;
+      const guint8 *feature_data = g_bytes_get_data (feature, &feature_len);
+
       g_variant_builder_add (&builder, "@ay",
                              g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
-                                                        img,
-                                                        GOODIX_SENSOR_PIXELS,
+                                                        feature_data,
+                                                        feature_len,
                                                         1));
     }
 
@@ -1768,7 +1864,7 @@ goodix_enroll_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
 
   g_object_set (G_OBJECT (print), "fpi-data", data, NULL);
 
-  g_clear_pointer (&self->enroll_images, g_ptr_array_unref);
+  g_clear_pointer (&self->enroll_features, g_ptr_array_unref);
 
   fp_info ("Enrollment complete with %d samples", GOODIX_ENROLL_SAMPLES);
 
@@ -1787,6 +1883,16 @@ goodix_clear_pending_result_report (FpiDeviceGoodix53x5 *self)
   self->pending_verify_result = 0;
   g_clear_object (&self->pending_identify_match);
   g_clear_error (&self->pending_result_error);
+  g_clear_error (&self->pending_action_error);
+}
+
+static void
+goodix_queue_action_error (FpiDeviceGoodix53x5 *self,
+                           GError              *error)
+{
+  goodix_clear_pending_result_report (self);
+
+  self->pending_action_error = error;
 }
 
 static void
@@ -1814,6 +1920,25 @@ goodix_queue_identify_report (FpiDeviceGoodix53x5 *self,
   if (match != NULL)
     self->pending_identify_match = g_object_ref (match);
   self->pending_result_error = error;
+}
+
+static GoodixSigfmTemplateStatus
+goodix_match_serialized_feature (SigfmImgInfo  *probe_info,
+                                 const guint8  *feature,
+                                 gsize          feature_len,
+                                 int           *score)
+{
+  SigfmImgInfo *tmpl_info;
+  GoodixSigfmTemplateStatus status;
+
+  tmpl_info = goodix_deserialize_sigfm_template (feature, feature_len, &status);
+  if (tmpl_info == NULL)
+    return status;
+
+  *score = sigfm_match_score (probe_info, tmpl_info);
+  sigfm_free_info (tmpl_info);
+
+  return GOODIX_SIGFM_TEMPLATE_OK;
 }
 
 static void
@@ -1914,6 +2039,8 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             GPtrArray *gallery = NULL;
             FpPrint *match = NULL;
             int best_score = 0;
+            int valid_templates = 0;
+            gboolean saw_unusable_template = FALSE;
 
             fpi_device_get_identify_data (dev, &gallery);
 
@@ -1935,20 +2062,32 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                 while ((child = g_variant_iter_next_value (&iter)))
                   {
                     gsize len;
-                    const guint8 *img;
+                    const guint8 *feature;
 
-                    img = g_variant_get_fixed_array (child, &len, 1);
-                    if (len == GOODIX_SENSOR_PIXELS)
+                    feature = g_variant_get_fixed_array (child, &len, 1);
+                    if (len > 0)
                       {
-                        SigfmImgInfo *tmpl_info;
+                        int score;
+                        GoodixSigfmTemplateStatus template_status;
 
-                        tmpl_info = sigfm_extract (img,
-                                                    GOODIX_SENSOR_WIDTH,
-                                                    GOODIX_SENSOR_HEIGHT);
-                        int score = sigfm_match_score (probe_info, tmpl_info);
+                        template_status = goodix_match_serialized_feature (probe_info,
+                                                                           feature,
+                                                                           len,
+                                                                           &score);
+                        if (template_status != GOODIX_SIGFM_TEMPLATE_OK)
+                          {
+                            saw_unusable_template = TRUE;
+
+                            fp_dbg ("identify: gallery[%u] sample %d invalid SIGFM template",
+                                    i, sample_idx);
+                            sample_idx++;
+                            g_variant_unref (child);
+                            continue;
+                          }
+
+                        valid_templates++;
                         fp_dbg ("identify: gallery[%u] sample %d sigfm_score %d",
                                 i, sample_idx, score);
-                        sigfm_free_info (tmpl_info);
 
                         if (score > tmpl_best_score)
                           tmpl_best_score = score;
@@ -1970,7 +2109,13 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             fp_dbg ("Identify best SIGFM score: %d (best_min: %d)",
                     best_score, GOODIX_SIGFM_BEST_MIN);
 
-            if (match != NULL)
+            if (valid_templates == 0 && saw_unusable_template)
+              {
+                goodix_queue_action_error (self,
+                                           fpi_device_error_new (FP_DEVICE_ERROR_DATA_INVALID));
+                self->verify_wait_finger_up = FALSE;
+              }
+            else if (match != NULL)
               {
                 goodix_queue_identify_report (self, match, NULL);
                 self->verify_wait_finger_up = FALSE;
@@ -1988,6 +2133,8 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             GVariant *data = NULL;
             int best_score = 0;
             int sample_idx = 0;
+            int valid_templates = 0;
+            gboolean saw_unusable_template = FALSE;
 
             fpi_device_get_verify_data (dev, &print);
             g_object_get (G_OBJECT (print), "fpi-data", &data, NULL);
@@ -2001,20 +2148,32 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                 while ((child = g_variant_iter_next_value (&iter)))
                   {
                     gsize len;
-                    const guint8 *img;
+                    const guint8 *feature;
 
-                    img = g_variant_get_fixed_array (child, &len, 1);
-                    if (len == GOODIX_SENSOR_PIXELS)
+                    feature = g_variant_get_fixed_array (child, &len, 1);
+                    if (len > 0)
                       {
-                        SigfmImgInfo *tmpl_info;
+                        int score;
+                        GoodixSigfmTemplateStatus template_status;
 
-                        tmpl_info = sigfm_extract (img,
-                                                    GOODIX_SENSOR_WIDTH,
-                                                    GOODIX_SENSOR_HEIGHT);
-                        int score = sigfm_match_score (probe_info, tmpl_info);
+                        template_status = goodix_match_serialized_feature (probe_info,
+                                                                           feature,
+                                                                           len,
+                                                                           &score);
+                        if (template_status != GOODIX_SIGFM_TEMPLATE_OK)
+                          {
+                            saw_unusable_template = TRUE;
+
+                            fp_dbg ("verify: sample %d invalid SIGFM template",
+                                    sample_idx);
+                            sample_idx++;
+                            g_variant_unref (child);
+                            continue;
+                          }
+
+                        valid_templates++;
                         fp_dbg ("verify: sample %d sigfm_score %d",
                                 sample_idx, score);
-                        sigfm_free_info (tmpl_info);
 
                         if (score > best_score)
                           best_score = score;
@@ -2029,7 +2188,13 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             fp_dbg ("Verify best SIGFM score: %d (best_min: %d)",
                     best_score, GOODIX_SIGFM_BEST_MIN);
 
-            if (best_score >= GOODIX_SIGFM_BEST_MIN)
+            if (valid_templates == 0 && saw_unusable_template)
+              {
+                goodix_queue_action_error (self,
+                                           fpi_device_error_new (FP_DEVICE_ERROR_DATA_INVALID));
+                self->verify_wait_finger_up = FALSE;
+              }
+            else if (best_score >= GOODIX_SIGFM_BEST_MIN)
               {
                 goodix_queue_verify_report (self, FPI_MATCH_SUCCESS, NULL);
                 self->verify_wait_finger_up = FALSE;
@@ -2095,7 +2260,12 @@ goodix_verify_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
     }
 
   if (error == NULL)
-    goodix_flush_pending_result_report (dev);
+    {
+      if (self->pending_action_error != NULL)
+        error = g_steal_pointer (&self->pending_action_error);
+      else
+        goodix_flush_pending_result_report (dev);
+    }
   else
     goodix_clear_pending_result_report (self);
 
@@ -2146,7 +2316,7 @@ goodix_close (FpDevice *dev)
   g_clear_pointer (&self->rx.buf, g_free);
   g_clear_pointer (&self->reference_image, g_free);
   g_clear_pointer (&self->captured_image, g_free);
-  g_clear_pointer (&self->enroll_images, g_ptr_array_unref);
+  g_clear_pointer (&self->enroll_features, g_ptr_array_unref);
 
   if (self->cmd)
     {
@@ -2176,8 +2346,8 @@ goodix_enroll (FpDevice *dev)
   self->enroll_stage = 0;
   g_clear_pointer (&self->reference_image, g_free);
   g_clear_pointer (&self->captured_image, g_free);
-  g_clear_pointer (&self->enroll_images, g_ptr_array_unref);
-  self->enroll_images = g_ptr_array_new_with_free_func (g_free);
+  g_clear_pointer (&self->enroll_features, g_ptr_array_unref);
+  self->enroll_features = g_ptr_array_new_with_free_func ((GDestroyNotify) g_bytes_unref);
 
   ssm = fpi_ssm_new (dev, goodix_enroll_ssm_handler,
                       GOODIX_ENROLL_NUM_STATES);

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -2044,6 +2044,7 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             GPtrArray *gallery = NULL;
             FpPrint *match = NULL;
             int best_score = 0;
+            int best_match_score = 0;
             int valid_templates = 0;
             gboolean saw_unusable_template = FALSE;
 
@@ -2103,10 +2104,13 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                   }
                 g_variant_unref (tmpl_data);
 
+                if (tmpl_best_score > best_score)
+                  best_score = tmpl_best_score;
+
                 if (tmpl_best_score >= GOODIX_SIGFM_BEST_MIN &&
-                    tmpl_best_score > best_score)
+                    tmpl_best_score > best_match_score)
                   {
-                    best_score = tmpl_best_score;
+                    best_match_score = tmpl_best_score;
                     match = tmpl;
                   }
               }

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -44,6 +44,7 @@
 #define GOODIX_SIGFM_TEMPLATE_VERSION    1
 #define GOODIX_SIGFM_TEMPLATE_HEADER_LEN \
   (GOODIX_SIGFM_TEMPLATE_MAGIC_LEN + sizeof (guint16))
+#define GOODIX_SIGFM_TEMPLATE_MAX_LEN    (1024 * 1024)
 
 typedef enum {
   GOODIX_SIGFM_TEMPLATE_OK,
@@ -1644,7 +1645,8 @@ goodix_serialize_sigfm_template (SigfmImgInfo *info)
   int feature_len;
 
   feature = sigfm_serialize_binary (info, &feature_len);
-  if (feature == NULL || feature_len <= 0)
+  if (feature == NULL || feature_len <= 0 ||
+      feature_len > GOODIX_SIGFM_TEMPLATE_MAX_LEN - GOODIX_SIGFM_TEMPLATE_HEADER_LEN)
     {
       g_free (feature);
       return NULL;
@@ -1675,6 +1677,7 @@ goodix_deserialize_sigfm_template (const guint8 *template,
   *status = GOODIX_SIGFM_TEMPLATE_INVALID;
 
   if (template_len <= GOODIX_SIGFM_TEMPLATE_HEADER_LEN ||
+      template_len > GOODIX_SIGFM_TEMPLATE_MAX_LEN ||
       memcmp (template, GOODIX_SIGFM_TEMPLATE_MAGIC,
               GOODIX_SIGFM_TEMPLATE_MAGIC_LEN) != 0)
     {
@@ -1937,6 +1940,8 @@ goodix_match_serialized_feature (SigfmImgInfo  *probe_info,
 
   *score = sigfm_match_score (probe_info, tmpl_info);
   sigfm_free_info (tmpl_info);
+  if (*score < 0)
+    return GOODIX_SIGFM_TEMPLATE_INVALID;
 
   return GOODIX_SIGFM_TEMPLATE_OK;
 }

--- a/drivers/goodix53x5/goodix53x5.h
+++ b/drivers/goodix53x5/goodix53x5.h
@@ -311,6 +311,7 @@ struct _FpiDeviceGoodix53x5
   FpiMatchResult  pending_verify_result;
   FpPrint        *pending_identify_match;
   GError         *pending_result_error;
+  GError         *pending_action_error;
 
   /* Suspend/resume state */
   gboolean suspended;            /* TRUE between suspend() and resume() calls */
@@ -323,7 +324,7 @@ struct _FpiDeviceGoodix53x5
   double   captured_clipped_fraction; /* non-contact (clipped) pixel fraction */
 
   /* Enrollment tracking */
-  GPtrArray *enroll_images; /* array of guint8* native images */
+  GPtrArray *enroll_features; /* array of GBytes* serialized SIGFM features */
   gint       enroll_stage;
 };
 

--- a/sigfm/binary.hpp
+++ b/sigfm/binary.hpp
@@ -111,6 +111,10 @@ public:
                          bool> = true>
     constexpr stream& read(Iter&& begin, std::size_t dist)
     {
+        if (store_.size() < dist) {
+            throw std::runtime_error{"tried to read past end of stream"};
+        }
+
         std::copy(store_.begin(), store_.begin() + dist, begin);
         store_.erase(store_.begin(), store_.begin() + dist);
         return *this;

--- a/sigfm/sigfm.cpp
+++ b/sigfm/sigfm.cpp
@@ -33,11 +33,19 @@
 #include <fstream>
 #include <iterator>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 
 #include <opencv2/opencv.hpp>
 #include <vector>
+
+namespace {
+constexpr std::size_t serialized_keypoint_size = sizeof(int) * 2 + sizeof(float) * 5;
+constexpr std::size_t max_serialized_keypoints = 2048;
+constexpr int sift_descriptor_cols = 128;
+constexpr int sift_descriptor_type = CV_32F;
+} // namespace
 
 namespace bin {
 
@@ -54,7 +62,35 @@ struct deserializer<SigfmImgInfo> : public std::true_type {
     static SigfmImgInfo deserialize(stream& in)
     {
         SigfmImgInfo info;
-        in >> info.keypoints >> info.descriptors;
+
+        std::size_t keypoint_count;
+        in >> keypoint_count;
+        if (keypoint_count > max_serialized_keypoints ||
+            keypoint_count > in.size() / serialized_keypoint_size) {
+            throw std::runtime_error{"invalid SIGFM keypoint count"};
+        }
+
+        info.keypoints.reserve(keypoint_count);
+        for (std::size_t i = 0; i < keypoint_count; i++) {
+            cv::KeyPoint keypoint;
+            in >> keypoint;
+            info.keypoints.emplace_back(std::move(keypoint));
+        }
+
+        int type, rows, cols;
+        in >> type >> rows >> cols;
+        if (type != sift_descriptor_type || rows < 0 || cols != sift_descriptor_cols ||
+            static_cast<std::size_t>(rows) != keypoint_count) {
+            throw std::runtime_error{"invalid SIGFM descriptor metadata"};
+        }
+
+        const auto descriptor_bytes = keypoint_count * sift_descriptor_cols * sizeof(float);
+        if (descriptor_bytes > in.size()) {
+            throw std::runtime_error{"invalid SIGFM descriptor data"};
+        }
+
+        info.descriptors.create(rows, cols, type);
+        in.read(info.descriptors.data, descriptor_bytes);
         return info;
     }
 };
@@ -109,10 +145,17 @@ unsigned char* sigfm_serialize_binary(SigfmImgInfo* info, int* outlen)
 
 SigfmImgInfo* sigfm_deserialize_binary(const unsigned char* bytes, int len)
 {
+    if (bytes == nullptr || len <= 0) {
+        return nullptr;
+    }
+
     try {
         bin::stream s{bytes, bytes + len};
         auto info = std::make_unique<SigfmImgInfo>();
         s >> *info;
+        if (s.size() != 0) {
+            return nullptr;
+        }
         return info.release();
     }
     catch (const std::exception&) {


### PR DESCRIPTION
## Summary

- store serialized SIGFM feature templates during enrollment instead of raw processed images
- deserialize stored feature blobs during verify/identify instead of re-extracting SIFT features from every stored sample
- wrap stored SIGFM blobs with a small driver-owned magic/version header so future preprocessing or matching changes can invalidate incompatible templates explicitly
- validate persisted SIGFM template data before matching so malformed stored blobs fail as invalid print data
- track the actual best identify score separately from the threshold-qualified match so no-match debug logs report the highest observed sub-threshold score instead of the initial 0

This is stacked on #17 and intentionally requires deleting/re-enrolling existing prints, matching the re-enrollment requirement from the base PR.

## Why this is better

Stored enrollment samples do not change between scans, but the current driver reprocesses each stored image and re-extracts SIGFM/SIFT features during every verify/identify attempt. This moves that work to enrollment time: templates are extracted once, serialized, and then loaded for matching. A fresh probe scan still needs feature extraction, but stored samples no longer pay that repeated extraction cost on every greeter/PAM attempt.

## Performance notes

Local SIGFM timing suggests this removes roughly 38% of the identify matching cost by replacing repeated stored-sample feature extraction with feature deserialization.

- 1 enrolled finger, 8 samples checked: ~39 ms before, ~24 ms after; about 15 ms saved per identify attempt
- 10 enrolled fingers, 80 samples checked: ~377 ms before, ~232 ms after; about 145 ms saved per identify attempt

## Testing

- `./scripts/build-local.sh`
- installed locally with `sudo ninja -C .build/libfprint/builddir install`
- restarted `fprintd`
- confirmed stale pre-change enrollments fail as invalid stored data
- deleted old enrollments, re-enrolled, and verified successfully
- confirmed the review-fix build still unlocks successfully
- malformed SIGFM deserialization smoke test rejects truncated, oversized, bad-metadata, and short-descriptor blobs
- confirmed no-match identify debug logs now report the highest observed SIGFM score below `GOODIX_SIGFM_BEST_MIN`
