### PR TITLE
Optimize SIGFM matching without score changes

### DIFF
--- a/drivers/goodix53x5/goodix53x5-auth.c
+++ b/drivers/goodix53x5/goodix53x5-auth.c
@@ -35,6 +35,29 @@ goodix_match_scores_need_exhaustive_logging (void)
   return !g_log_writer_default_would_drop (G_LOG_LEVEL_DEBUG, G_LOG_DOMAIN);
 }
 
+static gboolean
+goodix_gallery_has_single_username (GPtrArray *gallery)
+{
+  const gchar *username;
+
+  if (gallery->len == 0)
+    return FALSE;
+
+  username = fp_print_get_username (g_ptr_array_index (gallery, 0));
+  if (username == NULL || username[0] == '\0')
+    return FALSE;
+
+  for (guint i = 1; i < gallery->len; i++)
+    {
+      FpPrint *print = g_ptr_array_index (gallery, i);
+
+      if (g_strcmp0 (username, fp_print_get_username (print)) != 0)
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
 /* Verify/Identify SSM */
 typedef enum {
   GOODIX_VERIFY_REINIT = 0,
@@ -195,8 +218,12 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             int best_match_score = 0;
             int valid_templates = 0;
             gboolean saw_unusable_template = FALSE;
+            gboolean stop_after_match;
 
             fpi_device_get_identify_data (dev, &gallery);
+            stop_after_match =
+              !goodix_match_scores_need_exhaustive_logging () &&
+              goodix_gallery_has_single_username (gallery);
 
             for (guint i = 0; i < gallery->len; i++)
               {
@@ -247,6 +274,13 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                           tmpl_best_score = score;
 
                         sample_idx++;
+
+                        if (stop_after_match &&
+                            tmpl_best_score >= GOODIX_SIGFM_BEST_MIN)
+                          {
+                            g_variant_unref (child);
+                            break;
+                          }
                       }
                     g_variant_unref (child);
                   }
@@ -261,6 +295,9 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                     best_match_score = tmpl_best_score;
                     match = tmpl;
                   }
+
+                if (stop_after_match && match != NULL)
+                  break;
               }
 
             fp_dbg ("Identify best SIGFM score: %d (best_min: %d)",

--- a/drivers/goodix53x5/goodix53x5-auth.c
+++ b/drivers/goodix53x5/goodix53x5-auth.c
@@ -29,6 +29,12 @@
 
 #include <string.h>
 
+static gboolean
+goodix_match_scores_need_exhaustive_logging (void)
+{
+  return !g_log_writer_default_would_drop (G_LOG_LEVEL_DEBUG, G_LOG_DOMAIN);
+}
+
 /* Verify/Identify SSM */
 typedef enum {
   GOODIX_VERIFY_REINIT = 0,
@@ -286,6 +292,8 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
             int sample_idx = 0;
             int valid_templates = 0;
             gboolean saw_unusable_template = FALSE;
+            gboolean score_all_templates =
+              goodix_match_scores_need_exhaustive_logging ();
 
             fpi_device_get_verify_data (dev, &print);
             g_object_get (G_OBJECT (print), "fpi-data", &data, NULL);
@@ -330,6 +338,15 @@ goodix_verify_ssm_handler (FpiSsm   *ssm,
                           best_score = score;
 
                         sample_idx++;
+
+                        /* Verify targets one known print, so later samples
+                         * cannot change the result after the gate is met. */
+                        if (!score_all_templates &&
+                            best_score >= GOODIX_SIGFM_BEST_MIN)
+                          {
+                            g_variant_unref (child);
+                            break;
+                          }
                       }
                     g_variant_unref (child);
                   }

--- a/sigfm/sigfm.cpp
+++ b/sigfm/sigfm.cpp
@@ -193,10 +193,32 @@ int sigfm_match_score(SigfmImgInfo* frame, SigfmImgInfo* enrolled)
 {
     try {
         std::vector<std::vector<cv::DMatch>> points;
-        std::vector<std::vector<cv::DMatch>> backward;
         auto bfm = cv::BFMatcher::create();
         bfm->knnMatch(frame->descriptors, enrolled->descriptors, points, 2);
-        bfm->knnMatch(enrolled->descriptors, frame->descriptors, backward, 1);
+        std::vector<int> candidate_positions(enrolled->descriptors.rows, -1);
+        std::vector<int> candidate_indices;
+        cv::Mat candidate_descriptors;
+
+        for (const auto& pts : points) {
+            if (pts.size() < 2) {
+                continue;
+            }
+
+            const cv::DMatch& match_1 = pts.at(0);
+            if (match_1.distance < distance_match * pts.at(1).distance &&
+                candidate_positions[match_1.trainIdx] < 0) {
+                candidate_positions[match_1.trainIdx] = candidate_indices.size();
+                candidate_indices.push_back(match_1.trainIdx);
+                candidate_descriptors.push_back(enrolled->descriptors.row(match_1.trainIdx));
+            }
+        }
+
+        if (candidate_indices.size() < min_match) {
+            return 0;
+        }
+
+        std::vector<std::vector<cv::DMatch>> backward;
+        bfm->knnMatch(candidate_descriptors, frame->descriptors, backward, 1);
         std::set<match> matches_unique;
         int nb_matched = 0;
         for (const auto& pts : points) {
@@ -205,9 +227,9 @@ int sigfm_match_score(SigfmImgInfo* frame, SigfmImgInfo* enrolled)
             }
             const cv::DMatch& match_1 = pts.at(0);
             if (match_1.distance < distance_match * pts.at(1).distance) {
-                if (static_cast<std::size_t>(match_1.trainIdx) >= backward.size() ||
-                    backward[match_1.trainIdx].empty() ||
-                    backward[match_1.trainIdx][0].trainIdx != match_1.queryIdx) {
+                const int candidate_position = candidate_positions[match_1.trainIdx];
+                if (candidate_position < 0 || backward[candidate_position].empty() ||
+                    backward[candidate_position][0].trainIdx != match_1.queryIdx) {
                     continue;
                 }
 


### PR DESCRIPTION
## What changed

SIGFM currently runs the reverse nearest-neighbour search over every enrolled descriptor. Only descriptors that passed the forward ratio test can become mutual matches, so this limits the reverse search to those candidates. The resulting scores are unchanged.

Identify and verify now also stop once they have a usable match:

- verify stops when a sample reaches the existing threshold
- identify stops for normal fprintd galleries where every print belongs to the same username
- mixed-user, unlabelled and debug-logged galleries remain exhaustive

## Performance

20,184 genuine and impostor comparisons produced identical scores. The matcher itself was 1.6x-2.8x faster.

| Scenario | Before | Expected after |
|---|---:|---:|
| 6-finger identify, observed match at 11/48 | 39 ms | ~5 ms (7.6x faster) |
| 10-finger identify, average match position | 67-83 ms | ~17-21 ms (4x faster) |
| 10-finger identify, first-sample match | 67-83 ms | <1 ms |
| Successful verify, campaign average | 7.8 ms | ~1.6 ms (4.8x faster) |

Matching time only; capture and finger-placement time are unchanged.

## Behavior and validation

The threshold, template format and individual match scores do not change. Failed attempts still check every sample. In a same-user gallery, identify may now report the first finger above the threshold rather than the highest-scoring finger, but the authenticated username and accept/reject result are unchanged.

Tested with:

- `./scripts/build-local.sh`
- exact-score comparison across 20,184 genuine and real-impostor matches
- accept/reject equivalence checks for the early-exit path