### PR TITLE
Add synthetic Milan lifecycle CI coverage

### DIFF
--- a/.github/workflows/milan-tests.yml
+++ b/.github/workflows/milan-tests.yml
@@ -43,9 +43,18 @@ jobs:
       - name: Checkout pinned libfprint
         run: |
           mkdir -p .build
-          git clone --branch v1.94.10 --depth 1 \
-            https://gitlab.freedesktop.org/libfprint/libfprint.git \
-            .build/libfprint
+          for attempt in 1 2 3; do
+            if git clone --branch v1.94.10 --depth 1 \
+              https://gitlab.freedesktop.org/libfprint/libfprint.git \
+              .build/libfprint; then
+              break
+            fi
+            rm -rf .build/libfprint
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
 
       - name: Build Milan test targets
         env:

--- a/.github/workflows/milan-tests.yml
+++ b/.github/workflows/milan-tests.yml
@@ -1,0 +1,62 @@
+name: Milan Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: milan-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends \
+            build-essential \
+            git \
+            libcairo2-dev \
+            libglib2.0-dev \
+            libgusb-dev \
+            libssl-dev \
+            meson \
+            ninja-build \
+            pkg-config
+
+      - name: Checkout pinned libfprint
+        run: |
+          mkdir -p .build
+          git clone --branch v1.94.10 --depth 1 \
+            https://gitlab.freedesktop.org/libfprint/libfprint.git \
+            .build/libfprint
+
+      - name: Build Milan test targets
+        env:
+          GOODIX53X5_DEBUG: "0"
+          GOODIX_LIBFPRINT_OFFLINE: "1"
+        run: ./scripts/build-local.sh
+
+      - name: Run Milan tests
+        run: |
+          meson test -C .build/libfprint/builddir \
+            --print-errorlogs \
+            goodix53x5-milan-synthetic \
+            goodix53x5-milan-state \
+            goodix53x5-milan-runtime

--- a/meson-integration.patch
+++ b/meson-integration.patch
@@ -110,7 +110,7 @@ diff --git a/tests/meson.build b/tests/meson.build
 index 00aa566..f0c5dcf 100644
 --- a/tests/meson.build
 +++ b/tests/meson.build
-@@ -324,3 +324,46 @@ foreach test_name: unit_tests
+@@ -324,3 +324,59 @@ foreach test_name: unit_tests
 +if 'goodix53x5' in drivers
 +    goodix53x5_milan_synthetic = executable(
 +        'test-goodix53x5-milan-synthetic',
@@ -122,6 +122,19 @@ index 00aa566..f0c5dcf 100644
 +    )
 +    test('goodix53x5-milan-synthetic',
 +        goodix53x5_milan_synthetic,
++        suite: ['unit-tests'],
++        env: envs)
++
++    goodix53x5_milan_state = executable(
++        'test-goodix53x5-milan-state',
++        'test-goodix53x5-milan-state.c',
++        dependencies: libfprint_private_dep,
++        c_args: common_cflags + goodix53x5_cflags,
++        link_with: libfprint_drivers,
++        install: false,
++    )
++    test('goodix53x5-milan-state',
++        goodix53x5_milan_state,
 +        suite: ['unit-tests'],
 +        env: envs)
 +

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -58,6 +58,12 @@ if ! cmp -s "$repo_dir/tests/test-goodix53x5-milan-synthetic.c" \
      "$libfprint_dir/tests/test-goodix53x5-milan-synthetic.c"
 fi
 
+if ! cmp -s "$repo_dir/tests/test-goodix53x5-milan-state.c" \
+             "$libfprint_dir/tests/test-goodix53x5-milan-state.c"; then
+  cp "$repo_dir/tests/test-goodix53x5-milan-state.c" \
+     "$libfprint_dir/tests/test-goodix53x5-milan-state.c"
+fi
+
 if ! cmp -s "$repo_dir/tests/test-goodix53x5-milan-runtime.c" \
              "$libfprint_dir/tests/test-goodix53x5-milan-runtime.c"; then
   cp "$repo_dir/tests/test-goodix53x5-milan-runtime.c" \

--- a/scripts/build-milan-stack-local.sh
+++ b/scripts/build-milan-stack-local.sh
@@ -88,6 +88,8 @@ milan_run_stage "test libfprint update result" meson test -C "$libfprint_build" 
   --print-errorlogs fpi-device
 milan_run_stage "test Milan synthetic public contract" meson test -C "$libfprint_build" \
   --print-errorlogs goodix53x5-milan-synthetic
+milan_run_stage "test Milan state invariants" meson test -C "$libfprint_build" \
+  --print-errorlogs goodix53x5-milan-state
 milan_run_stage "test Milan runtime public contract" meson test -C "$libfprint_build" \
   --print-errorlogs goodix53x5-milan-runtime
 

--- a/tests/test-goodix53x5-milan-runtime.c
+++ b/tests/test-goodix53x5-milan-runtime.c
@@ -67,9 +67,12 @@ typedef struct
   gboolean done;
   gboolean success;
   gboolean matched;
+  guint completions;
   guint reports;
   FpPrint *match;
   FpPrint *reported_match;
+  FpPrint *reported_print;
+  GError *reported_error;
   gboolean updated;
   FpPrint *enrolled;
   GError *error;
@@ -77,15 +80,20 @@ typedef struct
 
 typedef struct
 {
+  AsyncResult *result;
   guint calls;
   gint stage;
   gint retry_code;
+  gint stages[GOODIX_ENROLL_SAMPLES + 1];
+  gint retry_codes[GOODIX_ENROLL_SAMPLES + 1];
+  gboolean early_publication;
 } EnrollProgress;
 
 static HarnessPlan plan;
 static FpiSsm *paused_ssm;
 static gboolean pause_wait;
 static gboolean pause_finger_up;
+static gboolean capture_enroll_stage_pattern;
 
 static void
 generate_frames (guint16 setup[PIXELS],
@@ -286,10 +294,11 @@ milan_runtime_harness_scan_capture (FpiSsm *ssm,
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   g_autofree guint16 *setup = g_new (guint16, PIXELS);
+  guint pattern = capture_enroll_stage_pattern ? self->enroll_stage : 0;
 
   g_clear_pointer (&self->captured_raw_image, g_free);
   self->captured_raw_image = g_new (guint16, PIXELS);
-  generate_frames (setup, self->captured_raw_image, 0);
+  generate_frames (setup, self->captured_raw_image, pattern);
   goodix_milan_generation_note_use (self->milan_generation);
   fpi_ssm_next_state (ssm);
 }
@@ -475,10 +484,12 @@ match_report (FpDevice *device,
   AsyncResult *result = user_data;
 
   (void) device;
-  (void) print;
-  (void) error;
   result->reports++;
-  result->reported_match = match;
+  g_set_object (&result->reported_match, match);
+  g_set_object (&result->reported_print, print);
+  g_clear_error (&result->reported_error);
+  if (error)
+    result->reported_error = g_error_copy (error);
 }
 
 static void
@@ -491,6 +502,7 @@ verify_done (GObject *source,
   result->success = fp_device_verify_finish_with_update (
     FP_DEVICE (source), async, &result->matched, NULL, &result->updated,
     &result->error);
+  result->completions++;
   result->done = TRUE;
 }
 
@@ -504,6 +516,7 @@ identify_done (GObject *source,
   result->success = fp_device_identify_finish_with_update (
     FP_DEVICE (source), async, &result->match, NULL, &result->updated,
     &result->error);
+  result->completions++;
   result->done = TRUE;
 }
 
@@ -517,6 +530,7 @@ enroll_done (GObject *source,
   result->enrolled = fp_device_enroll_finish (
     FP_DEVICE (source), async, &result->error);
   result->success = result->enrolled != NULL;
+  result->completions++;
   result->done = TRUE;
 }
 
@@ -528,9 +542,15 @@ enroll_progress (FpDevice *device,
                  GError *error)
 {
   EnrollProgress *progress = user_data;
+  guint index = progress->calls;
 
   (void) device;
   (void) print;
+  g_assert_cmpuint (index, <, G_N_ELEMENTS (progress->stages));
+  if (progress->result && progress->result->completions != 0)
+    progress->early_publication = TRUE;
+  progress->stages[index] = completed_stages;
+  progress->retry_codes[index] = error ? error->code : -1;
   progress->calls++;
   progress->stage = completed_stages;
   progress->retry_code = error ? error->code : -1;
@@ -585,7 +605,10 @@ static void
 clear_result (AsyncResult *result)
 {
   g_clear_object (&result->match);
+  g_clear_object (&result->reported_match);
+  g_clear_object (&result->reported_print);
   g_clear_object (&result->enrolled);
+  g_clear_error (&result->reported_error);
   g_clear_error (&result->error);
   memset (result, 0, sizeof(*result));
 }
@@ -678,6 +701,148 @@ test_auth_gallery_outcomes (void)
   g_assert_cmpuint (plan.study_calls, ==, 1);
   clear_result (&result);
   close_device (device);
+}
+
+typedef enum
+{
+  AUTH_PRINT_INVALID,
+  AUTH_PRINT_VALID_0,
+  AUTH_PRINT_VALID_1,
+  AUTH_PRINT_VALID_2,
+} AuthPrintKind;
+
+typedef struct
+{
+  const gchar *name;
+  gboolean identify;
+  const AuthPrintKind *prints;
+  gsize print_count;
+  const gint32 *scores;
+  gsize score_count;
+  gint expected_match_index;
+  guint expected_reports;
+  guint expected_study_calls;
+  gint expected_error_code;
+} AuthPublicationCase;
+
+static void
+test_auth_publication_contracts (void)
+{
+  static const AuthPrintKind mixed_prints[] = {
+    AUTH_PRINT_INVALID,
+    AUTH_PRINT_VALID_0,
+    AUTH_PRINT_INVALID,
+    AUTH_PRINT_VALID_1,
+    AUTH_PRINT_VALID_2,
+  };
+  static const AuthPrintKind invalid_prints[] = {
+    AUTH_PRINT_INVALID,
+    AUTH_PRINT_INVALID,
+  };
+  static const AuthPrintKind verify_prints[] = { AUTH_PRINT_VALID_0 };
+  static const gint32 mixed_scores[] = { -4, 37 };
+  static const gint32 no_match_score[] = { 0 };
+  static const AuthPublicationCase rows[] = {
+    {
+      "mixed-identify-first-positive", TRUE,
+      mixed_prints, G_N_ELEMENTS (mixed_prints),
+      mixed_scores, G_N_ELEMENTS (mixed_scores), 3, 1, 1, -1,
+    },
+    {
+      "all-invalid-identify", TRUE,
+      invalid_prints, G_N_ELEMENTS (invalid_prints),
+      NULL, 0, -1, 0, 0, FP_DEVICE_ERROR_DATA_INVALID,
+    },
+    {
+      "verify-no-match", FALSE,
+      verify_prints, G_N_ELEMENTS (verify_prints),
+      no_match_score, G_N_ELEMENTS (no_match_score), -1, 1, 0, -1,
+    },
+  };
+  g_autoptr(GBytes) stored0 = generate_template (0);
+  g_autoptr(GBytes) stored1 = generate_template (1);
+  g_autoptr(GBytes) stored2 = generate_template (2);
+  GBytes *stored[] = { stored0, stored1, stored2 };
+
+  for (gsize row_index = 0; row_index < G_N_ELEMENTS (rows); row_index++)
+    {
+      const AuthPublicationCase *row = &rows[row_index];
+      g_autoptr(FpDevice) device = new_device ();
+      g_autoptr(GPtrArray) gallery = g_ptr_array_new_with_free_func (
+        g_object_unref);
+      GBytes *expected_gallery[G_N_ELEMENTS (mixed_prints)] = { 0 };
+      gsize valid_count = 0;
+      guint invalid_count = 0;
+      AsyncResult result = { 0 };
+
+      for (gsize i = 0; i < row->print_count; i++)
+        {
+          if (row->prints[i] == AUTH_PRINT_INVALID)
+            {
+              g_ptr_array_add (gallery, make_malformed_current_print (device));
+              invalid_count++;
+            }
+          else
+            {
+              GBytes *template_bytes = stored[row->prints[i] - AUTH_PRINT_VALID_0];
+
+              g_ptr_array_add (gallery, make_print (device, template_bytes));
+              expected_gallery[valid_count++] = template_bytes;
+            }
+        }
+      g_assert_cmpuint (row->score_count, <=, valid_count);
+      reset_plan (row->scores, expected_gallery, row->score_count, NULL);
+      if (row->expected_study_calls != 0)
+        plan.study_action = GOODIX_MILAN_STUDY_NONE;
+      for (guint i = 0; i < invalid_count; i++)
+        g_test_expect_message ("libfprint-goodix53x5", G_LOG_LEVEL_WARNING,
+                               "*Skipping invalid Milan identify gallery entry*");
+
+      if (row->identify)
+        fp_device_identify (device, gallery, NULL, match_report, &result, NULL,
+                            identify_done, &result);
+      else
+        fp_device_verify (device, g_ptr_array_index (gallery, 0), NULL,
+                          match_report, &result, NULL, verify_done, &result);
+      wait_done (&result);
+      if (invalid_count != 0)
+        g_test_assert_expected_messages ();
+
+      g_test_message ("auth publication row=%s", row->name);
+      g_assert_cmpuint (result.completions, ==, 1);
+      g_assert_cmpuint (result.reports, ==, row->expected_reports);
+      g_assert_false (result.updated);
+      g_assert_cmpuint (plan.match_calls, ==, row->score_count);
+      g_assert_cmpuint (plan.study_calls, ==, row->expected_study_calls);
+      g_assert_null (result.reported_print);
+      g_assert_null (result.reported_error);
+      if (row->expected_error_code >= 0)
+        {
+          g_assert_false (result.success);
+          g_assert_error (result.error, FP_DEVICE_ERROR,
+                          row->expected_error_code);
+          g_assert_null (result.match);
+          g_assert_null (result.reported_match);
+        }
+      else if (row->expected_match_index >= 0)
+        {
+          FpPrint *expected = g_ptr_array_index (
+            gallery, row->expected_match_index);
+
+          g_assert_true (result.success);
+          g_assert_true (result.match == expected);
+          g_assert_true (result.reported_match == expected);
+        }
+      else
+        {
+          g_assert_true (result.success);
+          g_assert_false (result.matched);
+          g_assert_null (result.match);
+          g_assert_null (result.reported_match);
+        }
+      clear_result (&result);
+      close_device (device);
+    }
 }
 
 static void
@@ -794,6 +959,93 @@ test_enrollment_combine_retry (void)
   close_device (device);
 }
 
+static void
+test_complete_enrollment_after_combine_retry (void)
+{
+  static const gint32 no_match[] = { 0 };
+  g_autoptr(FpDevice) device = new_device ();
+  g_autoptr(FpPrint) print = g_object_ref_sink (fp_print_new (device));
+  g_autoptr(GBytes) stored = generate_template (0);
+  GBytes *templates[] = { stored };
+  g_autoptr(GPtrArray) gallery = g_ptr_array_new_with_free_func (
+    g_object_unref);
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (device);
+  AsyncResult result = { 0 };
+  EnrollProgress progress = { .result = &result };
+  GoodixMilanPrintTemplateInfo info = { 0 };
+  GoodixMilanGeneration *generation = self->milan_generation;
+  guint64 generation_id = generation->generation_id;
+  FpiPrintType print_type;
+
+  g_ptr_array_add (gallery, make_print (device, stored));
+  reset_plan (no_match, templates, G_N_ELEMENTS (no_match), NULL);
+  fp_device_identify (device, gallery, NULL, match_report, &result, NULL,
+                      identify_done, &result);
+  wait_done (&result);
+  g_assert_true (result.success);
+  g_assert_no_error (result.error);
+  g_assert_cmpuint (result.completions, ==, 1);
+  g_assert_cmpuint (result.reports, ==, 1);
+  g_assert_null (result.match);
+  g_assert_null (result.reported_match);
+  g_assert_null (result.reported_print);
+  g_assert_null (result.reported_error);
+  g_assert_false (result.updated);
+  g_assert_cmpuint (plan.match_calls, ==, 1);
+  g_assert_cmpuint (plan.study_calls, ==, 0);
+  g_assert_true (self->milan_generation == generation);
+  g_assert_cmpuint (self->milan_generation->generation_id, ==, generation_id);
+  g_assert_true (self->milan_generation->identify_prelude_seen);
+  clear_result (&result);
+
+  reset_plan (NULL, NULL, 0, NULL);
+  plan.fail_next_combine = TRUE;
+  capture_enroll_stage_pattern = TRUE;
+  fp_device_enroll (device, print, NULL, enroll_progress, &progress, NULL,
+                    enroll_done, &result);
+  wait_done (&result);
+  capture_enroll_stage_pattern = FALSE;
+
+  g_assert_true (result.success);
+  g_assert_no_error (result.error);
+  g_assert_cmpuint (result.completions, ==, 1);
+  g_assert_false (progress.early_publication);
+  g_assert_cmpuint (progress.calls, ==, GOODIX_ENROLL_SAMPLES + 1);
+  g_assert_cmpint (progress.stages[0], ==, 0);
+  g_assert_cmpint (progress.retry_codes[0], ==,
+                   FP_DEVICE_RETRY_REMOVE_FINGER);
+  for (guint i = 1; i < G_N_ELEMENTS (progress.stages); i++)
+    {
+      g_assert_cmpint (progress.stages[i], ==, i);
+      g_assert_cmpint (progress.retry_codes[i], ==, -1);
+    }
+  g_assert_cmpuint (plan.combine_calls, ==, GOODIX_ENROLL_SAMPLES + 2);
+  g_assert_cmpint (self->enroll_stage, ==, GOODIX_ENROLL_SAMPLES);
+  g_assert_cmpuint (self->milan_generation->enrollment_stages, ==,
+                    GOODIX_ENROLL_SAMPLES);
+  g_assert_null (self->enroll_features);
+  g_assert_true (result.enrolled == print);
+  g_object_get (result.enrolled, "fpi-type", &print_type, NULL);
+  g_assert_cmpint (print_type, ==, FPI_PRINT_RAW);
+  g_autoptr(GBytes) enrolled_template = get_print_template (result.enrolled);
+  g_assert_true (goodix_milan_print_validate_template (
+    enrolled_template, &info, NULL));
+  g_assert_cmpuint (info.byte_size, ==, g_bytes_get_size (enrolled_template));
+  g_assert_cmpuint (info.feature_count, ==, GOODIX_ENROLL_SAMPLES);
+  g_assert_cmpuint (info.registration_count, ==, 67);
+  g_assert_cmpuint (info.relation_count, ==, 4);
+  g_assert_cmpuint (info.graph_established, ==, 1);
+  g_assert_cmpint (info.graph_reference_index, ==, 3);
+  g_assert_cmpuint (info.maximum_features, ==,
+                    GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT);
+  g_assert_cmpuint (info.maximum_records, ==, 150);
+  g_assert_cmpuint (info.queue_state, ==, 0);
+  g_assert_cmpuint (info.queue_transaction_counter, ==, 0);
+
+  clear_result (&result);
+  close_device (device);
+}
+
 typedef enum
 {
   STALE_ACTION_EPOCH,
@@ -884,12 +1136,16 @@ main (int argc,
   g_cond_init (&plan.condition);
   g_test_add_func ("/goodix53x5/milan/runtime/auth-gallery-outcomes",
                    test_auth_gallery_outcomes);
+  g_test_add_func ("/goodix53x5/milan/runtime/auth-publication-contracts",
+                   test_auth_publication_contracts);
   g_test_add_func ("/goodix53x5/milan/runtime/malformed-current-print",
                    test_malformed_current_print);
   g_test_add_func ("/goodix53x5/milan/runtime/cancellation-no-publication",
                    test_cancellation_no_publication);
   g_test_add_func ("/goodix53x5/milan/runtime/enrollment-combine-retry",
                    test_enrollment_combine_retry);
+  g_test_add_func ("/goodix53x5/milan/runtime/complete-enrollment-after-retry",
+                   test_complete_enrollment_after_combine_retry);
   g_test_add_func ("/goodix53x5/milan/runtime/stale-result-guards",
                    test_stale_result_guards);
   status = g_test_run ();

--- a/tests/test-goodix53x5-milan-state.c
+++ b/tests/test-goodix53x5-milan-state.c
@@ -1,0 +1,1418 @@
+/*
+ * Goodix 53x5 driver for libfprint - synthetic Milan state invariants
+ * Copyright (C) 2026 goodix-fp-linux-dev contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "drivers/goodix53x5/milan/enrollment/template-private.h"
+#include "drivers/goodix53x5/milan/match/info-private.h"
+#include "drivers/goodix53x5/milan/match/match.h"
+#include "drivers/goodix53x5/milan/print.h"
+#include "drivers/goodix53x5/milan/study/queue.h"
+#include "drivers/goodix53x5/milan/template/codec-private.h"
+
+#include <glib.h>
+#include <stdint.h>
+#include <string.h>
+
+static guint8
+synthetic_byte (guint seed,
+                gsize index)
+{
+  return (guint8) ((seed * 37U + index * 19U + (index >> 2)) & 0xffU);
+}
+
+static GoodixMatchInfo *
+synthetic_match_info (guint seed)
+{
+  GoodixMatchInfo *info = goodix_match_info_new_empty ();
+  guint8 template_data[19];
+
+  for (gsize i = 0; i < sizeof(template_data); i++)
+    template_data[i] = synthetic_byte (seed, i);
+  info->template = g_bytes_new (template_data, sizeof(template_data));
+  info->record_count = 3;
+  info->partition_count = seed % (info->record_count + 1);
+  info->records = g_new0 (GoodixMilanFeatureRecord, info->record_count);
+  for (gsize i = 0; i < sizeof(info->feature_bitmaps); i++)
+    ((guint8 *) &info->feature_bitmaps)[i] = synthetic_byte (seed + 1, i);
+  for (gsize i = 0; i < sizeof(info->inline_mask); i++)
+    info->inline_mask[i] = synthetic_byte (seed + 2, i);
+  for (gsize i = 0; i < sizeof(info->rescue_mask); i++)
+    info->rescue_mask[i] = synthetic_byte (seed + 3, i);
+  for (gsize i = 0; i < sizeof(info->antifake); i++)
+    ((guint8 *) &info->antifake)[i] = synthetic_byte (seed + 4, i);
+  for (gint record = 0; record < info->record_count; record++)
+    {
+      guint8 *bytes = (guint8 *) &info->records[record];
+
+      for (gsize i = 0; i < sizeof(info->records[record]); i++)
+        bytes[i] = synthetic_byte (seed + 5 + (guint) record, i);
+      info->records[record].foreground = record < info->partition_count ? 0 : 1;
+      info->records[record].refined_x = (gint16) ((0x100 + record * 0x20) & ~0xf);
+      info->records[record].refined_y = (gint16) ((0x200 + seed * 0x10) & ~0xf);
+      info->records[record].orientation = (gint16) ((record - 1) * 0x100);
+      memset (info->records[record].payload + 24, 0, 4);
+      memset (info->records[record].payload + 36, 0, 8);
+    }
+  info->extraction_metadata.quality = 40 + (gint) seed;
+  info->extraction_metadata.coverage = 60 + (gint) seed;
+  info->extraction_metadata.optional_c7 = (gint32) seed;
+  g_assert_true (goodix_match_info_is_complete (info));
+  return info;
+}
+
+static void
+assert_match_info_equal (const GoodixMatchInfo *actual,
+                         const GoodixMatchInfo *expected)
+{
+  g_assert_true (goodix_match_info_is_complete (actual));
+  g_assert_true (g_bytes_equal (actual->template, expected->template));
+  g_assert_cmpint (actual->record_count, ==, expected->record_count);
+  g_assert_cmpint (actual->partition_count, ==, expected->partition_count);
+  g_assert_cmpmem (&actual->feature_bitmaps, sizeof(actual->feature_bitmaps),
+                   &expected->feature_bitmaps, sizeof(expected->feature_bitmaps));
+  g_assert_cmpmem (actual->inline_mask, sizeof(actual->inline_mask),
+                   expected->inline_mask, sizeof(expected->inline_mask));
+  g_assert_cmpmem (actual->rescue_mask, sizeof(actual->rescue_mask),
+                   expected->rescue_mask, sizeof(expected->rescue_mask));
+  g_assert_cmpmem (&actual->antifake, sizeof(actual->antifake),
+                   &expected->antifake, sizeof(expected->antifake));
+  g_assert_cmpmem (actual->records,
+                   (gsize) actual->record_count * sizeof(*actual->records),
+                   expected->records,
+                   (gsize) expected->record_count * sizeof(*expected->records));
+  g_assert_cmpmem (&actual->extraction_metadata,
+                   sizeof(actual->extraction_metadata),
+                   &expected->extraction_metadata,
+                   sizeof(expected->extraction_metadata));
+}
+
+static const GoodixMatchInfo *
+queue_entry_at_rank (const GoodixStudyQueue *queue,
+                     gint rank)
+{
+  for (gsize slot = 0; slot < GOODIX_STUDY_QUEUE_CAPACITY; slot++)
+    if (queue->entries[slot].rank == rank)
+      return queue->entries[slot].info;
+  return NULL;
+}
+
+typedef struct
+{
+  guint incoming_seed;
+  guint newest_seed;
+  gint metric;
+  guint calls;
+} MetricPlan;
+
+static gboolean
+planned_metric (const GoodixMatchInfo *incoming,
+                const GoodixMatchInfo *newest,
+                gint                  *metric,
+                gpointer               user_data)
+{
+  MetricPlan *plan = user_data;
+
+  g_assert_cmpint (incoming->extraction_metadata.optional_c7, ==,
+                   (gint32) plan->incoming_seed);
+  g_assert_cmpint (newest->extraction_metadata.optional_c7, ==,
+                   (gint32) plan->newest_seed);
+  *metric = plan->metric;
+  plan->calls++;
+  return TRUE;
+}
+
+static void
+test_queue_lifecycle (void)
+{
+  g_autofree GoodixStudyQueue *invalid = goodix_study_queue_new (2, 0);
+  GoodixStudyQueue *disabled = goodix_study_queue_new (1, 17);
+  GoodixStudyQueue *queue = goodix_study_queue_new (0, 17);
+  GoodixMatchInfo *incoming = synthetic_match_info (0);
+  GoodixMatchInfo *snapshot = goodix_match_info_new_empty ();
+  GoodixMatchInfo *incomplete = goodix_match_info_new_empty ();
+  MetricPlan metric = { 0 };
+
+  g_assert_null (invalid);
+  g_assert_true (goodix_study_queue_validate (disabled));
+  g_assert_cmpuint (goodix_study_queue_allocated (disabled), ==, 0);
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     disabled, incoming, NULL, NULL), ==,
+                   GOODIX_STUDY_QUEUE_DISABLED);
+  goodix_study_queue_disable (disabled);
+  g_assert_true (goodix_study_queue_validate (disabled));
+  goodix_study_queue_free (disabled);
+
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_allocated (queue), ==,
+                    GOODIX_STUDY_QUEUE_CAPACITY);
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, incomplete, NULL, NULL), ==,
+                   GOODIX_STUDY_QUEUE_INVALID);
+  goodix_match_free_info (incomplete);
+  queue->entries[0].rank = 0;
+  g_assert_false (goodix_study_queue_validate (queue));
+  queue->entries[0].rank = -1;
+  g_assert_true (goodix_study_queue_validate (queue));
+
+  g_assert_true (goodix_match_info_copy (snapshot, incoming));
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, incoming, NULL, NULL), ==,
+                   GOODIX_STUDY_QUEUE_ENQUEUED);
+  assert_match_info_equal (incoming, snapshot);
+  assert_match_info_equal (queue_entry_at_rank (queue, 0), snapshot);
+  incoming->feature_bitmaps.high_bitmap[0] ^= 0xff;
+  g_assert_cmpuint (queue_entry_at_rank (queue, 0)->feature_bitmaps.high_bitmap[0],
+                    ==, snapshot->feature_bitmaps.high_bitmap[0]);
+  goodix_match_free_info (incoming);
+  goodix_match_free_info (snapshot);
+
+  incoming = synthetic_match_info (1);
+  metric = (MetricPlan) { 1, 0, 191, 0 };
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, incoming, planned_metric, &metric), ==,
+                   GOODIX_STUDY_QUEUE_DUPLICATE);
+  g_assert_cmpuint (metric.calls, ==, 1);
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 1);
+  metric.metric = 190;
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, incoming, planned_metric, &metric), ==,
+                   GOODIX_STUDY_QUEUE_ENQUEUED);
+  g_assert_cmpuint (metric.calls, ==, 2);
+  goodix_match_free_info (incoming);
+
+  for (guint seed = 2; seed < GOODIX_STUDY_QUEUE_CAPACITY; seed++)
+    {
+      incoming = synthetic_match_info (seed);
+      metric = (MetricPlan) { seed, seed - 1, 0, 0 };
+      g_assert_cmpint (goodix_study_queue_enqueue (
+                         queue, incoming, planned_metric, &metric), ==,
+                       GOODIX_STUDY_QUEUE_ENQUEUED);
+      g_assert_cmpuint (metric.calls, ==, 1);
+      goodix_match_free_info (incoming);
+    }
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==,
+                    GOODIX_STUDY_QUEUE_CAPACITY);
+  for (guint rank = 0; rank < GOODIX_STUDY_QUEUE_CAPACITY; rank++)
+    g_assert_cmpint (queue_entry_at_rank (queue, (gint) rank)
+                       ->extraction_metadata.optional_c7, ==, (gint) rank);
+
+  incoming = synthetic_match_info (GOODIX_STUDY_QUEUE_CAPACITY);
+  metric = (MetricPlan) {
+    GOODIX_STUDY_QUEUE_CAPACITY, GOODIX_STUDY_QUEUE_CAPACITY - 1, 0, 0
+  };
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, incoming, planned_metric, &metric), ==,
+                   GOODIX_STUDY_QUEUE_ENQUEUED);
+  goodix_match_free_info (incoming);
+  for (guint rank = 0; rank < GOODIX_STUDY_QUEUE_CAPACITY; rank++)
+    g_assert_cmpint (queue_entry_at_rank (queue, (gint) rank)
+                       ->extraction_metadata.optional_c7, ==, (gint) rank + 1);
+
+  goodix_study_queue_disable (queue);
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
+  g_assert_cmpuint (goodix_study_queue_allocated (queue), ==, 0);
+  goodix_study_queue_disable (queue);
+  g_assert_true (goodix_study_queue_validate (queue));
+  goodix_study_queue_free (queue);
+}
+
+typedef struct
+{
+  guint seed;
+  gsize triggering_index;
+  gboolean succeed;
+  gsize selected_index;
+} FollowupStep;
+
+typedef struct
+{
+  const FollowupStep *steps;
+  gsize step_count;
+  gsize next_step;
+} FollowupPlan;
+
+static gboolean
+planned_followup (GoodixMatchInfo *queued,
+                  gsize            physical_slot,
+                  gsize            triggering_index,
+                  gsize           *selected_index,
+                  gpointer         user_data)
+{
+  FollowupPlan *plan = user_data;
+  const FollowupStep *step;
+
+  g_assert_cmpuint (physical_slot, <, GOODIX_STUDY_QUEUE_CAPACITY);
+  g_assert_cmpuint (plan->next_step, <, plan->step_count);
+  step = &plan->steps[plan->next_step++];
+  g_assert_cmpint (queued->extraction_metadata.optional_c7, ==,
+                   (gint32) step->seed);
+  g_assert_cmpuint (triggering_index, ==, step->triggering_index);
+  *selected_index = step->selected_index;
+  return step->succeed;
+}
+
+static GoodixStudyQueue *
+queue_with_seeds (const guint *seeds,
+                  gsize        seed_count)
+{
+  GoodixStudyQueue *queue = goodix_study_queue_new (0, 9);
+
+  for (gsize i = 0; i < seed_count; i++)
+    {
+      GoodixMatchInfo *info = synthetic_match_info (seeds[i]);
+      MetricPlan metric = { seeds[i], i == 0 ? 0 : seeds[i - 1], 0, 0 };
+
+      g_assert_cmpint (goodix_study_queue_enqueue (
+                         queue, info, i == 0 ? NULL : planned_metric,
+                         i == 0 ? NULL : &metric), ==,
+                       GOODIX_STUDY_QUEUE_ENQUEUED);
+      goodix_match_free_info (info);
+    }
+  return queue;
+}
+
+static void
+test_queue_process (void)
+{
+  static const guint seeds[] = { 1, 2, 3 };
+  static const FollowupStep success_steps[] = {
+    { 1, 50, TRUE, SIZE_MAX },
+    { 2, 50, TRUE, 60 },
+    { 3, 50, TRUE, 50 },
+    { 1, 60, TRUE, 61 },
+  };
+  static const FollowupStep failure_steps[] = {
+    { 7, 5, FALSE, SIZE_MAX },
+  };
+  GoodixStudyQueue *queue = queue_with_seeds (seeds, G_N_ELEMENTS (seeds));
+  FollowupPlan plan = { success_steps, G_N_ELEMENTS (success_steps), 0 };
+  gboolean mutated = FALSE;
+
+  g_assert_true (goodix_study_queue_process (
+    queue, 50, planned_followup, &plan, &mutated));
+  g_assert_true (mutated);
+  g_assert_cmpuint (plan.next_step, ==, plan.step_count);
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
+  g_assert_true (goodix_study_queue_validate (queue));
+  goodix_study_queue_free (queue);
+
+  {
+    static const guint failure_seed[] = { 7 };
+
+    queue = queue_with_seeds (failure_seed, G_N_ELEMENTS (failure_seed));
+  }
+  plan = (FollowupPlan) {
+    failure_steps, G_N_ELEMENTS (failure_steps), 0
+  };
+  mutated = TRUE;
+  g_assert_false (goodix_study_queue_process (
+    queue, 5, planned_followup, &plan, &mutated));
+  g_assert_false (mutated);
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 1);
+  g_assert_true (goodix_study_queue_validate (queue));
+  goodix_study_queue_free (queue);
+
+  queue = goodix_study_queue_new (1, 9);
+  plan = (FollowupPlan) { NULL, 0, 0 };
+  mutated = TRUE;
+  g_assert_false (goodix_study_queue_process (
+    queue, 5, planned_followup, &plan, &mutated));
+  g_assert_false (mutated);
+  g_assert_true (goodix_study_queue_validate (queue));
+  goodix_study_queue_free (queue);
+}
+
+typedef struct
+{
+  const gchar *name;
+  gsize feature_count;
+  gsize record_count;
+  gsize relation_count;
+  gboolean optional_c7;
+  gboolean graph_established;
+  guint64 lifecycle_mask;
+} TemplateShape;
+
+static GBytes *
+synthetic_feature_element (guint    seed,
+                           gsize    record_count,
+                           gboolean optional_c7)
+{
+  guint8 high[286];
+  guint8 enhanced[286];
+  guint8 inline_mask[72];
+  guint8 low[286];
+  GoodixMilanFeatureRecord *records = g_new0 (
+    GoodixMilanFeatureRecord, record_count);
+  GoodixMilanAntifakeBlob antifake;
+  GoodixMilanFeatureTemplateFields fields = { 0 };
+  g_autofree guint8 *packed = g_malloc (7950 + record_count * 32);
+  gsize packed_size = 0;
+
+  for (gsize i = 0; i < sizeof(high); i++)
+    {
+      high[i] = synthetic_byte (seed, i);
+      enhanced[i] = synthetic_byte (seed + 1, i);
+      low[i] = synthetic_byte (seed + 2, i);
+    }
+  for (gsize i = 0; i < sizeof(inline_mask); i++)
+    inline_mask[i] = synthetic_byte (seed + 3, i);
+  for (gsize i = 0; i < sizeof(antifake); i++)
+    ((guint8 *) &antifake)[i] = synthetic_byte (seed + 4, i);
+  for (gsize record = 0; record < record_count; record++)
+    {
+      guint8 *bytes = (guint8 *) &records[record];
+
+      for (gsize i = 0; i < sizeof(records[record]); i++)
+        bytes[i] = synthetic_byte (seed + 5 + (guint) record, i);
+      records[record].foreground = record % 2;
+      records[record].refined_x = (gint16) ((0x1200 + record * 0x110) & ~0xf);
+      records[record].refined_y = (gint16) ((0x2200 + record * 0x130) & ~0xf);
+      records[record].orientation = (gint16) (((gint) record - 1) * 0x100);
+    }
+  for (gsize i = 0; i < G_N_ELEMENTS (fields.tagged_values); i++)
+    fields.tagged_values[i] = (gint32) (seed * 100 + i * 7);
+  fields.tagged_values[0] = 0;
+  fields.optional_c7 = optional_c7 ? (gint32) (0x100 + seed) : 0;
+
+  {
+    g_autofree guint8 *high_before = g_memdup2 (high, sizeof(high));
+    g_autofree guint8 *enhanced_before = g_memdup2 (enhanced, sizeof(enhanced));
+    g_autofree guint8 *mask_before = g_memdup2 (inline_mask, sizeof(inline_mask));
+    g_autofree guint8 *low_before = g_memdup2 (low, sizeof(low));
+    g_autofree GoodixMilanFeatureRecord *records_before = g_memdup2 (
+      records, record_count * sizeof(*records));
+    g_autofree GoodixMilanAntifakeBlob *antifake_before = g_memdup2 (
+      &antifake, sizeof(antifake));
+    GoodixMilanFeatureTemplateFields fields_before = fields;
+
+    g_assert_cmpint (goodix_milan_template_pack_feature_element (
+                       high, enhanced, inline_mask, low, records, record_count,
+                       &antifake, &fields, packed,
+                       7950 + record_count * 32, &packed_size), ==, 0);
+    g_assert_cmpmem (high, sizeof(high), high_before, sizeof(high));
+    g_assert_cmpmem (enhanced, sizeof(enhanced), enhanced_before,
+                     sizeof(enhanced));
+    g_assert_cmpmem (inline_mask, sizeof(inline_mask), mask_before,
+                     sizeof(inline_mask));
+    g_assert_cmpmem (low, sizeof(low), low_before, sizeof(low));
+    g_assert_cmpmem (records, record_count * sizeof(*records), records_before,
+                     record_count * sizeof(*records));
+    g_assert_cmpmem (&antifake, sizeof(antifake), antifake_before,
+                     sizeof(antifake));
+    g_assert_cmpmem (&fields, sizeof(fields), &fields_before, sizeof(fields));
+  }
+  g_free (records);
+  return g_bytes_new (packed, packed_size);
+}
+
+static GBytes *
+study_feature_element (guint    seed,
+                       gboolean matchable,
+                       gint32   active,
+                       gint32   state,
+                       gint32   residual,
+                       gint32   ordinal)
+{
+  const gsize record_count = matchable ? 150 : 1;
+  guint8 high[286];
+  guint8 enhanced[286];
+  guint8 inline_mask[72];
+  guint8 low[286];
+  g_autofree GoodixMilanFeatureRecord *records = g_new0 (
+    GoodixMilanFeatureRecord, record_count);
+  GoodixMilanAntifakeBlob antifake = { 0 };
+  GoodixMilanFeatureTemplateFields fields = { 0 };
+  g_autofree guint8 *packed = g_malloc (7950 + record_count * 32);
+  gsize packed_size = 0;
+
+  /* Exact uniform maps are rejected by overlap admission; this balanced
+   * pattern supplies both zero and one agreement classes. */
+  for (gsize i = 0; i < sizeof(high); i++)
+    {
+      high[i] = matchable ? 0xaa : synthetic_byte (seed, i);
+      enhanced[i] = matchable ? 0xaa : synthetic_byte (seed + 1, i);
+      low[i] = matchable ? 0xaa : synthetic_byte (seed + 2, i);
+    }
+  memset (inline_mask, matchable ? 0xff : 0, sizeof(inline_mask));
+  for (gsize i = 0; i < record_count; i++)
+    {
+      records[i].foreground = 1;
+      records[i].refined_x = matchable
+                               ? (gint16) ((4 + (i % 15) * 6) * 0x100)
+                               : (gint16) (0x1200 + seed * 0x100);
+      records[i].refined_y = matchable
+                               ? (gint16) ((4 + (i / 15) * 8) * 0x100)
+                               : (gint16) (0x2200 + seed * 0x100);
+      records[i].orientation = matchable
+                                 ? (gint16) (((gint) (i % 16) - 8) * 0x100)
+                                 : (gint16) (seed * 0x100);
+      for (gsize byte = 0; byte < sizeof(records[i].payload); byte++)
+        records[i].payload[byte] = matchable
+                                     ? (guint8) (seed * 13 + i * 7 + byte * 3)
+                                     : (guint8) (seed + byte);
+      memset (records[i].payload + 24, 0, 4);
+      memset (records[i].payload + 36, 0, 8);
+    }
+  fields.tagged_values[0] = active;
+  fields.tagged_values[1] = ordinal == 0
+                              ? 0
+                              : 1 + ordinal * (ordinal - 1) / 2;
+  fields.tagged_values[2] = 0;
+  fields.tagged_values[3] = matchable ? 100 : 50;
+  fields.tagged_values[4] = matchable ? 100 : 80;
+  fields.tagged_values[5] = state;
+  fields.tagged_values[6] = residual;
+  fields.tagged_values[7] = ordinal;
+
+  g_assert_cmpint (goodix_milan_template_pack_feature_element (
+                     high, enhanced, inline_mask, low, records, record_count,
+                     &antifake, &fields, packed, 7950 + record_count * 32,
+                     &packed_size), ==, 0);
+  return g_bytes_new (packed, packed_size);
+}
+
+static GoodixMatchInfo *
+study_match_info (guint seed,
+                  gboolean matchable)
+{
+  GoodixMatchInfo *info = goodix_match_info_new_empty ();
+  g_autoptr(GBytes) feature = study_feature_element (
+    seed, matchable, 0, 0, 0, 0);
+  const guint8 *feature_data;
+  gsize feature_size;
+  guint8 tail[0x520] = { 0 };
+  g_autofree guint8 *packed = NULL;
+  size_t packed_size = 0;
+  GoodixMilanFeatureView view;
+
+  feature_data = g_bytes_get_data (feature, &feature_size);
+  packed = g_malloc (1433 + feature_size);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     feature_data, feature_size, &view), ==, 0);
+  g_assert_cmpint (goodix_milan_template_pack_one_feature (
+                     feature_data, feature_size, tail, sizeof(tail), packed,
+                     1433 + feature_size, &packed_size), ==, 0);
+  info->template = goodix_match_wrap_template (packed, packed_size);
+  info->record_count = (gint) view.record_count;
+  info->partition_count = view.fields.tagged_values[2];
+  info->records = g_new0 (GoodixMilanFeatureRecord, view.record_count);
+  g_assert_cmpint (goodix_milan_feature_unpack_template_records (
+                     view.packed_records, view.record_count,
+                     (gsize) info->partition_count, info->records,
+                     view.record_count), ==, 0);
+  memcpy (info->feature_bitmaps.high_bitmap, view.high_bitmap,
+          sizeof(info->feature_bitmaps.high_bitmap));
+  memcpy (info->feature_bitmaps.enhanced_bitmap, view.enhanced_bitmap,
+          sizeof(info->feature_bitmaps.enhanced_bitmap));
+  memcpy (info->feature_bitmaps.low_bitmap, view.low_bitmap,
+          sizeof(info->feature_bitmaps.low_bitmap));
+  memcpy (info->inline_mask, view.inline_mask, sizeof(info->inline_mask));
+  memset (info->rescue_mask, matchable ? 0xff : 0,
+          sizeof(info->rescue_mask));
+  memcpy (&info->antifake, view.antifake, sizeof(info->antifake));
+  info->extraction_metadata.quality = view.fields.tagged_values[3];
+  info->extraction_metadata.coverage = view.fields.tagged_values[4];
+  info->extraction_metadata.optional_c7 = view.fields.optional_c7;
+  g_assert_true (goodix_match_info_is_complete (info));
+  return info;
+}
+
+static GBytes *
+study_gallery (GoodixMilanStudyAction action,
+               gboolean               matchable_enrolled)
+{
+  enum { N_FEATURES = GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT };
+  GBytes *features[N_FEATURES] = { 0 };
+  const guint8 *feature_data[N_FEATURES];
+  gsize feature_sizes[N_FEATURES];
+  GoodixMilanTemplateRelation relations[N_FEATURES - 1] = { 0 };
+  GoodixMilanTemplateMetadata metadata = { 0 };
+  guint8 tail[0x520] = { 0 };
+  g_autofree guint8 *packed = NULL;
+  gsize capacity = 1433 + G_N_ELEMENTS (relations) * 45;
+  gsize packed_size = 0;
+  GBytes *wrapped;
+
+  for (gsize i = 0; i < N_FEATURES; i++)
+    {
+      gint32 state = action == GOODIX_MILAN_STUDY_GEOMETRIC && i + 1 < N_FEATURES
+                       ? 5 : 1;
+      gboolean matchable = matchable_enrolled && i == 1;
+      gint32 residual = i == 0 ? 0
+                         : action == GOODIX_MILAN_STUDY_GEOMETRIC
+                             ? 20 : (i == 1 ? 0 : 20);
+
+      features[i] = study_feature_element (
+        matchable ? 9 : (guint) i + 1, matchable, 1, state, residual,
+        (gint32) i);
+      feature_data[i] = g_bytes_get_data (features[i], &feature_sizes[i]);
+      capacity += feature_sizes[i];
+      goodix_milan_template_write_u32 (tail + i * 4, (guint32) i);
+      if (i != 0)
+        {
+          static const gint32 identity_relation[7] = {
+            0, 0x100, 0, 0, 0, 0x100, 0,
+          };
+
+          relations[i - 1].index = 1 + (gint32) (i * (i - 1) / 2);
+          memcpy (relations[i - 1].values, identity_relation,
+                  sizeof(identity_relation));
+        }
+    }
+  metadata.sensor_type = 12;
+  metadata.maximum_features = N_FEATURES;
+  metadata.registration_count = 1 + N_FEATURES * (N_FEATURES - 1) / 2;
+  metadata.maximum_records = 150;
+  metadata.queue_state = 0;
+  metadata.queue_transaction_counter = 7;
+  metadata.graph_reference_index = 0;
+  metadata.graph_companion_f3 = -1;
+  metadata.graph_companion_f4 = -1;
+  metadata.graph_established = 1;
+
+  packed = g_malloc (capacity);
+  g_assert_cmpint (goodix_milan_template_pack (
+                     feature_data, feature_sizes, N_FEATURES, relations,
+                     G_N_ELEMENTS (relations), &metadata, tail, sizeof(tail),
+                     packed, capacity, &packed_size), ==, 0);
+  wrapped = goodix_match_wrap_template (packed, packed_size);
+  for (gsize i = 0; i < N_FEATURES; i++)
+    g_bytes_unref (features[i]);
+  return wrapped;
+}
+
+static void
+assert_study_template (GBytes                       *bytes,
+                       guint32                       expected_relations,
+                       GoodixMilanPrintTemplateInfo *info,
+                       GoodixMilanUnpackedTemplate  *unpacked)
+{
+  g_autoptr(GError) error = NULL;
+  GoodixSigfmTemplateStatus status;
+  const guint8 *wrapped;
+  const guint8 *payload;
+  gsize wrapped_size;
+  gsize payload_size;
+
+  g_assert_true (goodix_milan_print_validate_template (bytes, info, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (info->feature_count, ==,
+                    GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT);
+  g_assert_cmpuint (info->maximum_features, ==,
+                    GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT);
+  g_assert_cmpuint (info->relation_count, ==, expected_relations);
+  g_assert_cmpuint (info->queue_state, ==, 1);
+  g_assert_cmpuint (info->queue_transaction_counter, ==, 7);
+  g_assert_cmpuint (info->registration_count, ==,
+                    1 + GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT *
+                          (GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1) / 2);
+  g_assert_cmpuint (info->graph_established, ==, 1);
+  g_assert_cmpint (info->graph_reference_index, ==, 0);
+  wrapped = g_bytes_get_data (bytes, &wrapped_size);
+  payload = goodix_match_unwrap_template (
+    wrapped, wrapped_size, &payload_size, &status);
+  g_assert_nonnull (payload);
+  g_assert_cmpint (goodix_milan_template_unpack (
+                     payload, payload_size, unpacked), ==, 0);
+}
+
+static void
+unpack_study_template (GBytes                      *bytes,
+                       GoodixMilanUnpackedTemplate *unpacked)
+{
+  GoodixSigfmTemplateStatus status;
+  const guint8 *wrapped;
+  const guint8 *payload;
+  gsize wrapped_size;
+  gsize payload_size;
+
+  wrapped = g_bytes_get_data (bytes, &wrapped_size);
+  payload = goodix_match_unwrap_template (
+    wrapped, wrapped_size, &payload_size, &status);
+  g_assert_nonnull (payload);
+  g_assert_cmpint (goodix_milan_template_unpack (
+                     payload, payload_size, unpacked), ==, 0);
+}
+
+static void
+assert_feature_material_equal (const GoodixMilanFeatureView *actual,
+                               const GoodixMilanFeatureView *expected)
+{
+  g_assert_cmpuint (actual->record_count, ==, expected->record_count);
+  g_assert_cmpmem (actual->high_bitmap, 286, expected->high_bitmap, 286);
+  g_assert_cmpmem (actual->enhanced_bitmap, 286,
+                   expected->enhanced_bitmap, 286);
+  g_assert_cmpmem (actual->inline_mask, 72, expected->inline_mask, 72);
+  g_assert_cmpmem (actual->low_bitmap, 286, expected->low_bitmap, 286);
+  g_assert_cmpmem (actual->packed_records, actual->record_count * 32,
+                   expected->packed_records, expected->record_count * 32);
+  g_assert_cmpmem (actual->antifake, GOODIX_MILAN_ANTIFAKE_SIZE,
+                   expected->antifake, GOODIX_MILAN_ANTIFAKE_SIZE);
+}
+
+static void
+assert_replacement_relations (const GoodixMilanUnpackedTemplate *unpacked,
+                              GoodixMilanStudyAction              action,
+                              gsize                               selected_index)
+{
+  static const gint32 identity_relation[7] = {
+    0, 0x100, 0, 0, 0, 0x100, 0,
+  };
+  gsize relation = 0;
+
+  for (gsize i = 1; i < GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT; i++)
+    {
+      if (action == GOODIX_MILAN_STUDY_REPLACE_NO_RELATION &&
+          i == selected_index)
+        continue;
+      g_assert_cmpuint (relation, <, unpacked->relation_count);
+      g_assert_cmpint (unpacked->relations[relation].index, ==,
+                       1 + (gint32) (i * (i - 1) / 2));
+      g_assert_cmpmem (unpacked->relations[relation].values,
+                       sizeof(identity_relation), identity_relation,
+                       sizeof(identity_relation));
+      relation++;
+    }
+  g_assert_cmpuint (relation, ==, unpacked->relation_count);
+}
+
+static void
+assert_replacement_semantics (
+  const GoodixMilanUnpackedTemplate *before,
+  const GoodixMilanUnpackedTemplate *after,
+  const GoodixMilanUnpackedTemplate *probe,
+  GoodixMilanStudyAction              action,
+  gsize                               selected_index,
+  gint32                              generation_count,
+  gint32                              lifecycle_count,
+  gboolean                            finalize_transaction)
+{
+  GoodixMilanFeatureView before_selected;
+  GoodixMilanFeatureView after_selected;
+  GoodixMilanFeatureView probe_view;
+  gint32 selected_ordinal;
+
+  g_assert_cmpuint (before->feature_count, ==, after->feature_count);
+  g_assert_cmpuint (after->metadata.sensor_type, ==,
+                    before->metadata.sensor_type);
+  g_assert_cmpuint (after->metadata.maximum_features, ==,
+                    before->metadata.maximum_features);
+  g_assert_cmpuint (after->metadata.registration_count, ==,
+                    before->metadata.registration_count);
+  g_assert_cmpuint (after->metadata.maximum_records, ==,
+                    before->metadata.maximum_records);
+  g_assert_cmpuint (after->metadata.queue_state, ==, 1);
+  g_assert_cmpuint (after->metadata.queue_transaction_counter, ==,
+                    before->metadata.queue_transaction_counter);
+  g_assert_cmpint (after->metadata.graph_reference_index, ==,
+                   before->metadata.graph_reference_index);
+  g_assert_cmpint (after->metadata.graph_companion_f3, ==,
+                   before->metadata.graph_companion_f3);
+  g_assert_cmpint (after->metadata.graph_companion_f4, ==,
+                   before->metadata.graph_companion_f4);
+  g_assert_cmpuint (after->metadata.graph_established, ==,
+                    before->metadata.graph_established);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     before->feature_elements[selected_index],
+                     before->feature_element_sizes[selected_index],
+                     &before_selected), ==, 0);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     after->feature_elements[selected_index],
+                     after->feature_element_sizes[selected_index],
+                     &after_selected), ==, 0);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     probe->feature_elements[0], probe->feature_element_sizes[0],
+                     &probe_view), ==, 0);
+  assert_feature_material_equal (&after_selected, &probe_view);
+  selected_ordinal = before_selected.fields.tagged_values[7];
+
+  const gint32 expected_selected[11] = {
+    action == GOODIX_MILAN_STUDY_REPLACE_NO_RELATION
+      ? 0 : before_selected.fields.tagged_values[0],
+    before_selected.fields.tagged_values[1],
+    probe_view.fields.tagged_values[2],
+    probe_view.fields.tagged_values[3],
+    probe_view.fields.tagged_values[4],
+    before_selected.fields.tagged_values[5] == 0 ? 0 : 2,
+    action == GOODIX_MILAN_STUDY_REPLACE_NO_RELATION
+      ? before_selected.fields.tagged_values[6] : 0,
+    GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1,
+    before_selected.fields.tagged_values[8] + generation_count,
+    lifecycle_count,
+    before_selected.fields.tagged_values[10],
+  };
+
+  g_assert_cmpmem (after_selected.fields.tagged_values,
+                   sizeof(expected_selected), expected_selected,
+                   sizeof(expected_selected));
+  g_assert_cmpint (after_selected.fields.optional_c7, ==,
+                   before_selected.fields.optional_c7);
+
+  for (gsize i = 0; i < before->feature_count; i++)
+    {
+      GoodixMilanFeatureView before_view;
+      GoodixMilanFeatureView after_view;
+
+      if (i == selected_index)
+        continue;
+      g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                         before->feature_elements[i],
+                         before->feature_element_sizes[i], &before_view), ==, 0);
+      g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                         after->feature_elements[i],
+                         after->feature_element_sizes[i], &after_view), ==, 0);
+      assert_feature_material_equal (&after_view, &before_view);
+      for (gsize field = 0; field < G_N_ELEMENTS (before_view.fields.tagged_values);
+           field++)
+        {
+          gint32 expected = before_view.fields.tagged_values[field];
+
+          if (field == 6 && action != GOODIX_MILAN_STUDY_REPLACE_NO_RELATION)
+            expected = 0;
+          if (field == 7 && expected > selected_ordinal)
+            expected--;
+          g_assert_cmpint (after_view.fields.tagged_values[field], ==, expected);
+        }
+      g_assert_cmpint (after_view.fields.optional_c7, ==,
+                       before_view.fields.optional_c7);
+    }
+
+  /* Feature zero has zero residual and precedes every replacement ordinal. */
+  g_assert_cmpmem (after->feature_elements[0], after->feature_element_sizes[0],
+                   before->feature_elements[0], before->feature_element_sizes[0]);
+  assert_replacement_relations (after, action, selected_index);
+  if (finalize_transaction)
+    {
+      gsize position = 0;
+
+      g_assert_cmpuint (goodix_milan_template_read_u32 (
+                          after->tail_state + position++ * 4), ==,
+                        selected_index);
+      for (gsize i = before->feature_count; i-- > 0;)
+        if (i != selected_index)
+          g_assert_cmpuint (goodix_milan_template_read_u32 (
+                              after->tail_state + position++ * 4), ==, i);
+      g_assert_cmpuint (position, ==, before->feature_count);
+      g_assert_cmpmem (after->tail_state + before->feature_count * 4,
+                       0x50c - before->feature_count * 4,
+                       before->tail_state + before->feature_count * 4,
+                       0x50c - before->feature_count * 4);
+      g_assert_cmpuint (goodix_milan_template_read_u32 (
+                          after->tail_state + 0x50c), ==,
+                        goodix_milan_template_read_u32 (
+                          before->tail_state + 0x50c) + 1);
+    }
+  else
+    {
+      g_assert_cmpmem (after->tail_state, 0x510, before->tail_state, 0x510);
+      for (gsize i = 0; i < before->feature_count; i++)
+        g_assert_cmpuint (goodix_milan_template_read_u32 (
+                            after->tail_state + i * 4), ==, i);
+    }
+  g_assert_cmpuint (goodix_milan_template_read_u32 (after->tail_state + 0x510),
+                    ==,
+                    goodix_milan_template_read_u32 (before->tail_state + 0x510) +
+                      (guint32) generation_count);
+  g_assert_cmpmem (after->tail_state + 0x514,
+                   sizeof(after->tail_state) - 0x514,
+                   before->tail_state + 0x514,
+                   sizeof(before->tail_state) - 0x514);
+}
+
+static void
+assert_match_update_semantics (const GoodixMilanUnpackedTemplate *before,
+                               const GoodixMilanUnpackedTemplate *after,
+                               gsize                               matched_index)
+{
+  g_assert_cmpmem (&after->metadata, sizeof(after->metadata),
+                   &before->metadata, sizeof(before->metadata));
+  g_assert_cmpuint (after->feature_count, ==, before->feature_count);
+  g_assert_cmpuint (after->relation_count, ==, before->relation_count);
+  g_assert_cmpmem (after->relations,
+                   after->relation_count * sizeof(after->relations[0]),
+                   before->relations,
+                   before->relation_count * sizeof(before->relations[0]));
+  g_assert_cmpmem (after->tail_state, sizeof(after->tail_state),
+                   before->tail_state, sizeof(before->tail_state));
+
+  for (gsize i = 0; i < before->feature_count; i++)
+    {
+      GoodixMilanFeatureView before_view;
+      GoodixMilanFeatureView after_view;
+
+      g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                         before->feature_elements[i],
+                         before->feature_element_sizes[i], &before_view), ==, 0);
+      g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                         after->feature_elements[i],
+                         after->feature_element_sizes[i], &after_view), ==, 0);
+      assert_feature_material_equal (&after_view, &before_view);
+      for (gsize field = 0; field < G_N_ELEMENTS (before_view.fields.tagged_values);
+           field++)
+        {
+          gint32 expected = before_view.fields.tagged_values[field];
+
+          if (field == 6)
+            expected = 0;
+          if (field == 9 && i == matched_index)
+            expected++;
+          g_assert_cmpint (after_view.fields.tagged_values[field], ==, expected);
+        }
+      g_assert_cmpint (after_view.fields.optional_c7, ==,
+                       before_view.fields.optional_c7);
+    }
+  g_assert_cmpmem (after->feature_elements[0], after->feature_element_sizes[0],
+                   before->feature_elements[0], before->feature_element_sizes[0]);
+}
+
+static GoodixMilanMatchResult
+study_primary_result (gint32 retained_flag)
+{
+  GoodixMilanMatchResult result = {
+    .matched_feature_index = 1,
+    .score = 1,
+    .match_transform = { 0x100, 0, 0, 0, 0x100, 0 },
+    .relation = {
+      .relation_count = 1,
+      .relation_values = { 0, 0x100, 0, 0, 0, 0x100, 0 },
+      .relation_valid = 1,
+    },
+    .retained_evidence_flag = retained_flag,
+    .study_control.study_action_gate = 1,
+  };
+
+  return result;
+}
+
+typedef struct
+{
+  const gchar *name;
+  GoodixMilanStudyAction action;
+  gint32 retained_flag;
+  gsize selected_index;
+  guint32 relation_count;
+} StudyActionCase;
+
+static GBytes *
+run_study_action_case (const StudyActionCase *test_case)
+{
+  g_autoptr(GBytes) gallery = study_gallery (test_case->action, FALSE);
+  GoodixMatchInfo *probe = study_match_info (9, FALSE);
+  GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
+  GoodixMilanMatchResult result = study_primary_result (
+    test_case->retained_flag);
+  GoodixMilanStudyAction action = GOODIX_MILAN_STUDY_NONE;
+  GBytes *updated = NULL;
+  const guint8 *gallery_data;
+  gsize gallery_size;
+  GoodixMilanPrintTemplateInfo info;
+  GoodixMilanUnpackedTemplate before;
+  GoodixMilanUnpackedTemplate unpacked;
+  GoodixMilanUnpackedTemplate probe_unpacked;
+
+  unpack_study_template (gallery, &before);
+  unpack_study_template (probe->template, &probe_unpacked);
+  gallery_data = g_bytes_get_data (gallery, &gallery_size);
+  g_assert_cmpint (goodix_match_study_feature_queued (
+                     probe, gallery_data, gallery_size, &result, TRUE, queue,
+                     &updated, &action), ==, GOODIX_SIGFM_TEMPLATE_OK);
+  g_assert_cmpint (action, ==, test_case->action);
+  g_assert_nonnull (updated);
+  g_assert_false (g_bytes_equal (gallery, updated));
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
+  g_assert_cmpuint (goodix_study_queue_allocated (queue), ==, 0);
+  assert_study_template (
+    updated, test_case->relation_count, &info, &unpacked);
+  assert_replacement_semantics (
+    &before, &unpacked, &probe_unpacked, test_case->action,
+    test_case->selected_index, 1, 0, FALSE);
+
+  goodix_study_queue_free (queue);
+  goodix_match_free_info (probe);
+  return updated;
+}
+
+static void
+test_study_actions (void)
+{
+  static const StudyActionCase cases[] = {
+    { "replace-no-relation", GOODIX_MILAN_STUDY_REPLACE_NO_RELATION,
+      0, 1, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 2 },
+    { "geometric", GOODIX_MILAN_STUDY_GEOMETRIC,
+      1, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1,
+      GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1 },
+    { "replace", GOODIX_MILAN_STUDY_REPLACE,
+      1, 1, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1 },
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++)
+    {
+      g_autoptr(GBytes) first = NULL;
+
+      for (gsize repeat = 0; repeat < 2; repeat++)
+        {
+          g_autoptr(GBytes) current = run_study_action_case (&cases[i]);
+
+          g_test_message ("study action=%s repeat=%zu", cases[i].name, repeat);
+          if (!first)
+            first = g_bytes_ref (current);
+          else
+            g_assert_true (g_bytes_equal (first, current));
+        }
+    }
+}
+
+static GBytes *
+run_queued_study_case (void)
+{
+  g_autoptr(GBytes) baseline_gallery = study_gallery (
+    GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, FALSE);
+  g_autoptr(GBytes) queued_gallery = study_gallery (
+    GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, FALSE);
+  GoodixMatchInfo *primary = study_match_info (9, TRUE);
+  GoodixMatchInfo *queued = study_match_info (9, TRUE);
+  GoodixStudyQueue *baseline_queue = goodix_study_queue_new (0, 7);
+  GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
+  GoodixMilanMatchResult primary_result = study_primary_result (0);
+  GoodixMilanMatchResult queued_primary_result = study_primary_result (0);
+  GoodixMilanMatchResult followup = { 0 };
+  GoodixMilanStudyAction action = GOODIX_MILAN_STUDY_NONE;
+  GBytes *baseline = NULL;
+  GBytes *updated = NULL;
+  const guint8 *gallery_data;
+  const guint8 *baseline_data;
+  const guint8 *baseline_payload;
+  gsize gallery_size;
+  gsize baseline_size;
+  gsize baseline_payload_size;
+  GoodixSigfmTemplateStatus unwrap_status;
+  const GoodixMilanFeatureRecord *live_records[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  size_t live_record_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  size_t live_partition_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  GoodixMilanPrintTemplateInfo info;
+  GoodixMilanUnpackedTemplate before;
+  GoodixMilanUnpackedTemplate unpacked;
+  GoodixMilanUnpackedTemplate baseline_unpacked;
+  GoodixMilanUnpackedTemplate probe_unpacked;
+
+  unpack_study_template (baseline_gallery, &before);
+  unpack_study_template (primary->template, &probe_unpacked);
+  gallery_data = g_bytes_get_data (baseline_gallery, &gallery_size);
+  g_assert_cmpint (goodix_match_study_feature_queued (
+                     primary, gallery_data, gallery_size, &primary_result, TRUE,
+                     baseline_queue, &baseline, &action), ==,
+                   GOODIX_SIGFM_TEMPLATE_OK);
+  g_assert_cmpint (action, ==, GOODIX_MILAN_STUDY_REPLACE_NO_RELATION);
+  assert_study_template (
+    baseline, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 2,
+    &info, &baseline_unpacked);
+  assert_replacement_semantics (
+    &before, &baseline_unpacked, &probe_unpacked,
+    GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, 1, 1, 0, FALSE);
+
+  baseline_data = g_bytes_get_data (baseline, &baseline_size);
+  baseline_payload = goodix_match_unwrap_template (
+    baseline_data, baseline_size, &baseline_payload_size, &unwrap_status);
+  g_assert_nonnull (baseline_payload);
+  live_records[1] = primary->records;
+  live_record_counts[1] = (size_t) primary->record_count;
+  live_partition_counts[1] = (size_t) primary->partition_count;
+  g_assert_cmpint (goodix_milan_match_live_probe_result (
+                     queued->feature_bitmaps.high_bitmap,
+                     queued->feature_bitmaps.enhanced_bitmap,
+                     queued->feature_bitmaps.low_bitmap, queued->inline_mask,
+                     queued->rescue_mask, queued->records,
+                     (size_t) queued->record_count,
+                     (size_t) queued->partition_count,
+                     queued->extraction_metadata.quality,
+                     queued->extraction_metadata.coverage,
+                     queued->extraction_metadata.optional_c7,
+                     baseline_payload, baseline_payload_size, live_records,
+                     live_record_counts, live_partition_counts, 1,
+                     &followup), ==, 0);
+  g_assert_cmpint (followup.score, ==, 100);
+  g_assert_cmpuint (followup.matched_feature_index, ==, 1);
+  g_assert_true (followup.relation.relation_valid);
+  g_assert_cmpint (followup.study_control.study_finalization_gate, ==, 1);
+  g_assert_cmpint (followup.study_control.study_action_gate, ==, 1);
+  g_assert_cmpuint (followup.lifecycle_update_feature_mask, ==, UINT64_C (2));
+
+  g_assert_cmpint (goodix_study_queue_enqueue (
+                     queue, queued, NULL, NULL), ==,
+                   GOODIX_STUDY_QUEUE_ENQUEUED);
+  action = GOODIX_MILAN_STUDY_NONE;
+  gallery_data = g_bytes_get_data (queued_gallery, &gallery_size);
+  g_assert_cmpint (goodix_match_study_feature_queued (
+                     primary, gallery_data, gallery_size,
+                     &queued_primary_result, TRUE, queue, &updated, &action),
+                   ==, GOODIX_SIGFM_TEMPLATE_OK);
+  g_assert_cmpint (action, ==, GOODIX_MILAN_STUDY_QUEUED);
+  g_assert_nonnull (updated);
+  g_assert_false (g_bytes_equal (queued_gallery, updated));
+  g_assert_false (g_bytes_equal (baseline, updated));
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
+  g_assert_cmpuint (goodix_study_queue_allocated (queue), ==, 0);
+  assert_study_template (
+    updated, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 2,
+    &info, &unpacked);
+  assert_replacement_semantics (
+    &before, &unpacked, &probe_unpacked,
+    GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, 1, 2, 1, FALSE);
+
+  g_bytes_unref (baseline);
+  goodix_study_queue_free (queue);
+  goodix_study_queue_free (baseline_queue);
+  goodix_match_free_info (queued);
+  goodix_match_free_info (primary);
+  return updated;
+}
+
+static void
+test_queued_study_action (void)
+{
+  g_autoptr(GBytes) first = NULL;
+
+  for (gsize repeat = 0; repeat < 2; repeat++)
+    {
+      g_autoptr(GBytes) current = run_queued_study_case ();
+
+      if (!first)
+        first = g_bytes_ref (current);
+      else
+        g_assert_true (g_bytes_equal (first, current));
+    }
+}
+
+static GBytes *
+run_production_match_study_handoff (void)
+{
+  g_autoptr(GBytes) gallery = study_gallery (
+    GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, TRUE);
+  g_autoptr(GError) error = NULL;
+  GoodixMatchInfo *probe = study_match_info (9, TRUE);
+  GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
+  GoodixMilanMatchResult result;
+  GoodixMilanStudyAction action = GOODIX_MILAN_STUDY_NONE;
+  GBytes *after_match = NULL;
+  GBytes *after_study = NULL;
+  const guint8 *data;
+  gsize size;
+  GoodixMilanPrintTemplateInfo match_info;
+  GoodixMilanPrintTemplateInfo study_info;
+  GoodixMilanUnpackedTemplate before;
+  GoodixMilanUnpackedTemplate matched;
+  GoodixMilanUnpackedTemplate studied;
+  GoodixMilanUnpackedTemplate probe_unpacked;
+
+  unpack_study_template (gallery, &before);
+  unpack_study_template (probe->template, &probe_unpacked);
+  data = g_bytes_get_data (gallery, &size);
+  g_assert_cmpint (goodix_match_serialized_feature_result_queued (
+                     probe, data, size, &result, &after_match, queue), ==,
+                   GOODIX_SIGFM_TEMPLATE_OK);
+  g_assert_nonnull (after_match);
+  g_assert_false (g_bytes_equal (gallery, after_match));
+  g_assert_cmpint (result.score, ==, 100);
+  g_assert_cmpuint (result.matched_feature_index, ==, 1);
+  static const gint32 identity_relation[7] = {
+    0, 0x100, 0, 0, 0, 0x100, 0,
+  };
+
+  g_assert_true (result.relation.relation_valid);
+  g_assert_cmpint (result.relation.relation_count, ==, 42);
+  g_assert_cmpmem (result.relation.relation_values,
+                   sizeof(identity_relation), identity_relation,
+                   sizeof(identity_relation));
+  g_assert_cmpmem (result.match_transform, 6 * sizeof(gint32),
+                   identity_relation + 1, 6 * sizeof(gint32));
+  g_assert_cmpuint (result.direct_positive_feature_mask, ==, UINT64_C (2));
+  g_assert_cmpuint (result.contributor_feature_mask, ==, UINT64_C (2));
+  g_assert_cmpuint (result.lifecycle_update_feature_mask, ==, UINT64_C (2));
+  g_assert_cmpuint (result.retained_evidence_count, ==, 0);
+  g_assert_cmpint (result.retained_evidence_flag, ==, 1);
+  g_assert_cmpint (result.study_control.study_finalization_gate, ==, 1);
+  g_assert_cmpint (result.study_control.study_action_gate, ==, 1);
+  g_assert_cmpint (result.study_control.queue_candidate_eligible, ==, 1);
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 1);
+  g_assert_true (goodix_milan_print_validate_template (
+    after_match, &match_info, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (match_info.queue_state, ==, 0);
+  unpack_study_template (after_match, &matched);
+  assert_match_update_semantics (&before, &matched, 1);
+
+  data = g_bytes_get_data (after_match, &size);
+  g_assert_cmpint (goodix_match_study_feature_queued (
+                     probe, data, size, &result, TRUE, queue, &after_study,
+                     &action), ==, GOODIX_SIGFM_TEMPLATE_OK);
+  g_assert_nonnull (after_study);
+  g_assert_cmpint (action, ==, GOODIX_MILAN_STUDY_QUEUED);
+  g_assert_false (g_bytes_equal (after_match, after_study));
+  g_assert_true (goodix_study_queue_validate (queue));
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
+  g_assert_cmpuint (goodix_study_queue_allocated (queue), ==, 0);
+  assert_study_template (
+    after_study, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 1,
+    &study_info, &studied);
+  assert_replacement_semantics (
+    &before, &studied, &probe_unpacked, GOODIX_MILAN_STUDY_REPLACE,
+    1, 2, 2, TRUE);
+
+  g_bytes_unref (after_match);
+  goodix_study_queue_free (queue);
+  goodix_match_free_info (probe);
+  return after_study;
+}
+
+static void
+test_production_match_study_handoff (void)
+{
+  g_autoptr(GBytes) first = NULL;
+
+  for (gsize repeat = 0; repeat < 2; repeat++)
+    {
+      g_autoptr(GBytes) current = run_production_match_study_handoff ();
+
+      if (!first)
+        first = g_bytes_ref (current);
+      else
+        g_assert_true (g_bytes_equal (first, current));
+    }
+}
+
+static void
+assert_feature_roundtrip (GBytes *feature,
+                          gsize   partition_count)
+{
+  const guint8 *packed;
+  gsize packed_size;
+  GoodixMilanFeatureView view;
+  g_autofree GoodixMilanFeatureRecord *records = NULL;
+  g_autofree guint8 *repacked = NULL;
+  gsize repacked_size = 0;
+
+  packed = g_bytes_get_data (feature, &packed_size);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     packed, packed_size, &view), ==, 0);
+  records = g_new0 (GoodixMilanFeatureRecord, view.record_count);
+  repacked = g_malloc (packed_size);
+  g_assert_cmpint (goodix_milan_feature_unpack_template_records (
+                     view.packed_records, view.record_count, partition_count,
+                     records, view.record_count), ==, 0);
+  g_assert_cmpint (goodix_milan_template_pack_feature_element (
+                     view.high_bitmap, view.enhanced_bitmap, view.inline_mask,
+                     view.low_bitmap, records, view.record_count, view.antifake,
+                     &view.fields, repacked, packed_size, &repacked_size), ==, 0);
+  g_assert_cmpuint (repacked_size, ==, packed_size);
+  g_assert_cmpmem (repacked, repacked_size, packed, packed_size);
+}
+
+static void
+test_template_state (void)
+{
+  static const TemplateShape shapes[] = {
+    { "single-graphless", 1, 1, 0, FALSE, FALSE, UINT64_C (1) },
+    { "multi-graph", 3, 4, 2, TRUE, TRUE, UINT64_C (5) },
+  };
+
+  for (gsize shape_index = 0; shape_index < G_N_ELEMENTS (shapes);
+       shape_index++)
+    {
+      const TemplateShape *shape = &shapes[shape_index];
+      GBytes *features[3] = { NULL };
+      GBytes *feature_snapshots[3] = { NULL };
+      const guint8 *feature_data[3] = { NULL };
+      gsize feature_sizes[3] = { 0 };
+      GoodixMilanTemplateRelation relations[2] = { 0 };
+      GoodixMilanTemplateMetadata metadata = { 0 };
+      guint8 tail[0x520];
+      g_autofree guint8 *tail_before = NULL;
+      g_autofree guint8 *packed = NULL;
+      g_autofree guint8 *input_before = NULL;
+      g_autofree guint8 *repacked = NULL;
+      g_autofree guint8 *updated = NULL;
+      g_autofree guint8 *updated_twice = NULL;
+      g_autofree GoodixMilanUnpackedTemplate *unpacked = g_new0 (
+        GoodixMilanUnpackedTemplate, 1);
+      g_autofree GoodixMilanUnpackedTemplate *twice = g_new0 (
+        GoodixMilanUnpackedTemplate, 1);
+      gsize capacity;
+      gsize packed_size = 0;
+      gsize repacked_size = 0;
+      gsize updated_size = 0;
+      gsize updated_twice_size = 0;
+      gsize rejected_size = 0;
+
+      g_test_message ("template shape=%s", shape->name);
+      for (gsize i = 0; i < shape->feature_count; i++)
+        {
+          features[i] = synthetic_feature_element (
+            (guint) (shape_index * 10 + i + 1), shape->record_count,
+            shape->optional_c7);
+          feature_data[i] = g_bytes_get_data (features[i], &feature_sizes[i]);
+          feature_snapshots[i] = g_bytes_new (feature_data[i], feature_sizes[i]);
+          assert_feature_roundtrip (features[i], shape->record_count / 2);
+        }
+      for (gsize i = 0; i < shape->relation_count; i++)
+        {
+          static const gint32 identity_relation[7] = {
+            205, 0x100, 0, 0, 0, 0x100, 0,
+          };
+
+          relations[i].index = (gint32) i + 1;
+          memcpy (relations[i].values, identity_relation,
+                  sizeof(identity_relation));
+        }
+      metadata.sensor_type = 12;
+      metadata.maximum_features = GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT;
+      metadata.registration_count = 7;
+      metadata.maximum_records = 150;
+      metadata.queue_state = 0;
+      metadata.queue_transaction_counter = (guint32) (30 + shape_index);
+      metadata.graph_reference_index = shape->graph_established ? 0 : -1;
+      metadata.graph_companion_f3 = -1;
+      metadata.graph_companion_f4 = -1;
+      metadata.graph_established = shape->graph_established;
+      for (gsize i = 0; i < sizeof(tail); i++)
+        tail[i] = synthetic_byte ((guint) shape_index + 20, i);
+
+      capacity = 1433 + shape->relation_count * 45;
+      for (gsize i = 0; i < shape->feature_count; i++)
+        capacity += feature_sizes[i];
+      packed = g_malloc (capacity);
+      repacked = g_malloc (capacity);
+      updated = g_malloc (capacity);
+      updated_twice = g_malloc (capacity);
+      tail_before = g_memdup2 (tail, sizeof(tail));
+      g_assert_cmpint (goodix_milan_template_pack (
+                         feature_data, feature_sizes, shape->feature_count,
+                         relations, shape->relation_count, &metadata, tail,
+                         sizeof(tail), packed, capacity, &packed_size), ==, 0);
+      g_assert_cmpuint (packed_size, ==, capacity);
+      g_assert_cmpmem (tail, sizeof(tail), tail_before, sizeof(tail));
+      for (gsize i = 0; i < shape->feature_count; i++)
+        g_assert_true (feature_data[i] == g_bytes_get_data (features[i], NULL));
+
+      input_before = g_memdup2 (packed, packed_size);
+      g_assert_cmpint (goodix_milan_template_unpack (
+                         packed, packed_size, unpacked), ==, 0);
+      g_assert_cmpmem (packed, packed_size, input_before, packed_size);
+      g_assert_cmpuint (unpacked->feature_count, ==, shape->feature_count);
+      g_assert_cmpuint (unpacked->relation_count, ==, shape->relation_count);
+      g_assert_cmpmem (&unpacked->metadata, sizeof(unpacked->metadata),
+                       &metadata, sizeof(metadata));
+      g_assert_cmpint (goodix_milan_template_pack (
+                         unpacked->feature_elements,
+                         unpacked->feature_element_sizes,
+                         unpacked->feature_count, unpacked->relations,
+                         unpacked->relation_count, &unpacked->metadata,
+                         unpacked->tail_state, sizeof(unpacked->tail_state),
+                         repacked, capacity, &repacked_size), ==, 0);
+      g_assert_cmpuint (repacked_size, ==, packed_size);
+      g_assert_cmpmem (repacked, repacked_size, packed, packed_size);
+
+      g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
+                         packed, packed_size, 0, updated, capacity,
+                         &updated_size), ==, 0);
+      g_assert_cmpuint (updated_size, ==, packed_size);
+      g_assert_cmpmem (updated, updated_size, packed, packed_size);
+      g_assert_cmpmem (packed, packed_size, input_before, packed_size);
+      g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
+                         packed, packed_size, shape->lifecycle_mask, updated,
+                         capacity, &updated_size), ==, 0);
+      g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
+                         updated, updated_size, shape->lifecycle_mask,
+                         updated_twice, capacity, &updated_twice_size), ==, 0);
+      g_assert_cmpuint (updated_size, ==, packed_size);
+      g_assert_cmpuint (updated_twice_size, ==, packed_size);
+      g_assert_cmpmem (packed, packed_size, input_before, packed_size);
+      g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
+                         packed, packed_size,
+                         UINT64_C (1) << shape->feature_count, repacked,
+                         capacity, &rejected_size), ==, -1);
+      g_assert_cmpmem (packed, packed_size, input_before, packed_size);
+      memset (unpacked, 0, sizeof(*unpacked));
+      g_assert_cmpint (goodix_milan_template_unpack (
+                         updated, updated_size, unpacked), ==, 0);
+      g_assert_cmpint (goodix_milan_template_unpack (
+                         updated_twice, updated_twice_size, twice), ==, 0);
+      for (gsize i = 0; i < shape->feature_count; i++)
+        {
+          GoodixMilanFeatureView before_view;
+          GoodixMilanFeatureView after_view;
+          gint increment = (gint) ((shape->lifecycle_mask >> i) & 1);
+
+          g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                             feature_data[i], feature_sizes[i],
+                             &before_view), ==, 0);
+          g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                             unpacked->feature_elements[i],
+                             unpacked->feature_element_sizes[i],
+                             &after_view), ==, 0);
+          g_assert_cmpint (after_view.fields.tagged_values[9], ==,
+                           before_view.fields.tagged_values[9] + increment);
+          g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                             twice->feature_elements[i],
+                             twice->feature_element_sizes[i],
+                             &after_view), ==, 0);
+          g_assert_cmpint (after_view.fields.tagged_values[9], ==,
+                           before_view.fields.tagged_values[9] + 2 * increment);
+        }
+
+      if (!shape->graph_established)
+        {
+          g_autofree guint8 *normalized = g_malloc (capacity);
+          g_autofree guint8 *renormalized = g_malloc (capacity);
+          gsize normalized_size = 0;
+          gsize renormalized_size = 0;
+
+          g_assert_cmpint (goodix_milan_template_normalize (
+                             packed, packed_size, normalized, capacity,
+                             &normalized_size), ==, 0);
+          g_assert_cmpint (goodix_milan_template_normalize (
+                             normalized, normalized_size, renormalized,
+                             capacity, &renormalized_size), ==, 0);
+          g_assert_cmpuint (normalized_size, ==, renormalized_size);
+          g_assert_cmpmem (normalized, normalized_size, renormalized,
+                           renormalized_size);
+          g_assert_cmpmem (packed, packed_size, input_before, packed_size);
+        }
+
+      for (gsize i = 0; i < shape->feature_count; i++)
+        {
+          g_assert_true (g_bytes_equal (features[i], feature_snapshots[i]));
+          g_bytes_unref (feature_snapshots[i]);
+          g_bytes_unref (features[i]);
+        }
+    }
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/goodix53x5/milan/state/queue-lifecycle",
+                   test_queue_lifecycle);
+  g_test_add_func ("/goodix53x5/milan/state/queue-process",
+                   test_queue_process);
+  g_test_add_func ("/goodix53x5/milan/state/template", test_template_state);
+  g_test_add_func ("/goodix53x5/milan/state/study-actions",
+                   test_study_actions);
+  g_test_add_func ("/goodix53x5/milan/state/queued-study-action",
+                   test_queued_study_action);
+  g_test_add_func ("/goodix53x5/milan/state/production-match-study-handoff",
+                   test_production_match_study_handoff);
+  return g_test_run ();
+}

--- a/tests/test-goodix53x5-milan-state.c
+++ b/tests/test-goodix53x5-milan-state.c
@@ -1186,9 +1186,9 @@ run_production_match_study_handoff (void)
   g_assert_cmpint (result.retained_evidence_flag, ==, 1);
   g_assert_cmpint (result.study_control.study_finalization_gate, ==, 1);
   g_assert_cmpint (result.study_control.study_action_gate, ==, 1);
-  g_assert_cmpint (result.study_control.queue_candidate_eligible, ==, 1);
+  g_assert_cmpint (result.study_control.queue_candidate_eligible, ==, 0);
   g_assert_true (goodix_study_queue_validate (queue));
-  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 1);
+  g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
   g_assert_true (goodix_milan_print_validate_template (
     after_match, &match_info, &error));
   g_assert_no_error (error);
@@ -1201,7 +1201,7 @@ run_production_match_study_handoff (void)
                      probe, data, size, &result, TRUE, queue, &after_study,
                      &action), ==, GOODIX_SIGFM_TEMPLATE_OK);
   g_assert_nonnull (after_study);
-  g_assert_cmpint (action, ==, GOODIX_MILAN_STUDY_QUEUED);
+  g_assert_cmpint (action, ==, GOODIX_MILAN_STUDY_REPLACE);
   g_assert_false (g_bytes_equal (after_match, after_study));
   g_assert_true (goodix_study_queue_validate (queue));
   g_assert_cmpuint (goodix_study_queue_occupied (queue), ==, 0);
@@ -1211,7 +1211,7 @@ run_production_match_study_handoff (void)
     &study_info, &studied);
   assert_replacement_semantics (
     &before, &studied, &probe_unpacked, GOODIX_MILAN_STUDY_REPLACE,
-    1, 2, 2, TRUE);
+    1, 1, 1, TRUE);
 
   g_bytes_unref (after_match);
   goodix_study_queue_free (queue);

--- a/tests/test-goodix53x5-milan-state.c
+++ b/tests/test-goodix53x5-milan-state.c
@@ -419,7 +419,8 @@ study_feature_element (guint    seed,
                        gint32   active,
                        gint32   state,
                        gint32   residual,
-                       gint32   ordinal)
+                       gint32   ordinal,
+                       gint32   marker)
 {
   const gsize record_count = matchable ? 150 : 1;
   guint8 high[286];
@@ -471,6 +472,7 @@ study_feature_element (guint    seed,
   fields.tagged_values[5] = state;
   fields.tagged_values[6] = residual;
   fields.tagged_values[7] = ordinal;
+  goodix_milan_antifake_set_calibration_scalar (&antifake, marker);
 
   g_assert_cmpint (goodix_milan_template_pack_feature_element (
                      high, enhanced, inline_mask, low, records, record_count,
@@ -481,11 +483,12 @@ study_feature_element (guint    seed,
 
 static GoodixMatchInfo *
 study_match_info (guint seed,
-                  gboolean matchable)
+                  gboolean matchable,
+                  gint32   marker)
 {
   GoodixMatchInfo *info = goodix_match_info_new_empty ();
   g_autoptr(GBytes) feature = study_feature_element (
-    seed, matchable, 0, 0, 0, 0);
+    seed, matchable, 0, 0, 0, 0, marker);
   const guint8 *feature_data;
   gsize feature_size;
   guint8 tail[0x520] = { 0 };
@@ -552,7 +555,7 @@ study_gallery (GoodixMilanStudyAction action,
 
       features[i] = study_feature_element (
         matchable ? 9 : (guint) i + 1, matchable, 1, state, residual,
-        (gint32) i);
+        (gint32) i, 0);
       feature_data[i] = g_bytes_get_data (features[i], &feature_sizes[i]);
       capacity += feature_sizes[i];
       goodix_milan_template_write_u32 (tail + i * 4, (guint32) i);
@@ -905,7 +908,7 @@ static GBytes *
 run_study_action_case (const StudyActionCase *test_case)
 {
   g_autoptr(GBytes) gallery = study_gallery (test_case->action, FALSE);
-  GoodixMatchInfo *probe = study_match_info (9, FALSE);
+  GoodixMatchInfo *probe = study_match_info (9, FALSE, 0);
   GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
   GoodixMilanMatchResult result = study_primary_result (
     test_case->retained_flag);
@@ -974,12 +977,14 @@ test_study_actions (void)
 static GBytes *
 run_queued_study_case (void)
 {
+  static const gint32 primary_marker = INT32_C (0x13579bdf);
+  static const gint32 queued_marker = INT32_C (0x2468ace0);
   g_autoptr(GBytes) baseline_gallery = study_gallery (
     GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, FALSE);
   g_autoptr(GBytes) queued_gallery = study_gallery (
     GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, FALSE);
-  GoodixMatchInfo *primary = study_match_info (9, TRUE);
-  GoodixMatchInfo *queued = study_match_info (9, TRUE);
+  GoodixMatchInfo *primary = study_match_info (9, TRUE, primary_marker);
+  GoodixMatchInfo *queued = study_match_info (9, TRUE, queued_marker);
   GoodixStudyQueue *baseline_queue = goodix_study_queue_new (0, 7);
   GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
   GoodixMilanMatchResult primary_result = study_primary_result (0);
@@ -1003,9 +1008,38 @@ run_queued_study_case (void)
   GoodixMilanUnpackedTemplate unpacked;
   GoodixMilanUnpackedTemplate baseline_unpacked;
   GoodixMilanUnpackedTemplate probe_unpacked;
+  GoodixMilanUnpackedTemplate queued_probe_unpacked;
+  GoodixMilanFeatureView primary_feature;
+  GoodixMilanFeatureView queued_feature;
+  GoodixMilanFeatureView selected_feature;
 
   unpack_study_template (baseline_gallery, &before);
   unpack_study_template (primary->template, &probe_unpacked);
+  unpack_study_template (queued->template, &queued_probe_unpacked);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     probe_unpacked.feature_elements[0],
+                     probe_unpacked.feature_element_sizes[0],
+                     &primary_feature), ==, 0);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     queued_probe_unpacked.feature_elements[0],
+                     queued_probe_unpacked.feature_element_sizes[0],
+                     &queued_feature), ==, 0);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     &primary->antifake), ==,
+                   primary_marker);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     &queued->antifake), ==,
+                   queued_marker);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     &primary->antifake), !=,
+                   goodix_milan_antifake_calibration_scalar (
+                     &queued->antifake));
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     primary_feature.antifake), ==,
+                   primary_marker);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     queued_feature.antifake), ==,
+                   queued_marker);
   gallery_data = g_bytes_get_data (baseline_gallery, &gallery_size);
   g_assert_cmpint (goodix_match_study_feature_queued (
                      primary, gallery_data, gallery_size, &primary_result, TRUE,
@@ -1066,8 +1100,18 @@ run_queued_study_case (void)
     updated, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT - 2,
     &info, &unpacked);
   assert_replacement_semantics (
-    &before, &unpacked, &probe_unpacked,
+    &before, &unpacked, &queued_probe_unpacked,
     GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, 1, 2, 1, FALSE);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     unpacked.feature_elements[1],
+                     unpacked.feature_element_sizes[1], &selected_feature), ==,
+                   0);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     selected_feature.antifake), ==,
+                   queued_marker);
+  g_assert_cmpint (goodix_milan_antifake_calibration_scalar (
+                     selected_feature.antifake), !=,
+                   primary_marker);
 
   g_bytes_unref (baseline);
   goodix_study_queue_free (queue);
@@ -1099,7 +1143,7 @@ run_production_match_study_handoff (void)
   g_autoptr(GBytes) gallery = study_gallery (
     GOODIX_MILAN_STUDY_REPLACE_NO_RELATION, TRUE);
   g_autoptr(GError) error = NULL;
-  GoodixMatchInfo *probe = study_match_info (9, TRUE);
+  GoodixMatchInfo *probe = study_match_info (9, TRUE, 0);
   GoodixStudyQueue *queue = goodix_study_queue_new (0, 7);
   GoodixMilanMatchResult result;
   GoodixMilanStudyAction action = GOODIX_MILAN_STUDY_NONE;

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -14,6 +14,7 @@
 #include "drivers/goodix53x5/milan/match/selection.h"
 #include "drivers/goodix53x5/milan/milan.h"
 #include "drivers/goodix53x5/milan/preprocess/gain.h"
+#include "drivers/goodix53x5/milan/private.h"
 #include "drivers/goodix53x5/milan/print.h"
 #include "drivers/goodix53x5/milan/study/policy.h"
 #include "drivers/goodix53x5/milan/study/queue.h"
@@ -561,14 +562,22 @@ distinct_fixture_scalar (int32_t probe_value,
 }
 
 static GoodixMatchInfo *
-make_distinct_antifake_fixture (const GoodixMatchInfo *probe)
+make_distinct_append_fixture (const GoodixMatchInfo *probe)
 {
+  static const struct
+  {
+    size_t field;
+    uint8_t tag;
+  } probe_owned_fields[] = {
+    { 2, 0xb7 }, { 3, 0xb8 }, { 4, 0xb9 }, { 8, 0xbd }, { 10, 0xc0 },
+  };
   const gsize header_size = 6;
   GoodixMatchInfo *fixture = goodix_match_info_new_empty ();
   g_autofree GoodixMilanUnpackedTemplate *unpacked = g_new0 (
     GoodixMilanUnpackedTemplate, 1);
   g_autofree guint8 *feature_element = NULL;
   g_autofree guint8 *packed = NULL;
+  GoodixMilanFeatureView serialized_view;
   GoodixMilanAntifakeBlob *serialized_antifake;
   GBytes *wrapped;
   gsize wrapped_size;
@@ -591,6 +600,7 @@ make_distinct_antifake_fixture (const GoodixMatchInfo *probe)
     &fixture->antifake,
     distinct_fixture_scalar (goodix_milan_antifake_pair_score (&probe->antifake),
                              -0x11223344));
+  goodix_milan_antifake_mask (&fixture->antifake)[0] ^= 1;
   g_assert_cmpint (goodix_milan_antifake_texture (&fixture->antifake),
                    !=, goodix_milan_antifake_texture (&probe->antifake));
   g_assert_cmpint (goodix_milan_antifake_mean (&fixture->antifake),
@@ -604,9 +614,32 @@ make_distinct_antifake_fixture (const GoodixMatchInfo *probe)
   g_assert_cmpuint (unpacked->feature_count, ==, 1);
   feature_element = g_memdup2 (unpacked->feature_elements[0],
                                unpacked->feature_element_sizes[0]);
-  serialized_antifake = goodix_milan_template_mutable_feature_antifake (
-    feature_element, unpacked->feature_element_sizes[0]);
-  g_assert_nonnull (serialized_antifake);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     feature_element, unpacked->feature_element_sizes[0],
+                     &serialized_view), ==, 0);
+  g_assert_cmpuint (serialized_view.record_count, >, 0);
+  ((guint8 *) serialized_view.high_bitmap)[285] ^= 1;
+  ((guint8 *) serialized_view.enhanced_bitmap)[285] ^= 1;
+  ((guint8 *) serialized_view.inline_mask)[71] ^= 1;
+  ((guint8 *) serialized_view.low_bitmap)[285] ^= 1;
+  ((guint8 *) serialized_view.packed_records)[
+    serialized_view.record_count * 32 - 1] ^= 1;
+  for (size_t i = 0; i < G_N_ELEMENTS (probe_owned_fields); i++)
+    {
+      int32_t value =
+        serialized_view.fields.tagged_values[probe_owned_fields[i].field];
+
+      g_assert_cmpint (goodix_milan_template_patch_feature_scalar (
+                         feature_element, unpacked->feature_element_sizes[0],
+                         probe_owned_fields[i].tag,
+                         value == 0 ? 1 : value - 1), ==, 0);
+    }
+  g_assert_cmpint (goodix_milan_template_patch_feature_scalar (
+                     feature_element, unpacked->feature_element_sizes[0],
+                     0xbe,
+                     distinct_fixture_scalar (
+                       serialized_view.fields.tagged_values[9], 1)), ==, 0);
+  serialized_antifake = (GoodixMilanAntifakeBlob *) serialized_view.antifake;
   memcpy (serialized_antifake, &fixture->antifake, sizeof(*serialized_antifake));
   unpacked->feature_elements[0] = feature_element;
   wrapped_size = g_bytes_get_size (fixture->template);
@@ -639,6 +672,7 @@ assert_antifake_append_ownership (const GoodixMilanAntifakeBlob *actual,
   };
   const guint8 *actual_data = goodix_milan_antifake_const_data (actual);
   const guint8 *probe_data = goodix_milan_antifake_const_data (probe);
+  const guint8 *matched_data = goodix_milan_antifake_const_data (matched);
   size_t start = 0;
 
   for (size_t i = 0; i < G_N_ELEMENTS (inherited_scalar_offsets); i++)
@@ -651,6 +685,10 @@ assert_antifake_append_ownership (const GoodixMilanAntifakeBlob *actual,
     }
   g_assert_cmpmem (actual_data + start, GOODIX_MILAN_ANTIFAKE_SIZE - start,
                    probe_data + start, GOODIX_MILAN_ANTIFAKE_SIZE - start);
+  g_assert_cmpint (actual_data[GOODIX_MILAN_ANTIFAKE_MASK_OFFSET],
+                   ==, probe_data[GOODIX_MILAN_ANTIFAKE_MASK_OFFSET]);
+  g_assert_cmpint (actual_data[GOODIX_MILAN_ANTIFAKE_MASK_OFFSET],
+                   !=, matched_data[GOODIX_MILAN_ANTIFAKE_MASK_OFFSET]);
   g_assert_cmpint (goodix_milan_antifake_texture (actual),
                    ==, goodix_milan_antifake_texture (matched));
   g_assert_cmpint (goodix_milan_antifake_mean (actual),
@@ -659,6 +697,14 @@ assert_antifake_append_ownership (const GoodixMilanAntifakeBlob *actual,
                    ==, goodix_milan_antifake_threshold (matched));
   g_assert_cmpint (goodix_milan_antifake_pair_score (actual),
                    ==, goodix_milan_antifake_pair_score (matched));
+  g_assert_cmpint (goodix_milan_antifake_texture (actual),
+                   !=, goodix_milan_antifake_texture (probe));
+  g_assert_cmpint (goodix_milan_antifake_mean (actual),
+                   !=, goodix_milan_antifake_mean (probe));
+  g_assert_cmpint (goodix_milan_antifake_threshold (actual),
+                   !=, goodix_milan_antifake_threshold (probe));
+  g_assert_cmpint (goodix_milan_antifake_pair_score (actual),
+                   !=, goodix_milan_antifake_pair_score (probe));
   g_assert_cmpint (goodix_milan_antifake_texture (matched),
                    !=, goodix_milan_antifake_texture (probe));
   g_assert_cmpint (goodix_milan_antifake_mean (matched),
@@ -753,18 +799,38 @@ assert_generic_append_material (GBytes *probe,
                      after_template->feature_element_sizes[inserted_index],
                      &inserted_view), ==, 0);
   g_assert_cmpuint (inserted_view.record_count, ==, probe_view.record_count);
+  g_assert_cmpuint (matched_view.record_count, ==, probe_view.record_count);
   g_assert_cmpmem (inserted_view.high_bitmap, 286, probe_view.high_bitmap, 286);
+  g_assert_cmpint (memcmp (inserted_view.high_bitmap,
+                           matched_view.high_bitmap, 286), !=, 0);
   g_assert_cmpmem (inserted_view.enhanced_bitmap, 286,
                    probe_view.enhanced_bitmap, 286);
+  g_assert_cmpint (memcmp (inserted_view.enhanced_bitmap,
+                           matched_view.enhanced_bitmap, 286), !=, 0);
   g_assert_cmpmem (inserted_view.inline_mask, 72, probe_view.inline_mask, 72);
+  g_assert_cmpint (memcmp (inserted_view.inline_mask,
+                           matched_view.inline_mask, 72), !=, 0);
   g_assert_cmpmem (inserted_view.low_bitmap, 286, probe_view.low_bitmap, 286);
+  g_assert_cmpint (memcmp (inserted_view.low_bitmap,
+                           matched_view.low_bitmap, 286), !=, 0);
   g_assert_cmpmem (inserted_view.packed_records, inserted_view.record_count * 32,
                    probe_view.packed_records, probe_view.record_count * 32);
+  g_assert_cmpint (memcmp (inserted_view.packed_records,
+                           matched_view.packed_records,
+                           inserted_view.record_count * 32), !=, 0);
   for (size_t i = 0; i < G_N_ELEMENTS (probe_owned_fields); i++)
-    g_assert_cmpint (inserted_view.fields.tagged_values[probe_owned_fields[i]],
-                     ==, probe_view.fields.tagged_values[probe_owned_fields[i]]);
+    {
+      size_t field = probe_owned_fields[i];
+
+      g_assert_cmpint (inserted_view.fields.tagged_values[field],
+                       ==, probe_view.fields.tagged_values[field]);
+      g_assert_cmpint (inserted_view.fields.tagged_values[field],
+                       !=, matched_view.fields.tagged_values[field]);
+    }
   g_assert_cmpint (inserted_view.fields.tagged_values[0],
                    ==, matched_view.fields.tagged_values[0]);
+  g_assert_cmpint (inserted_view.fields.tagged_values[0],
+                   !=, probe_view.fields.tagged_values[0]);
   g_assert_cmpint (inserted_view.fields.tagged_values[1],
                    ==, (int32_t) before_template->metadata.registration_count);
   g_assert_cmpint (inserted_view.fields.tagged_values[5], ==, 1);
@@ -773,6 +839,8 @@ assert_generic_append_material (GBytes *probe,
                    ==, (int32_t) before_template->feature_count);
   g_assert_cmpint (inserted_view.fields.tagged_values[9],
                    ==, matched_view.fields.tagged_values[9]);
+  g_assert_cmpint (inserted_view.fields.tagged_values[9],
+                   !=, probe_view.fields.tagged_values[9]);
   assert_antifake_append_ownership (inserted_view.antifake,
                                     probe_view.antifake,
                                     matched_view.antifake);
@@ -877,7 +945,7 @@ static void
 test_generated_production_replay (void)
 {
   GoodixMatchInfo *info = generate_match_info ();
-  GoodixMatchInfo *matched_info = make_distinct_antifake_fixture (info);
+  GoodixMatchInfo *matched_info = make_distinct_append_fixture (info);
   g_autoptr(GBytes) extracted = goodix_match_serialize_template (info);
   g_autoptr(GBytes) matched_extracted = goodix_match_serialize_template (
     matched_info);

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -10,10 +10,14 @@
 
 #include "drivers/goodix53x5/device/base.h"
 #include "drivers/goodix53x5/milan/match/match.h"
+#include "drivers/goodix53x5/milan/match/info-private.h"
 #include "drivers/goodix53x5/milan/match/selection.h"
 #include "drivers/goodix53x5/milan/milan.h"
 #include "drivers/goodix53x5/milan/preprocess/gain.h"
 #include "drivers/goodix53x5/milan/print.h"
+#include "drivers/goodix53x5/milan/study/policy.h"
+#include "drivers/goodix53x5/milan/study/queue.h"
+#include "drivers/goodix53x5/milan/template/codec-private.h"
 
 #include <glib.h>
 #include <stdint.h>
@@ -87,6 +91,35 @@ generate_feature_frames (uint16_t *setup,
           delta = 1200;
         live[index] = (uint16_t) (baseline - delta);
       }
+}
+
+static GoodixMatchInfo *
+generate_match_info (void)
+{
+  g_autofree GoodixMilanPreprocessState *state = g_new0 (
+    GoodixMilanPreprocessState, 1);
+  GoodixMilanProfileState profile = { 0 };
+  g_autofree uint16_t *setup = g_new (uint16_t, PIXELS);
+  g_autofree uint16_t *live = g_new (uint16_t, PIXELS);
+  g_autofree uint8_t *processed = g_new (uint8_t, PIXELS);
+  GoodixMatchInfo *info = NULL;
+  int quality = -1;
+  int coverage = -1;
+
+  generate_feature_frames (setup, live);
+  goodix_milan_preprocess_reset (state);
+  g_assert_cmpint (goodix_milan_preprocess (
+                     state, &profile, setup, live,
+                     GOODIX_MILAN_PURPOSE_ENROLL, processed, &quality,
+                     &coverage), ==, 0);
+  g_assert_cmpint (quality, ==, 100);
+  g_assert_cmpint (coverage, ==, 100);
+  g_assert_cmpint (goodix_match_extract_native_result (
+                     processed, state, live, 0, 0, 0, 12, &info), ==,
+                   GOODIX_MILAN_EXTRACTION_OK);
+  g_assert_true (goodix_match_info_is_complete (info));
+  g_assert_cmpint (goodix_match_keypoints_count (info), ==, 150);
+  return info;
 }
 
 static void
@@ -364,15 +397,9 @@ test_negative_orientation_scaling (void)
 static void
 test_generated_extraction (void)
 {
-  g_autofree GoodixMilanPreprocessState *state = g_new0 (
-    GoodixMilanPreprocessState, 1);
   g_autofree GoodixMilanUnpackedTemplate *unpacked = g_new0 (
     GoodixMilanUnpackedTemplate, 1);
-  g_autofree uint16_t *setup = g_new (uint16_t, PIXELS);
-  g_autofree uint16_t *live = g_new (uint16_t, PIXELS);
-  g_autofree uint8_t *processed = g_new (uint8_t, PIXELS);
-  GoodixMatchInfo *info = NULL;
-  GoodixMilanProfileState profile = { 0 };
+  GoodixMatchInfo *info = generate_match_info ();
   g_autoptr(GBytes) extracted = NULL;
   g_autoptr(GPtrArray) features = g_ptr_array_new_with_free_func (
     (GDestroyNotify) g_bytes_unref);
@@ -393,23 +420,8 @@ test_generated_extraction (void)
   const gchar *boundary_policy;
   const uint8_t *bytes;
   gsize size;
-  int quality = -1;
-  int coverage = -1;
 
   test_negative_orientation_scaling ();
-  generate_feature_frames (setup, live);
-  goodix_milan_preprocess_reset (state);
-  g_assert_cmpint (goodix_milan_preprocess (
-                     state, &profile, setup, live,
-                     GOODIX_MILAN_PURPOSE_ENROLL, processed, &quality,
-                     &coverage), ==, 0);
-  g_assert_cmpint (quality, ==, 100);
-  g_assert_cmpint (coverage, ==, 100);
-  g_assert_cmpint (goodix_match_extract_native_result (
-                     processed, state, live, 0, 0, 0, 12, &info), ==,
-                   GOODIX_MILAN_EXTRACTION_OK);
-  g_assert_cmpint (goodix_match_keypoints_count (info), ==, 150);
-
   extracted = goodix_match_serialize_template (info);
   bytes = g_bytes_get_data (extracted, &size);
   g_assert_cmpuint (size, >, 6);
@@ -462,6 +474,601 @@ test_generated_extraction (void)
   goodix_match_free_info (info);
 }
 
+static void
+test_study_policy_actions (void)
+{
+  static const struct
+  {
+    const char *name;
+    int32_t action_gate;
+    size_t maximum_features;
+    int32_t matched_residual;
+    int32_t retained_flag;
+    GoodixMilanStudyActionCode expected_action;
+    size_t expected_index;
+    int expected_primary;
+  } cases[] = {
+    { "none", 0, 3, 0, 0, GOODIX_MILAN_STUDY_ACTION_NONE, SIZE_MAX, 0 },
+    { "append", 1, 4, 20, 0, GOODIX_MILAN_STUDY_ACTION_APPEND, 3, 0 },
+    { "replace-no-relation", 1, 3, 0, 0,
+      GOODIX_MILAN_STUDY_ACTION_REPLACE_NO_RELATION, 1, 1 },
+    { "geometric", 1, 3, 20, 1,
+      GOODIX_MILAN_STUDY_ACTION_GEOMETRIC, 2, 0 },
+    { "replace", 1, 3, 0, 1,
+      GOODIX_MILAN_STUDY_ACTION_REPLACE, 1, 1 },
+  };
+
+  for (size_t i = 0; i < G_N_ELEMENTS (cases); i++)
+    {
+      GoodixMilanStudyPolicyInput input = {
+        .action_gate = cases[i].action_gate,
+        .mode_enabled = 1,
+        .replacement_enabled = 1,
+        .probe_quality = 100,
+        .probe_coverage = 100,
+        .feature_count = 3,
+        .maximum_features = cases[i].maximum_features,
+        .matched_feature_index = 1,
+        .reference_feature_index = 0,
+        .retained_flag = cases[i].retained_flag,
+        .primary_transform_area = GOODIX_MILAN_STUDY_MASK_SIZE,
+      };
+      GoodixMilanStudyPolicyResult result;
+
+      for (size_t feature = 0; feature < input.feature_count; feature++)
+        {
+          input.features[feature].active = 1;
+          input.features[feature].quality = 50;
+          input.features[feature].coverage = 80;
+          input.features[feature].residual = 20;
+          input.features[feature].uncovered_probe_residual = 0;
+          input.features[feature].geometric_overlap_percent =
+            feature == 2 ? 85 : 70;
+        }
+      input.features[input.matched_feature_index].residual =
+        cases[i].matched_residual;
+
+      g_test_message ("study policy row=%s", cases[i].name);
+      g_assert_cmpint (goodix_milan_study_policy_select (&input, &result),
+                       ==, 0);
+      g_assert_cmpint (result.action, ==, cases[i].expected_action);
+      g_assert_cmpuint (result.selected_feature_index,
+                        ==, cases[i].expected_index);
+      g_assert_cmpint (result.primary_candidate,
+                       ==, cases[i].expected_primary);
+    }
+}
+
+static void
+unpack_test_template (GBytes                       *wrapped,
+                      GoodixMilanUnpackedTemplate *unpacked)
+{
+  const gsize header_size = 6;
+  const guint8 *data;
+  gsize size;
+
+  data = g_bytes_get_data (wrapped, &size);
+  g_assert_cmpuint (size, >, header_size);
+  g_assert_cmpint (goodix_milan_template_unpack (
+                     data + header_size, size - header_size, unpacked), ==, 0);
+}
+
+static int32_t
+distinct_fixture_scalar (int32_t probe_value,
+                         int32_t fixture_value)
+{
+  return probe_value == fixture_value ? fixture_value + 1 : fixture_value;
+}
+
+static GoodixMatchInfo *
+make_distinct_antifake_fixture (const GoodixMatchInfo *probe)
+{
+  const gsize header_size = 6;
+  GoodixMatchInfo *fixture = goodix_match_info_new_empty ();
+  g_autofree GoodixMilanUnpackedTemplate *unpacked = g_new0 (
+    GoodixMilanUnpackedTemplate, 1);
+  g_autofree guint8 *feature_element = NULL;
+  g_autofree guint8 *packed = NULL;
+  GoodixMilanAntifakeBlob *serialized_antifake;
+  GBytes *wrapped;
+  gsize wrapped_size;
+  size_t packed_size = 0;
+
+  g_assert_true (goodix_match_info_copy (fixture, probe));
+  goodix_milan_antifake_set_texture (
+    &fixture->antifake,
+    distinct_fixture_scalar (goodix_milan_antifake_texture (&probe->antifake),
+                             0x1020304));
+  goodix_milan_antifake_set_mean (
+    &fixture->antifake,
+    distinct_fixture_scalar (goodix_milan_antifake_mean (&probe->antifake),
+                             -0x1020304));
+  goodix_milan_antifake_set_threshold (
+    &fixture->antifake,
+    distinct_fixture_scalar (goodix_milan_antifake_threshold (&probe->antifake),
+                             0x11223344));
+  goodix_milan_antifake_set_pair_score (
+    &fixture->antifake,
+    distinct_fixture_scalar (goodix_milan_antifake_pair_score (&probe->antifake),
+                             -0x11223344));
+  g_assert_cmpint (goodix_milan_antifake_texture (&fixture->antifake),
+                   !=, goodix_milan_antifake_texture (&probe->antifake));
+  g_assert_cmpint (goodix_milan_antifake_mean (&fixture->antifake),
+                   !=, goodix_milan_antifake_mean (&probe->antifake));
+  g_assert_cmpint (goodix_milan_antifake_threshold (&fixture->antifake),
+                   !=, goodix_milan_antifake_threshold (&probe->antifake));
+  g_assert_cmpint (goodix_milan_antifake_pair_score (&fixture->antifake),
+                   !=, goodix_milan_antifake_pair_score (&probe->antifake));
+
+  unpack_test_template (fixture->template, unpacked);
+  g_assert_cmpuint (unpacked->feature_count, ==, 1);
+  feature_element = g_memdup2 (unpacked->feature_elements[0],
+                               unpacked->feature_element_sizes[0]);
+  serialized_antifake = goodix_milan_template_mutable_feature_antifake (
+    feature_element, unpacked->feature_element_sizes[0]);
+  g_assert_nonnull (serialized_antifake);
+  memcpy (serialized_antifake, &fixture->antifake, sizeof(*serialized_antifake));
+  unpacked->feature_elements[0] = feature_element;
+  wrapped_size = g_bytes_get_size (fixture->template);
+  packed = g_malloc (wrapped_size - header_size);
+  g_assert_cmpint (goodix_milan_template_pack (
+                     unpacked->feature_elements,
+                     unpacked->feature_element_sizes,
+                     unpacked->feature_count, unpacked->relations,
+                     unpacked->relation_count, &unpacked->metadata,
+                     unpacked->tail_state, sizeof(unpacked->tail_state), packed,
+                     wrapped_size - header_size, &packed_size), ==, 0);
+  g_assert_cmpuint (packed_size, ==, wrapped_size - header_size);
+  wrapped = goodix_match_wrap_template (packed, packed_size);
+  g_assert_nonnull (wrapped);
+  g_clear_pointer (&fixture->template, g_bytes_unref);
+  fixture->template = wrapped;
+  return fixture;
+}
+
+static void
+assert_antifake_append_ownership (const GoodixMilanAntifakeBlob *actual,
+                                  const GoodixMilanAntifakeBlob *probe,
+                                  const GoodixMilanAntifakeBlob *matched)
+{
+  static const size_t inherited_scalar_offsets[] = {
+    GOODIX_MILAN_ANTIFAKE_TEXTURE_OFFSET,
+    GOODIX_MILAN_ANTIFAKE_MEAN_OFFSET,
+    GOODIX_MILAN_ANTIFAKE_THRESHOLD_OFFSET,
+    GOODIX_MILAN_ANTIFAKE_PAIR_SCORE_OFFSET,
+  };
+  const guint8 *actual_data = goodix_milan_antifake_const_data (actual);
+  const guint8 *probe_data = goodix_milan_antifake_const_data (probe);
+  size_t start = 0;
+
+  for (size_t i = 0; i < G_N_ELEMENTS (inherited_scalar_offsets); i++)
+    {
+      size_t offset = inherited_scalar_offsets[i];
+
+      g_assert_cmpmem (actual_data + start, offset - start,
+                       probe_data + start, offset - start);
+      start = offset + sizeof(int32_t);
+    }
+  g_assert_cmpmem (actual_data + start, GOODIX_MILAN_ANTIFAKE_SIZE - start,
+                   probe_data + start, GOODIX_MILAN_ANTIFAKE_SIZE - start);
+  g_assert_cmpint (goodix_milan_antifake_texture (actual),
+                   ==, goodix_milan_antifake_texture (matched));
+  g_assert_cmpint (goodix_milan_antifake_mean (actual),
+                   ==, goodix_milan_antifake_mean (matched));
+  g_assert_cmpint (goodix_milan_antifake_threshold (actual),
+                   ==, goodix_milan_antifake_threshold (matched));
+  g_assert_cmpint (goodix_milan_antifake_pair_score (actual),
+                   ==, goodix_milan_antifake_pair_score (matched));
+  g_assert_cmpint (goodix_milan_antifake_texture (matched),
+                   !=, goodix_milan_antifake_texture (probe));
+  g_assert_cmpint (goodix_milan_antifake_mean (matched),
+                   !=, goodix_milan_antifake_mean (probe));
+  g_assert_cmpint (goodix_milan_antifake_threshold (matched),
+                   !=, goodix_milan_antifake_threshold (probe));
+  g_assert_cmpint (goodix_milan_antifake_pair_score (matched),
+                   !=, goodix_milan_antifake_pair_score (probe));
+}
+
+static void
+assert_generic_append_material (GBytes *probe,
+                                GBytes *before,
+                                GBytes *after)
+{
+  static const size_t probe_owned_fields[] = { 2, 3, 4, 8, 10 };
+  static const int32_t appended_relation_values[7] = {
+    0, 0x100, 0, 0, 0, 0x100, 0,
+  };
+  g_autofree GoodixMilanUnpackedTemplate *probe_template = g_new0 (
+    GoodixMilanUnpackedTemplate, 1);
+  g_autofree GoodixMilanUnpackedTemplate *before_template = g_new0 (
+    GoodixMilanUnpackedTemplate, 1);
+  g_autofree GoodixMilanUnpackedTemplate *after_template = g_new0 (
+    GoodixMilanUnpackedTemplate, 1);
+  GoodixMilanFeatureView probe_view;
+  GoodixMilanFeatureView matched_view;
+  GoodixMilanFeatureView inserted_view;
+  const GoodixMilanTemplateRelation *appended_relation = NULL;
+  size_t inserted_index;
+
+  unpack_test_template (probe, probe_template);
+  unpack_test_template (before, before_template);
+  unpack_test_template (after, after_template);
+  inserted_index = before_template->feature_count;
+  g_assert_cmpuint (probe_template->feature_count, ==, 1);
+  g_assert_cmpuint (after_template->feature_count, ==, inserted_index + 1);
+
+  for (size_t i = 0; i < before_template->feature_count; i++)
+    {
+      g_assert_cmpuint (after_template->feature_element_sizes[i],
+                        ==, before_template->feature_element_sizes[i]);
+      g_assert_cmpmem (after_template->feature_elements[i],
+                       after_template->feature_element_sizes[i],
+                       before_template->feature_elements[i],
+                       before_template->feature_element_sizes[i]);
+    }
+  g_assert_cmpuint (after_template->relation_count,
+                    ==, before_template->relation_count + 1);
+  for (size_t i = 0; i < before_template->relation_count; i++)
+    {
+      gboolean found = FALSE;
+
+      for (size_t j = 0; j < after_template->relation_count; j++)
+        if (after_template->relations[j].index ==
+            before_template->relations[i].index)
+          {
+            found = TRUE;
+            for (size_t value = 0;
+                 value < G_N_ELEMENTS (before_template->relations[i].values);
+                 value++)
+              g_assert_cmpint (after_template->relations[j].values[value],
+                               ==, before_template->relations[i].values[value]);
+            break;
+          }
+      g_assert_true (found);
+    }
+  for (size_t i = 0; i < after_template->relation_count; i++)
+    if (after_template->relations[i].index ==
+        (int32_t) before_template->metadata.registration_count)
+      {
+        appended_relation = &after_template->relations[i];
+        break;
+      }
+  g_assert_nonnull (appended_relation);
+  g_assert_cmpint (appended_relation->index,
+                   ==, (int32_t) before_template->metadata.registration_count);
+  for (size_t i = 0; i < G_N_ELEMENTS (appended_relation_values); i++)
+    g_assert_cmpint (appended_relation->values[i],
+                     ==, appended_relation_values[i]);
+
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     probe_template->feature_elements[0],
+                     probe_template->feature_element_sizes[0],
+                     &probe_view), ==, 0);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     before_template->feature_elements[0],
+                     before_template->feature_element_sizes[0],
+                     &matched_view), ==, 0);
+  g_assert_cmpint (goodix_milan_template_parse_feature_element (
+                     after_template->feature_elements[inserted_index],
+                     after_template->feature_element_sizes[inserted_index],
+                     &inserted_view), ==, 0);
+  g_assert_cmpuint (inserted_view.record_count, ==, probe_view.record_count);
+  g_assert_cmpmem (inserted_view.high_bitmap, 286, probe_view.high_bitmap, 286);
+  g_assert_cmpmem (inserted_view.enhanced_bitmap, 286,
+                   probe_view.enhanced_bitmap, 286);
+  g_assert_cmpmem (inserted_view.inline_mask, 72, probe_view.inline_mask, 72);
+  g_assert_cmpmem (inserted_view.low_bitmap, 286, probe_view.low_bitmap, 286);
+  g_assert_cmpmem (inserted_view.packed_records, inserted_view.record_count * 32,
+                   probe_view.packed_records, probe_view.record_count * 32);
+  for (size_t i = 0; i < G_N_ELEMENTS (probe_owned_fields); i++)
+    g_assert_cmpint (inserted_view.fields.tagged_values[probe_owned_fields[i]],
+                     ==, probe_view.fields.tagged_values[probe_owned_fields[i]]);
+  g_assert_cmpint (inserted_view.fields.tagged_values[0],
+                   ==, matched_view.fields.tagged_values[0]);
+  g_assert_cmpint (inserted_view.fields.tagged_values[1],
+                   ==, (int32_t) before_template->metadata.registration_count);
+  g_assert_cmpint (inserted_view.fields.tagged_values[5], ==, 1);
+  g_assert_cmpint (inserted_view.fields.tagged_values[6], ==, 0);
+  g_assert_cmpint (inserted_view.fields.tagged_values[7],
+                   ==, (int32_t) before_template->feature_count);
+  g_assert_cmpint (inserted_view.fields.tagged_values[9],
+                   ==, matched_view.fields.tagged_values[9]);
+  assert_antifake_append_ownership (inserted_view.antifake,
+                                    probe_view.antifake,
+                                    matched_view.antifake);
+
+  g_assert_cmpuint (after_template->metadata.registration_count,
+                    ==, before_template->metadata.registration_count +
+                        before_template->feature_count);
+  for (size_t i = 0; i < before_template->feature_count; i++)
+    g_assert_cmpuint (goodix_milan_template_read_u32 (
+                        after_template->tail_state + i * 4),
+                      ==, goodix_milan_template_read_u32 (
+                            before_template->tail_state + i * 4));
+  g_assert_cmpuint (goodix_milan_template_read_u32 (
+                      after_template->tail_state + inserted_index * 4),
+                    ==, inserted_index);
+  g_assert_cmpuint (goodix_milan_template_read_u32 (
+                      after_template->tail_state + 0x50c),
+                    ==, goodix_milan_template_read_u32 (
+                          before_template->tail_state + 0x50c));
+  g_assert_cmpuint (goodix_milan_template_read_u32 (
+                      after_template->tail_state + 0x510),
+                    ==, goodix_milan_template_read_u32 (
+                          before_template->tail_state + 0x510));
+  g_assert_cmpuint (goodix_milan_template_read_u32 (
+                      after_template->tail_state + 0x514),
+                    ==, goodix_milan_template_read_u32 (
+                          before_template->tail_state + 0x514) + 1);
+}
+
+static void
+test_generated_enrollment_prefix_lifecycle (void)
+{
+  enum { ENROLLMENT_PREFIX_COUNT = 12 };
+  static const size_t complete_prefixes[] = { 1, 2, 12 };
+  GoodixMatchInfo *info = generate_match_info ();
+  g_autoptr(GBytes) extracted = goodix_match_serialize_template (info);
+  g_autoptr(GPtrArray) sources = g_ptr_array_new_with_free_func (
+    (GDestroyNotify) g_bytes_unref);
+  g_autoptr(GBytes) final_prefix = NULL;
+  const guint8 *source_data;
+  gsize source_size;
+
+  g_assert_nonnull (extracted);
+  source_data = g_bytes_get_data (extracted, &source_size);
+  for (size_t i = 0; i < ENROLLMENT_PREFIX_COUNT; i++)
+    g_ptr_array_add (sources, g_bytes_new (source_data, source_size));
+
+  for (size_t stage_index = 0;
+       stage_index < G_N_ELEMENTS (complete_prefixes); stage_index++)
+    {
+      size_t prefix = complete_prefixes[stage_index];
+      g_autoptr(GPtrArray) stage = g_ptr_array_new_with_free_func (
+        (GDestroyNotify) g_bytes_unref);
+      g_autoptr(GBytes) combined = NULL;
+      GoodixMilanPrintTemplateInfo print_info;
+      g_autoptr(GError) error = NULL;
+      size_t expected_registration_count = 1 + prefix * (prefix - 1) / 2;
+
+      for (size_t i = 0; i < prefix; i++)
+        g_ptr_array_add (stage, g_bytes_ref (g_ptr_array_index (sources, i)));
+      combined = goodix_match_combine_templates (stage);
+      g_assert_nonnull (combined);
+      g_assert_true (goodix_milan_print_validate_template (
+        combined, &print_info, &error));
+      g_assert_no_error (error);
+      g_assert_cmpuint (print_info.feature_count, ==, prefix);
+      g_assert_cmpuint (print_info.maximum_features,
+                        ==, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT);
+      g_assert_cmpuint (print_info.registration_count,
+                        ==, expected_registration_count);
+      g_assert_cmpuint (print_info.relation_count,
+                        ==, prefix == 1 ? 0 : prefix - 1);
+      g_assert_cmpuint (print_info.graph_established,
+                        ==, prefix == 1 ? 0 : 1);
+      g_assert_cmpint (print_info.graph_reference_index,
+                       ==, prefix == 1 ? -1 : 0);
+      g_assert_cmpuint (print_info.queue_state, ==, 0);
+      g_assert_cmpuint (print_info.queue_transaction_counter, ==, 0);
+      for (size_t i = 0; i < sources->len; i++)
+        g_assert_true (g_bytes_equal (g_ptr_array_index (sources, i),
+                                      extracted));
+      if (prefix == ENROLLMENT_PREFIX_COUNT)
+        final_prefix = g_bytes_ref (combined);
+    }
+
+  {
+    g_autoptr(GPtrArray) fresh = g_ptr_array_new_with_free_func (
+      (GDestroyNotify) g_bytes_unref);
+    g_autoptr(GBytes) recombined = NULL;
+
+    for (size_t i = 0; i < sources->len; i++)
+      g_ptr_array_add (fresh, g_bytes_ref (g_ptr_array_index (sources, i)));
+    recombined = goodix_match_combine_templates (fresh);
+    g_assert_nonnull (recombined);
+    g_assert_true (g_bytes_equal (recombined, final_prefix));
+  }
+
+  goodix_match_free_info (info);
+}
+
+static void
+test_generated_production_replay (void)
+{
+  GoodixMatchInfo *info = generate_match_info ();
+  GoodixMatchInfo *matched_info = make_distinct_antifake_fixture (info);
+  g_autoptr(GBytes) extracted = goodix_match_serialize_template (info);
+  g_autoptr(GBytes) matched_extracted = goodix_match_serialize_template (
+    matched_info);
+  g_autoptr(GPtrArray) features = g_ptr_array_new_with_free_func (
+    (GDestroyNotify) g_bytes_unref);
+  g_autoptr(GBytes) combined = NULL;
+  g_autoptr(GBytes) first_after_match = NULL;
+  g_autoptr(GBytes) first_append_update = NULL;
+  GoodixMilanPrintTemplateInfo combined_info;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (extracted);
+  g_assert_nonnull (matched_extracted);
+  g_ptr_array_add (features, g_bytes_ref (matched_extracted));
+  g_ptr_array_add (features, g_bytes_ref (extracted));
+  goodix_match_free_info (matched_info);
+  combined = goodix_match_combine_templates (features);
+  g_assert_nonnull (combined);
+  g_assert_true (goodix_milan_print_validate_template (
+    combined, &combined_info, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (combined_info.feature_count, ==, 2);
+  g_assert_cmpuint (combined_info.maximum_features,
+                    ==, GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT);
+  g_assert_cmpuint (combined_info.registration_count, ==, 2);
+  g_assert_cmpuint (combined_info.relation_count, ==, 1);
+  g_assert_cmpuint (combined_info.graph_established, ==, 1);
+  g_assert_cmpint (combined_info.graph_reference_index, ==, 0);
+
+  for (size_t iteration = 0; iteration < 2; iteration++)
+    {
+      GoodixStudyQueue *match_queue = goodix_study_queue_new (
+        combined_info.queue_state, combined_info.queue_transaction_counter);
+      GoodixMilanMatchResult result;
+      g_autoptr(GBytes) after_match = NULL;
+      g_autoptr(GBytes) negative_update = NULL;
+      GoodixMilanPrintTemplateInfo after_match_info;
+      const guint8 *combined_data;
+      const guint8 *after_match_data;
+      gsize combined_size;
+      gsize after_match_size;
+      GoodixMilanStudyAction negative_action = GOODIX_MILAN_STUDY_APPEND;
+
+      g_assert_nonnull (match_queue);
+      g_assert_true (goodix_study_queue_validate (match_queue));
+      combined_data = g_bytes_get_data (combined, &combined_size);
+      g_assert_cmpint (goodix_match_serialized_feature_result_queued (
+                         info, combined_data, combined_size, &result,
+                         &after_match, match_queue), ==,
+                       GOODIX_SIGFM_TEMPLATE_OK);
+      g_assert_nonnull (after_match);
+      g_assert_cmpint (result.score, ==, -4);
+      g_assert_cmpuint (result.matched_feature_index, ==, SIZE_MAX);
+      for (size_t i = 0; i < G_N_ELEMENTS (result.match_transform); i++)
+        g_assert_cmpint (result.match_transform[i],
+                         ==, i == 0 || i == 4 ? 0x100 : 0);
+      g_assert_cmpint (result.relation.relation_count, ==, 0);
+      g_assert_cmpint (result.relation.relation_valid, ==, 0);
+      g_assert_cmpuint (result.direct_positive_feature_mask, ==, 0);
+      g_assert_cmpuint (result.contributor_feature_mask, ==, 0);
+      g_assert_cmpuint (result.lifecycle_update_feature_mask, ==, 0);
+      g_assert_cmpuint (result.retained_evidence_count, ==, 0);
+      g_assert_cmpint (result.retained_evidence_flag, ==, 0);
+      g_assert_cmpint (result.study_control.study_finalization_gate, ==, 0);
+      g_assert_cmpint (result.study_control.study_action_gate, ==, 0);
+      g_assert_cmpint (result.study_control.queue_candidate_eligible, ==, 0);
+      g_assert_true (goodix_study_queue_validate (match_queue));
+      g_assert_cmpuint (goodix_study_queue_occupied (match_queue), ==, 0);
+      g_assert_true (goodix_milan_print_validate_template (
+        after_match, &after_match_info, &error));
+      g_assert_no_error (error);
+      g_assert_cmpuint (after_match_info.feature_count,
+                        ==, combined_info.feature_count);
+      g_assert_cmpuint (after_match_info.relation_count,
+                         ==, combined_info.relation_count);
+
+      after_match_data = g_bytes_get_data (after_match, &after_match_size);
+      g_assert_cmpint (goodix_match_study_feature_queued (
+                         info, after_match_data, after_match_size, &result,
+                         TRUE, match_queue, &negative_update,
+                         &negative_action), ==,
+                       GOODIX_SIGFM_TEMPLATE_INVALID);
+      g_assert_null (negative_update);
+      g_assert_cmpint (negative_action, ==, GOODIX_MILAN_STUDY_NONE);
+      g_assert_true (goodix_study_queue_validate (match_queue));
+      g_assert_cmpuint (goodix_study_queue_occupied (match_queue), ==, 0);
+      goodix_study_queue_free (match_queue);
+
+      /* Independent generic action-0 transient subcase. With no retained
+       * evidence the identity relation is not consumed, but keeps the
+       * publication coherent and fully defined. */
+      {
+        GoodixStudyQueue *action0_queue = goodix_study_queue_new (
+          after_match_info.queue_state,
+          after_match_info.queue_transaction_counter);
+        GoodixMilanMatchResult generic_action0_result = {
+          .matched_feature_index = SIZE_MAX,
+          .score = 1,
+          .match_transform = { 0x100, 0, 0, 0, 0x100, 0 },
+          .relation = {
+            .relation_count = 0,
+            .relation_values = { 0, 0x100, 0, 0, 0, 0x100, 0 },
+            .relation_valid = 0,
+          },
+          .study_control.study_finalization_gate = 1,
+          .study_control.study_action_gate = 1,
+        };
+        GoodixMilanStudyAction action0_action = GOODIX_MILAN_STUDY_APPEND;
+        g_autoptr(GBytes) action0_update = NULL;
+
+        g_assert_nonnull (action0_queue);
+        g_assert_cmpint (goodix_match_study_feature_queued (
+                           info, after_match_data, after_match_size,
+                           &generic_action0_result, TRUE, action0_queue,
+                           &action0_update, &action0_action), ==,
+                         GOODIX_SIGFM_TEMPLATE_OK);
+        g_assert_null (action0_update);
+        g_assert_cmpint (action0_action, ==, GOODIX_MILAN_STUDY_NONE);
+        g_assert_true (goodix_study_queue_validate (action0_queue));
+        g_assert_cmpuint (action0_queue->enabled_state, ==, 0);
+        g_assert_cmpuint (action0_queue->transaction_counter,
+                          ==, after_match_info.queue_transaction_counter);
+        g_assert_cmpuint (goodix_study_queue_allocated (action0_queue),
+                          ==, GOODIX_STUDY_QUEUE_CAPACITY);
+        g_assert_cmpuint (goodix_study_queue_occupied (action0_queue), ==, 1);
+        goodix_study_queue_free (action0_queue);
+      }
+
+      /* Independent generic action-1 append API subcase, not a matcher
+       * result handoff. */
+      {
+        GoodixStudyQueue *append_queue = goodix_study_queue_new (
+          after_match_info.queue_state,
+          after_match_info.queue_transaction_counter);
+        GoodixMilanMatchResult generic_append_result = {
+          .matched_feature_index = 0,
+          .score = 1,
+          .match_transform = { 0x100, 0, 0, 0, 0x100, 0 },
+          .relation = {
+            .relation_count = 150,
+            .relation_values = { 0, 0x100, 0, 0, 0, 0x100, 0 },
+            .relation_valid = 1,
+          },
+          .study_control.study_action_gate = 1,
+        };
+        GoodixMilanStudyAction append_action = GOODIX_MILAN_STUDY_NONE;
+        g_autoptr(GBytes) append_update = NULL;
+        GoodixMilanPrintTemplateInfo after_study_info;
+
+        g_assert_nonnull (append_queue);
+        g_assert_cmpint (goodix_match_study_feature_queued (
+                           info, after_match_data, after_match_size,
+                           &generic_append_result, TRUE, append_queue,
+                           &append_update, &append_action), ==,
+                         GOODIX_SIGFM_TEMPLATE_OK);
+        g_assert_true (goodix_study_queue_validate (append_queue));
+        g_assert_cmpuint (goodix_study_queue_occupied (append_queue), ==, 0);
+        g_assert_nonnull (append_update);
+        g_assert_cmpint (append_action, ==, GOODIX_MILAN_STUDY_APPEND);
+        g_assert_true (goodix_milan_print_validate_template (
+          append_update, &after_study_info, &error));
+        g_assert_no_error (error);
+        g_assert_cmpuint (after_study_info.feature_count,
+                          ==, combined_info.feature_count + 1);
+        g_assert_cmpuint (after_study_info.maximum_features,
+                          ==, combined_info.maximum_features);
+        g_assert_cmpuint (after_study_info.queue_state,
+                          ==, combined_info.queue_state);
+        g_assert_cmpuint (after_study_info.queue_transaction_counter,
+                          ==, combined_info.queue_transaction_counter);
+        assert_generic_append_material (extracted, after_match, append_update);
+        if (iteration == 0)
+          first_append_update = g_bytes_ref (append_update);
+        else
+          g_assert_true (g_bytes_equal (append_update, first_append_update));
+        goodix_study_queue_free (append_queue);
+      }
+
+      if (iteration == 0)
+        first_after_match = g_bytes_ref (after_match);
+      else
+        g_assert_true (g_bytes_equal (after_match, first_after_match));
+      g_test_message (
+        "generated replay iteration=%zu score=%d generic-action0-queue=1 "
+        "generic-append-action=%d",
+        iteration, result.score, GOODIX_MILAN_STUDY_APPEND);
+    }
+
+  goodix_match_free_info (info);
+}
+
 int
 main (int argc,
       char **argv)
@@ -476,5 +1083,11 @@ main (int argc,
   g_test_add_func ("/goodix53x5/milan/gain-tail", test_gain_tail);
   g_test_add_func ("/goodix53x5/milan/generated-extraction",
                     test_generated_extraction);
+  g_test_add_func ("/goodix53x5/milan/study-policy-actions",
+                    test_study_policy_actions);
+  g_test_add_func ("/goodix53x5/milan/generated-enrollment-prefix-lifecycle",
+                    test_generated_enrollment_prefix_lifecycle);
+  g_test_add_func ("/goodix53x5/milan/generated-production-replay",
+                    test_generated_production_replay);
   return g_test_run ();
 }


### PR DESCRIPTION
Depends on #28.

## Summary
- add fully synthetic production-owner coverage for enrollment, identify, verify, template lifecycle, study actions 0-5, and queued learning
- exercise a real positive matcher-to-study handoff and complete identify-prelude plus 12-stage enrollment transaction
- run the focused Milan suites on every pull request synchronization with stale-run cancellation

## Privacy
- all test frames, match information, and templates are generated algorithmically
- no biometric captures, private corpus artifacts, or hashes derived from them are included

## Local validation
- release and debug overlay builds passed
- synthetic, state, and runtime suites passed repeatedly
- stack transaction tests passed 10/10
- detector test passed