### PR TITLE
Validate manual FDT replies

### DIFF
--- a/drivers/goodix53x5/goodix53x5-commands.c
+++ b/drivers/goodix53x5/goodix53x5-commands.c
@@ -348,6 +348,27 @@ goodix_cmd_parse_ec_control_reply (FpDevice *dev)
 }
 
 gboolean
+goodix_cmd_parse_fdt_manual_reply (FpDevice      *dev,
+                                   const guint8 **out_payload,
+                                   gsize         *out_payload_len,
+                                   GError       **error)
+{
+  if (!goodix_parse_reply_exact (dev, GOODIX_PROTO_CATEGORY_FDT,
+                                 GOODIX_PROTO_CMD_FDT_MANUAL,
+                                 out_payload, out_payload_len, error))
+    return FALSE;
+
+  if (*out_payload_len < 4 + GOODIX_FDT_BASE_LEN)
+    {
+      g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                   "Manual FDT reply is too short: %zu", *out_payload_len);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
 goodix_cmd_parse_fdt_event (FpDevice      *dev,
                             gboolean       up,
                             const guint8 **out_payload,

--- a/drivers/goodix53x5/goodix53x5-commands.h
+++ b/drivers/goodix53x5/goodix53x5-commands.h
@@ -132,6 +132,12 @@ gboolean goodix_cmd_parse_config_reply (FpDevice *dev);
 /* TRUE if the EC power control reply reports success. */
 gboolean goodix_cmd_parse_ec_control_reply (FpDevice *dev);
 
+/* Parse a manual FDT reading returned by goodix_cmd_fdt_manual(). */
+gboolean goodix_cmd_parse_fdt_manual_reply (FpDevice      *dev,
+                                             const guint8 **out_payload,
+                                             gsize         *out_payload_len,
+                                             GError       **error);
+
 /* Parse an FDT down/up event delivered after goodix_cmd_fdt_down_setup() /
  * goodix_cmd_fdt_up_setup(). The payload layout is
  * [irq_status(2)][touch_flag(2)][fdt_data(GOODIX_FDT_BASE_LEN)]. */

--- a/drivers/goodix53x5/goodix53x5-scan.c
+++ b/drivers/goodix53x5/goodix53x5-scan.c
@@ -247,16 +247,13 @@ goodix_finger_wait_ssm_handler (FpiSsm   *ssm,
     case GOODIX_FINGER_WAIT_VALIDATE:
       {
         /* Parse manual FDT response and check for a false FDT-down event. */
-        guint8 cat, cmd;
+        g_autoptr(GError) error = NULL;
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_parse_reply (dev, &cat, &cmd, &pl, &pl_len, NULL) ||
-            pl_len < 4 + GOODIX_FDT_BASE_LEN)
+        if (!goodix_cmd_parse_fdt_manual_reply (dev, &pl, &pl_len, &error))
           {
-            fpi_ssm_mark_failed (ssm,
-                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse FDT check"));
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
             return;
           }
 

--- a/drivers/goodix53x5/goodix53x5-session.c
+++ b/drivers/goodix53x5/goodix53x5-session.c
@@ -464,24 +464,19 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
     case GOODIX_OPEN_VALIDATE_FDT:
       {
         /* Parse FDT response and save */
-        guint8 cat, cmd;
+        g_autoptr(GError) error = NULL;
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_parse_reply (dev, &cat, &cmd, &pl, &pl_len, NULL))
+        if (!goodix_cmd_parse_fdt_manual_reply (dev, &pl, &pl_len, &error))
           {
-            fpi_ssm_mark_failed (ssm,
-                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse FDT response"));
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
             return;
           }
 
         /* FDT data is the payload after 4 bytes of irq+touch_flag */
-        if (pl_len >= 4 + GOODIX_FDT_BASE_LEN)
-          {
-            g_free (self->fdt_data_tx_on);
-            self->fdt_data_tx_on = g_memdup2 (pl + 4, GOODIX_FDT_BASE_LEN);
-          }
+        g_free (self->fdt_data_tx_on);
+        self->fdt_data_tx_on = g_memdup2 (pl + 4, GOODIX_FDT_BASE_LEN);
 
         fpi_ssm_next_state (ssm);
       }
@@ -495,43 +490,38 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
     case GOODIX_OPEN_VALIDATE_FDT_2:
       {
         /* Parse and validate second FDT */
-        guint8 cat, cmd;
+        g_autoptr(GError) error = NULL;
         const guint8 *pl;
         gsize pl_len;
 
-        if (!goodix_parse_reply (dev, &cat, &cmd, &pl, &pl_len, NULL))
+        if (!goodix_cmd_parse_fdt_manual_reply (dev, &pl, &pl_len, &error))
           {
-            fpi_ssm_mark_failed (ssm,
-                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
-                                                           "Failed to parse second FDT"));
+            fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
             return;
           }
 
         /* Validate against the open-time FDT base we just recorded. */
-        if (pl_len >= 4 + GOODIX_FDT_BASE_LEN && self->fdt_data_tx_on)
+        if (!goodix_device_is_fdt_base_valid (pl + 4,
+                                              self->fdt_data_tx_on,
+                                              GOODIX_FDT_BASE_LEN,
+                                              self->calib.delta_fdt))
           {
-            if (!goodix_device_is_fdt_base_valid (pl + 4,
-                                                  self->fdt_data_tx_on,
-                                                  GOODIX_FDT_BASE_LEN,
-                                                  self->calib.delta_fdt))
+            if (self->open_fdt_retries++ < GOODIX_OPEN_FDT_MAX_RETRIES)
               {
-                if (self->open_fdt_retries++ < GOODIX_OPEN_FDT_MAX_RETRIES)
-                  {
-                    fp_warn ("Open FDT validation unstable, retrying (%u/%u)",
-                             self->open_fdt_retries,
-                             GOODIX_OPEN_FDT_MAX_RETRIES);
-                    g_free (self->fdt_data_tx_on);
-                    self->fdt_data_tx_on = g_memdup2 (pl + 4,
-                                                      GOODIX_FDT_BASE_LEN);
-                    fpi_ssm_jump_to_state (ssm, GOODIX_OPEN_FDT_TX_ON_2);
-                    return;
-                  }
-
-                fpi_ssm_mark_failed (ssm,
-                                     fpi_device_error_new_msg (FP_DEVICE_ERROR_GENERAL,
-                                                               "Open FDT baseline did not stabilize"));
+                fp_warn ("Open FDT validation unstable, retrying (%u/%u)",
+                         self->open_fdt_retries,
+                         GOODIX_OPEN_FDT_MAX_RETRIES);
+                g_free (self->fdt_data_tx_on);
+                self->fdt_data_tx_on = g_memdup2 (pl + 4,
+                                                  GOODIX_FDT_BASE_LEN);
+                fpi_ssm_jump_to_state (ssm, GOODIX_OPEN_FDT_TX_ON_2);
                 return;
               }
+
+            fpi_ssm_mark_failed (ssm,
+                                 fpi_device_error_new_msg (FP_DEVICE_ERROR_GENERAL,
+                                                           "Open FDT baseline did not stabilize"));
+            return;
           }
 
         fpi_ssm_next_state (ssm);


### PR DESCRIPTION
## Summary

- validate manual FDT reply category, command, and payload length in one shared parser
- reject incomplete open-time calibration readings instead of continuing with an unset baseline
- apply the same validation to runtime false-touch checks

## Validation

- built against libfprint 1.94.10 with OpenCV 5
- libfprint unit suites passed (3/3)
- SIGFM regression benchmark: 2,792 comparisons with zero score or decision mismatches
- hardware UAT passed: repeated verify, wrong-finger rejection, false-touch recovery, and suspend/resume