### PR TITLE
Improve libfprint install workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,6 @@ sudo systemctl restart fprintd
 
 Use `--prefix=/usr` so the installed libfprint replaces the system library used by `fprintd`. A default Meson setup may install into `/usr/local`, which `fprintd` may not load.
 
-On Debian/Ubuntu, Meson should normally choose the multiarch library directory automatically. Check it before installing:
-
-```bash
-meson configure builddir | grep libdir
-```
-
-If it reports `lib` instead of a distro multiarch path such as `lib/x86_64-linux-gnu`, recreate the build directory and pass:
-
-```bash
---libdir=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
-```
-
 ### Updating
 
 If you already installed this driver, update this repository, copy the newer driver files into libfprint, then rebuild libfprint:

--- a/README.md
+++ b/README.md
@@ -37,24 +37,26 @@ The current preprocessing pipeline is shown below:
 - **libfprint** source tree (tested with v1.94.10)
 - **OpenCV 4** (`opencv_core`, `opencv_features2d`, `opencv_flann`, `opencv_imgproc`)
 - **OpenSSL 3.0+**
-- Standard libfprint build dependencies (meson, ninja, glib, libgusb, etc.)
+- Standard libfprint build dependencies: Meson, Ninja, pkg-config, GLib, and libgusb
 
-### Installing OpenCV
+### Build Packages
 
 **Arch Linux:**
 ```
-sudo pacman -S opencv
+sudo pacman -S --needed git base-devel meson ninja pkgconf glib2 libgusb opencv openssl fprintd
 ```
 
 **Fedora:**
 ```
-sudo dnf install opencv opencv-devel
+sudo dnf install git gcc gcc-c++ meson ninja-build pkgconf-pkg-config glib2-devel libgusb-devel opencv-devel openssl-devel fprintd
 ```
 
 **Ubuntu/Debian:**
 ```
-sudo apt install libopencv-dev
+sudo apt install git build-essential meson ninja-build pkg-config libglib2.0-dev libgusb-dev libopencv-dev libssl-dev fprintd
 ```
+
+The minimal build command below disables libfprint's generated udev rules and hwdb install, so Debian/Ubuntu users should not need the `udev.pc` build dependency. If you enable udev rules/hwdb or build libfprint's default driver set, Debian 13 provides `udev.pc` in `systemd-dev`.
 
 ## Installation
 
@@ -68,16 +70,34 @@ cd libfprint
 # Copy this driver into libfprint
 /path/to/goodix53x5-libfprint/install.sh .
 
-# The install script will print manual meson.build edits needed.
-# Apply those edits, then:
-
-meson setup builddir --prefix=/usr -Dinstalled-tests=false -Ddoc=false
+meson setup builddir \
+  --prefix=/usr \
+  -Ddrivers=goodix53x5 \
+  -Dudev_hwdb=disabled \
+  -Dudev_rules=disabled \
+  -Dintrospection=false \
+  -Dinstalled-tests=false \
+  -Ddoc=false
 ninja -C builddir
 sudo ninja -C builddir install
 sudo systemctl restart fprintd
 ```
 
+`-Ddrivers=goodix53x5` avoids building unrelated libfprint drivers and their dependencies. `-Dudev_hwdb=disabled -Dudev_rules=disabled` avoids requiring `udev.pc`; the Goodix 53x5 driver itself is a USB/libgusb driver and does not use udev APIs.
+
 Use `--prefix=/usr` so the installed libfprint replaces the system library used by `fprintd`. A default Meson setup may install into `/usr/local`, which `fprintd` may not load.
+
+On Debian/Ubuntu, Meson should normally choose the multiarch library directory automatically. Check it before installing:
+
+```bash
+meson configure builddir | grep libdir
+```
+
+If it reports `lib` instead of a distro multiarch path such as `lib/x86_64-linux-gnu`, recreate the build directory and pass:
+
+```bash
+--libdir=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+```
 
 ### Updating
 
@@ -89,13 +109,20 @@ git pull
 ./install.sh /path/to/libfprint
 
 cd /path/to/libfprint/builddir
-meson setup --reconfigure .. --prefix=/usr -Dinstalled-tests=false -Ddoc=false
+meson setup --reconfigure .. \
+  --prefix=/usr \
+  -Ddrivers=goodix53x5 \
+  -Dudev_hwdb=disabled \
+  -Dudev_rules=disabled \
+  -Dintrospection=false \
+  -Dinstalled-tests=false \
+  -Ddoc=false
 ninja
 sudo ninja install
 sudo systemctl restart fprintd
 ```
 
-You usually do not need to repeat the manual Meson edits after the first install.
+If `install.sh` cannot apply the Meson integration patch automatically, it prints the manual edits needed for that libfprint tree.
 
 ## Troubleshooting
 

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,10 @@
 #
 # Usage: ./install.sh /path/to/libfprint
 #
-# After running this script, reconfigure and build libfprint:
-#   cd /path/to/libfprint/builddir
-#   meson setup --reconfigure ..
-#   ninja && sudo ninja install
+# After running this script, configure and build libfprint:
+#   cd /path/to/libfprint
+#   meson setup builddir --prefix=/usr -Ddrivers=goodix53x5 -Dudev_hwdb=disabled -Dudev_rules=disabled -Dintrospection=false -Dinstalled-tests=false -Ddoc=false
+#   ninja -C builddir && sudo ninja -C builddir install
 
 set -euo pipefail
 
@@ -37,26 +37,7 @@ ROOT_MESON="$LIBFPRINT_DIR/meson.build"
 
 DRIVER_SOURCES="[ 'drivers/goodix53x5/goodix53x5.c', 'drivers/goodix53x5/goodix53x5-proto.c', 'drivers/goodix53x5/goodix53x5-crypto.c', 'drivers/goodix53x5/goodix53x5-transport.c', 'drivers/goodix53x5/goodix53x5-commands.c', 'drivers/goodix53x5/goodix53x5-session.c', 'drivers/goodix53x5/goodix53x5-scan.c', 'drivers/goodix53x5/goodix53x5-enroll.c', 'drivers/goodix53x5/goodix53x5-auth.c', 'drivers/goodix53x5/goodix53x5-match.c', 'drivers/goodix53x5/goodix53x5-calibration.c', 'drivers/goodix53x5/goodix53x5-image.c' ],"
 
-# Check if the driver is registered, and whether the registration matches the
-# current module layout. goodix53x5-commands.c only exists in the current
-# layout, so its absence from an existing entry means the source list is stale.
-if grep -q "'goodix53x5'" "$MESON" && grep -q "goodix53x5-commands.c" "$MESON"; then
-    echo "Driver already registered in libfprint/meson.build"
-elif grep -q "'goodix53x5'" "$MESON"; then
-    echo ""
-    echo "========================================="
-    echo "MANUAL UPDATE REQUIRED"
-    echo "========================================="
-    echo ""
-    echo "An older goodix53x5 entry was found in $MESON."
-    echo "The driver module layout has changed; building with the old source"
-    echo "list will fail. Replace the existing 'goodix53x5' driver_sources"
-    echo "entry with:"
-    echo ""
-    echo "   'goodix53x5' :"
-    echo "       $DRIVER_SOURCES"
-    echo ""
-else
+print_manual_steps() {
     echo ""
     echo "========================================="
     echo "MANUAL STEPS REQUIRED"
@@ -90,7 +71,37 @@ else
     echo "5. In the root meson.build, add 'goodix53x5' to the default_drivers list"
     echo "   and add: 'goodix53x5' : [ 'openssl' ] to the driver_helpers dict."
     echo ""
+}
+
+# Check if the driver is registered, and whether the registration matches the
+# current module layout. goodix53x5-commands.c only exists in the current
+# layout, so its absence from an existing entry means the source list is stale.
+if grep -q "'goodix53x5'" "$MESON" && grep -q "goodix53x5-commands.c" "$MESON"; then
+    echo "Driver already registered in libfprint/meson.build"
+elif grep -q "'goodix53x5'" "$MESON"; then
+    echo ""
+    echo "========================================="
+    echo "MANUAL UPDATE REQUIRED"
+    echo "========================================="
+    echo ""
+    echo "An older goodix53x5 entry was found in $MESON."
+    echo "The driver module layout has changed; building with the old source"
+    echo "list will fail. Replace the existing 'goodix53x5' driver_sources"
+    echo "entry with:"
+    echo ""
+    echo "   'goodix53x5' :"
+    echo "       $DRIVER_SOURCES"
+    echo ""
+else
+    echo "Applying Meson integration patch ..."
+    if patch --dry-run -d "$LIBFPRINT_DIR" -p1 < "$SCRIPT_DIR/meson-integration.patch" >/dev/null; then
+        patch -d "$LIBFPRINT_DIR" -p1 < "$SCRIPT_DIR/meson-integration.patch"
+        echo "Meson integration patch applied."
+    else
+        echo "Could not apply meson-integration.patch automatically."
+        print_manual_steps
+    fi
 fi
 
 echo ""
-echo "Done. Now reconfigure and rebuild libfprint."
+echo "Done. Now configure and build libfprint. See README.md for distro-specific commands."

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -8,6 +8,15 @@ work_dir="${GOODIX_LOCAL_BUILD_DIR:-$repo_dir/.build}"
 libfprint_dir="$work_dir/libfprint"
 libfprint_ref="${GOODIX_LIBFPRINT_REF:-v1.94.10}"
 build_dir="${GOODIX_MESON_BUILDDIR:-builddir}"
+meson_options=(
+  --prefix=/usr
+  -Ddrivers=goodix53x5
+  -Dudev_hwdb=disabled
+  -Dudev_rules=disabled
+  -Dintrospection=false
+  -Dinstalled-tests=false
+  -Ddoc=false
+)
 
 mkdir -p "$work_dir"
 
@@ -33,9 +42,9 @@ if ! grep -q "'goodix53x5'" "$libfprint_dir/libfprint/meson.build"; then
 fi
 
 if [ -d "$libfprint_dir/$build_dir" ]; then
-  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure
+  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure "${meson_options[@]}"
 else
-  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --prefix=/usr -Dinstalled-tests=false -Ddoc=false
+  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" "${meson_options[@]}"
 fi
 
 ninja -C "$libfprint_dir/$build_dir"


### PR DESCRIPTION
## Summary
- document distro build packages for Arch, Fedora, and Debian/Ubuntu
- build only the goodix53x5 driver in install docs and local build helper
- disable libfprint udev hwdb/rules generation for the end-user build path to avoid requiring udev.pc
- make install.sh apply the Meson integration patch automatically when possible

## Validation
- bash -n install.sh && bash -n scripts/build-local.sh
- ./scripts/build-local.sh
- fprint-list-supported-devices from the built tree lists only 27c6:5335, 27c6:5385, and 27c6:5395
- user-tested the locally built libfprint with fprintd successfully