### PR TITLE
Stabilize Goodix FDT and enrollment recapture

### DIFF
--- a/drivers/goodix53x5/goodix53x5-enroll.c
+++ b/drivers/goodix53x5/goodix53x5-enroll.c
@@ -29,6 +29,8 @@
 
 #include <string.h>
 
+#define GOODIX_ENROLL_RELEASE_SETTLE_MS 350
+
 /* Enroll SSM */
 typedef enum {
   GOODIX_ENROLL_REINIT = 0,
@@ -65,6 +67,15 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
       break;
 
     case GOODIX_ENROLL_CAPTURE_REF:
+      if (self->cancel && g_cancellable_is_cancelled (self->cancel))
+        {
+          fpi_ssm_mark_failed (ssm,
+                               g_error_new_literal (G_IO_ERROR,
+                                                    G_IO_ERROR_CANCELLED,
+                                                    "Enrollment cancelled"));
+          return;
+        }
+
       goodix_scan_start_ref_capture_subsm (ssm, dev);
       break;
 
@@ -141,7 +152,21 @@ goodix_enroll_ssm_handler (FpiSsm   *ssm,
 
     case GOODIX_ENROLL_NEXT:
       if (self->enroll_stage < GOODIX_ENROLL_SAMPLES)
-        fpi_ssm_jump_to_state (ssm, GOODIX_ENROLL_CAPTURE_REF);
+        {
+          if (self->cancel && g_cancellable_is_cancelled (self->cancel))
+            {
+              fpi_ssm_mark_failed (ssm,
+                                   g_error_new_literal (G_IO_ERROR,
+                                                        G_IO_ERROR_CANCELLED,
+                                                        "Enrollment cancelled"));
+              return;
+            }
+
+          fp_dbg ("Waiting %dms for enrollment release to settle",
+                  GOODIX_ENROLL_RELEASE_SETTLE_MS);
+          fpi_ssm_jump_to_state_delayed (ssm, GOODIX_ENROLL_CAPTURE_REF,
+                                         GOODIX_ENROLL_RELEASE_SETTLE_MS);
+        }
       else
         fpi_ssm_mark_completed (ssm);
       break;

--- a/drivers/goodix53x5/goodix53x5-private.h
+++ b/drivers/goodix53x5/goodix53x5-private.h
@@ -119,6 +119,7 @@ struct _FpiDeviceGoodix53x5
 
   /* Temporary FDT data from calibration */
   guint8 *fdt_data_tx_on;
+  guint8  open_fdt_retries;
 
   /* OTP raw data */
   guint8 *otp_data;

--- a/drivers/goodix53x5/goodix53x5-scan.c
+++ b/drivers/goodix53x5/goodix53x5-scan.c
@@ -240,13 +240,13 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
       break;
 
     case GOODIX_FINGER_WAIT_FDT_CHECK:
-      /* FDT manual TX-off to verify it's a real touch, not temperature */
+      /* FDT manual TX-off to verify the interrupt moved away from baseline. */
       goodix_cmd_fdt_manual (ssm, dev, FALSE, self->calib.fdt_base_manual);
       break;
 
     case GOODIX_FINGER_WAIT_VALIDATE:
       {
-        /* Parse manual FDT response and check if it's a temperature event */
+        /* Parse manual FDT response and check for a false FDT-down event. */
         guint8 cat, cmd;
         const guint8 *pl;
         gsize pl_len;
@@ -260,14 +260,14 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
             return;
           }
 
-        /* If fdt_base_valid == TRUE, it's a temperature event (false alarm) */
+        /* If the event and immediate manual reading still match, the interrupt
+         * was baseline drift/noise rather than a stable finger-down. */
         if (goodix_device_is_fdt_base_valid (self->fdt_event_data,
                                              pl + 4,
                                              GOODIX_FDT_BASE_LEN,
                                              self->calib.delta_fdt))
           {
-            fp_dbg ("Temperature event detected, retrying finger wait");
-            /* Re-arm FDT down detection and wait again */
+            fp_dbg ("False FDT down event detected, retrying finger wait");
             fpi_ssm_jump_to_state (ssm, GOODIX_FINGER_WAIT_FDT_DOWN_SETUP);
             return;
           }

--- a/drivers/goodix53x5/goodix53x5-scan.h
+++ b/drivers/goodix53x5/goodix53x5-scan.h
@@ -27,7 +27,7 @@ void goodix_scan_start_ref_capture_subsm (FpiSsm   *parent_ssm,
                                           FpDevice *dev);
 
 /* Power the sensor and block (cancellably) until a validated finger-down
- * FDT event arrives. Filters temperature false positives. */
+ * FDT event arrives. Filters false FDT-down interrupts. */
 void goodix_scan_start_finger_wait_subsm (FpiSsm   *parent_ssm,
                                           FpDevice *dev);
 

--- a/drivers/goodix53x5/goodix53x5-session.c
+++ b/drivers/goodix53x5/goodix53x5-session.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <openssl/rand.h>
 
+#define GOODIX_OPEN_FDT_MAX_RETRIES 2
+
 /* Open SSM — full device initialization */
 typedef enum {
   GOODIX_OPEN_USB_RESET = 0,
@@ -428,6 +430,7 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
         self->gtls.hmac_client_counter = self->gtls.hmac_client_counter_init;
         self->gtls.hmac_server_counter = self->gtls.hmac_server_counter_init;
         self->gtls.state = 5;
+        self->open_fdt_retries = 0;
 
         fp_info ("GTLS handshake completed");
 
@@ -511,7 +514,24 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
                                                   self->fdt_data_tx_on,
                                                   GOODIX_FDT_BASE_LEN,
                                                   self->calib.delta_fdt))
-              fp_warn ("Second FDT validation failed, continuing anyway");
+              {
+                if (self->open_fdt_retries++ < GOODIX_OPEN_FDT_MAX_RETRIES)
+                  {
+                    fp_warn ("Open FDT validation unstable, retrying (%u/%u)",
+                             self->open_fdt_retries,
+                             GOODIX_OPEN_FDT_MAX_RETRIES);
+                    g_free (self->fdt_data_tx_on);
+                    self->fdt_data_tx_on = g_memdup2 (pl + 4,
+                                                      GOODIX_FDT_BASE_LEN);
+                    fpi_ssm_jump_to_state (ssm, GOODIX_OPEN_FDT_TX_ON_2);
+                    return;
+                  }
+
+                fpi_ssm_mark_failed (ssm,
+                                     fpi_device_error_new_msg (FP_DEVICE_ERROR_GENERAL,
+                                                               "Open FDT baseline did not stabilize"));
+                return;
+              }
           }
 
         fpi_ssm_next_state (ssm);


### PR DESCRIPTION
## Summary
- Stabilize Goodix open-time FDT baseline validation by retrying transient unstable readings and failing open if the baseline never settles.
- Delay enrollment recapture briefly after each accepted sample so the release state can settle before the next reference capture.
- Keep enrollment cancellation responsive before capture and before scheduling delayed recapture.
- Clarify FDT validation comments/logging to describe false FDT-down interrupts rather than temperature-only events.

## Changes vs main
- `drivers/goodix53x5/goodix53x5-session.c`: added `GOODIX_OPEN_FDT_MAX_RETRIES` and reset an open-time FDT retry counter after GTLS handshake completion.
- `drivers/goodix53x5/goodix53x5-session.c`: changed second open FDT validation from warning-and-continuing to retrying up to 2 times with a refreshed TX-on baseline, then failing open with `FP_DEVICE_ERROR_GENERAL` if the baseline still does not stabilize.
- `drivers/goodix53x5/goodix53x5-private.h`: added `open_fdt_retries` to track those bounded open-time validation retries on the device instance.
- `drivers/goodix53x5/goodix53x5-enroll.c`: added a 350ms enrollment release-settle delay before jumping back to reference capture for the next sample.
- `drivers/goodix53x5/goodix53x5-enroll.c`: added explicit cancellable checks before reference capture and before scheduling the delayed next capture so cancellation does not wait behind the recapture loop.
- `drivers/goodix53x5/goodix53x5-scan.c` and `drivers/goodix53x5/goodix53x5-scan.h`: updated comments and debug wording to describe validation as filtering false FDT-down interrupts/noise rather than only temperature events.

## Why
- Continuing after an unstable open-time FDT baseline can leave the driver with a bad baseline and make later finger-down detection unreliable, especially after resume or noisy startup conditions.
- A small bounded retry window gives transient readings a chance to settle while still surfacing persistent instability as an open failure instead of hiding it.
- Enrollment was immediately recapturing after a sample; delaying the next capture reduces the chance of re-entering capture while finger release/sensor state is still settling.
- The cancellation checks preserve responsive abort behavior despite the new delayed recapture path.
- The terminology update makes the code match the behavior: the validation rejects any baseline-like false FDT-down interrupt, not just temperature-driven events.