### PR TITLE
Speed up targeted Milan dump parity validation

### DIFF
--- a/tools/milan-parity/README.md
+++ b/tools/milan-parity/README.md
@@ -168,15 +168,20 @@ when both are present they are combined:
 ./tools/milan-parity/milan-parity validate-dump \
   --dump-dir /private/snapshot \
   --compare-current \
+  --native-session 01234567-89ab-4cde-8123-456789abcdef \
   --native-generation 27 \
   --native-epoch 58 \
   --native-epoch 59
 ```
 
 `--compare-current` requires at least one selector so it cannot accidentally
-start a complete source replay. Native checks execute the DLL rather than using
-stored results, so repeated native runs remain meaningful. Targeted reports use
-separate names and do not overwrite the complete audit report.
+start a complete source replay. Epoch and generation counters are scoped to a
+runtime-debug v2 capture session. `--native-session` is required only when the
+numeric selection matches multiple sessions; use a runtime record's
+`capture_session_id`. Native checks execute the DLL rather than using stored
+results, so repeated native runs remain meaningful. Targeted reports use
+separate names and do not overwrite the complete audit report. `native_coverage`
+is printed for captured-driver audits, not current-versus-native comparisons.
 
 ## Storage
 

--- a/tools/milan-parity/README.md
+++ b/tools/milan-parity/README.md
@@ -145,6 +145,34 @@ preprocessing-only preludes; matching and study remain scoped to the target
 operation and its captured input gallery. Runtime debug v1 remains readable;
 v2 requires a capture-session UUID and never joins preludes across sessions.
 
+Use the plain command for the complete captured-driver audit:
+
+```sh
+export MILAN_PARITY_DLL=/persistent/private/GoodixEngineAdapter.dll
+export MILAN_PARITY_DLL_SHA256=6673db3874fea66a58e2da29e371d797b890c767ba0491134d4a372c5b27e3b4
+export MILAN_PARITY_WINEPREFIX=/persistent/private/sealed-prefix
+
+./tools/milan-parity/milan-parity validate-dump --dump-dir /private/snapshot
+```
+
+When validating a source change against selected captured operations, compare
+the rebuilt current runner directly with native. Both selectors are repeatable;
+when both are present they are combined:
+
+```sh
+./tools/milan-parity/milan-parity validate-dump \
+  --dump-dir /private/snapshot \
+  --compare-current \
+  --native-generation 27 \
+  --native-epoch 58 \
+  --native-epoch 59
+```
+
+`--compare-current` requires at least one selector so it cannot accidentally
+start a complete source replay. Native checks execute the DLL rather than using
+stored results, so repeated native runs remain meaningful. Targeted reports use
+separate names and do not overwrite the complete audit report.
+
 ## Storage
 
 ```sh

--- a/tools/milan-parity/milan_parity.py
+++ b/tools/milan-parity/milan_parity.py
@@ -451,6 +451,40 @@ def execute_runner(runner: Path, corpus: dict[str, Any], case_id: str,
     return record
 
 
+def execute_native_batch(runner: Path, jobs: list[dict[str, Any]], dll: Path,
+                         state: Path) -> list[dict[str, Any]]:
+    descriptor = {
+        "schema": "milan-parity-native-batch/v1",
+        "jobs": [{"corpus": str(job["case"]["root"]),
+                  "case": job["case"]["case_id"]} for job in jobs],
+    }
+    batch_path = state / "work" / "native-batch.json"
+    write_atomic(batch_path, canonical(descriptor))
+    process = subprocess.run((str(runner), "--batch", str(batch_path),
+                              "--dll", str(dll)),
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             check=False)
+    if process.returncode:
+        diagnostic = process.stderr.decode("utf-8", "replace").strip()
+        raise HarnessError(
+            f"native batch runner failed with status {process.returncode}: {diagnostic}")
+    try:
+        result = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise HarnessError(f"native batch runner returned invalid JSON: {error}") from error
+    if process.stdout != canonical(result):
+        raise HarnessError("native batch runner returned non-canonical JSON")
+    if not isinstance(result, dict):
+        raise HarnessError("native batch runner result is not an object")
+    records = result.get("records")
+    if (result.get("schema") != "milan-parity-native-batch/v1" or
+            not isinstance(records, list) or len(records) != len(jobs)):
+        raise HarnessError("native batch runner result schema or record count differs")
+    for job, record in zip(jobs, records):
+        validate_record(record, job["case"]["case_id"], "native batch record")
+    return records
+
+
 def default_state_root() -> Path:
     base = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
     return base / "milan-parity"
@@ -990,12 +1024,24 @@ def pgm_payload(path: Path, raw: bool) -> bytes:
     return data[len(header):]
 
 
+def make_crc32_mpeg2_table() -> tuple[int, ...]:
+    table = []
+    for byte in range(256):
+        value = byte << 24
+        for _ in range(8):
+            value = ((value << 1) ^
+                     (0x04C11DB7 if value & 0x80000000 else 0)) & UINT32_MAX
+        table.append(value)
+    return tuple(table)
+
+
+CRC32_MPEG2_TABLE = make_crc32_mpeg2_table()
+
+
 def crc32_mpeg2(data: bytes) -> int:
     value = 0xFFFFFFFF
     for byte in data:
-        value ^= byte << 24
-        for _ in range(8):
-            value = ((value << 1) ^ (0x04C11DB7 if value & 0x80000000 else 0)) & UINT32_MAX
+        value = ((value << 8) & UINT32_MAX) ^ CRC32_MPEG2_TABLE[(value >> 24) ^ byte]
     return value
 
 
@@ -1280,8 +1326,56 @@ def print_dump_summary(report: dict[str, Any], output: Path) -> None:
     print(f"report={output}")
 
 
+def runtime_record_projection(record: dict[str, Any]) -> dict[str, Any]:
+    phases = {phase["name"]: phase["outputs"] for phase in record["phases"]}
+    required_phases = {"stage-01-preprocess", "stage-01-extract-antifake"}
+    missing_phases = sorted(required_phases - phases.keys())
+    if missing_phases:
+        raise HarnessError(
+            "runner record is missing required phases: " + ", ".join(missing_phases))
+    preprocess = phases["stage-01-preprocess"]
+    extraction = phases["stage-01-extract-antifake"]
+    result = record["result"]
+    try:
+        return {
+            "quality": preprocess["quality_i32"],
+            "coverage": preprocess["coverage_i32"],
+            "processed": preprocess["processed_image_sha256"],
+            "records": extraction["active_record_count_u32"],
+            "score": result["score_i32"],
+            "accepted": result["accepted"],
+            "winner_index": result["winner_index_u32"],
+            "winner_position": result["winner_position_u32"],
+            "study_action": result["study_action_u32"],
+            "candidate": result["final_candidate_sha256"],
+            "gallery": [{
+                "index": row["gallery_index_u32"],
+                "after_match": row["after_match_sha256"],
+                "score": row["score_i32"],
+                "accepted": row["accepted"],
+                "evaluated": row["evaluated"],
+                "valid": row["valid"],
+            } for row in result["gallery"]],
+        }
+    except (KeyError, TypeError) as error:
+        raise HarnessError(f"runner record is missing required output: {error}") from error
+
+
 def run_validate_dump(args: argparse.Namespace) -> None:
     dump = ensure_private_directory(Path(args.dump_dir))
+    selected_epochs = set(args.native_epoch)
+    selected_generations = set(args.native_generation)
+    if args.compare_current and not (selected_epochs or selected_generations):
+        raise HarnessError("--compare-current requires --native-epoch or --native-generation")
+    dll = Path(args.dll).expanduser().resolve() if args.dll else None
+    prefix = Path(args.wine_prefix).expanduser().resolve() if args.wine_prefix else None
+    if (dll is None) != (prefix is None):
+        raise HarnessError("DLL and Wine prefix must be supplied together")
+    if args.compare_current and (not dll or not prefix):
+        raise HarnessError("--compare-current requires an approved DLL and Wine prefix")
+    if dll and (not args.approved_dll_sha256 or sha256_file(dll) != args.approved_dll_sha256):
+        raise HarnessError("selected DLL is absent or not explicitly approved")
+    targeted_native = bool(selected_epochs or selected_generations)
     runtimes = []
     templates_by_identity: dict[
         tuple[str, int, int, int], dict[tuple[str, int | None], list[tuple[str, Path]]]
@@ -1334,9 +1428,15 @@ def run_validate_dump(args: argparse.Namespace) -> None:
             continue
         match = TEMPLATE_FILE_RE.fullmatch(path.name)
         if match:
-            verify_dump_crc(path, match["crc"])
             identity = (match["action"], int(match["epoch"]), int(match["generation"]),
                         int(match["stage"]))
+            template_selected = (
+                (not selected_epochs or int(match["epoch"]) in selected_epochs) and
+                (not selected_generations or
+                 int(match["generation"]) in selected_generations)
+            )
+            if not targeted_native or template_selected:
+                verify_dump_crc(path, match["crc"])
             position = int(match["position"]) if match["position"] is not None else None
             templates_by_identity.setdefault(identity, {}).setdefault(
                 (match["role"], position), []).append((sha256_file(path), path))
@@ -1385,10 +1485,8 @@ def run_validate_dump(args: argparse.Namespace) -> None:
     if len(timestamps) != len(set(timestamps)):
         raise HarnessError("runtime chronology is ambiguous because timestamps are duplicated")
     operations = []
-    dll = Path(args.dll).expanduser().resolve() if args.dll else None
-    prefix = Path(args.wine_prefix).expanduser().resolve() if args.wine_prefix else None
-    if dll and (not args.approved_dll_sha256 or sha256_file(dll) != args.approved_dll_sha256):
-        raise HarnessError("selected DLL is absent or not explicitly approved")
+    pending_native: list[dict[str, Any]] = []
+    native_name = "native-parity"
     with locked_state(args.state_root) as state:
         for runtime_position, (timestamp, runtime_path, runtime) in enumerate(runtimes):
             identity = (runtime["action"], runtime["action_epoch_u64"],
@@ -1419,7 +1517,7 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                                        "all referenced template artifact digests match")})
             checks.append(gallery_admission)
             checks.append(capture_completeness)
-            native_check = {"name": "native-parity", "status": "skipped", "detail": ""}
+            native_check = {"name": native_name, "status": "skipped", "detail": ""}
             action = runtime["action"]
             live = (artifact_with_digest(auth_raw.get(action, []),
                                          runtime.get("live_raw_sha256"))
@@ -1445,7 +1543,14 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                 "dac_high_u16": 125, "dac_low_u16": 198, "profile_u16": 9,
                 "purpose_u32": 0, "sensor_subtype_u16": 12, "tcode_u16": 121,
             }
-            if action == "enroll":
+            native_selected = (
+                (not selected_epochs or runtime["action_epoch_u64"] in selected_epochs) and
+                (not selected_generations or
+                 runtime["generation_id_u64"] in selected_generations)
+            )
+            if not native_selected:
+                native_check["detail"] = "operation was not selected for native replay"
+            elif action == "enroll":
                 native_check["detail"] = "enrollment authority requires a complete twelve-stage chain"
             elif runtime.get("status_u32") == RUNTIME_STATUS_CANCELLED:
                 native_check["detail"] = "cancelled operations are excluded from native target replay"
@@ -1469,61 +1574,18 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                 native_check["detail"] = "DLL or Wine prefix was not supplied"
             else:
                 case = native_case_for_dump(state, dump, runtime_path, runtime, setup, live,
-                                            prelude,
-                                            template_map, args.approved_dll_sha256, prefix)
-                actual = execute_runner(Path(args.native_runner).resolve(),
-                                        validate_corpus(str(case["root"])), case["case_id"],
-                                        None, dll)
-                expected = {
-                    "quality": runtime["quality_i32"],
-                    "coverage": runtime["coverage_i32"],
-                    "processed": sha256_bytes(pgm_payload(processed, raw=False)),
-                    "records": runtime["probe_record_count_u32"],
-                    "score": runtime["score_i32"],
-                    "accepted": runtime["status_u32"] == 0,
-                    "winner_index": runtime["winner_index_u32"],
-                    "winner_position": min(runtime["winner_position_u64"], UINT32_MAX),
-                    "study_action": runtime["study_action_u32"],
-                    "candidate": (native_template_sha256(final) if final else
-                                  runtime["candidate_sha256"]),
-                    "gallery": [],
-                }
-                for position, row in enumerate(runtime["gallery"]):
-                    after_match = artifact_with_digest(
-                        template_map.get(("after-match", position), []),
-                        row["after_match_sha256"])
-                    expected["gallery"].append({
-                        "index": row["gallery_index_u32"],
-                        "after_match": (native_template_sha256(after_match)
-                                        if after_match else row["after_match_sha256"]),
-                        "score": row["score_i32"],
-                        "accepted": row["accepted"],
-                        "evaluated": row["evaluated"],
-                        "valid": row["valid"],
-                    })
-                native = {
-                    "quality": actual["phases"][0]["outputs"]["quality_i32"],
-                    "coverage": actual["phases"][0]["outputs"]["coverage_i32"],
-                    "processed": actual["phases"][0]["outputs"]["processed_image_sha256"],
-                    "records": actual["phases"][1]["outputs"]["active_record_count_u32"],
-                    "score": actual["result"]["score_i32"],
-                    "accepted": actual["result"]["accepted"],
-                    "winner_index": actual["result"]["winner_index_u32"],
-                    "winner_position": actual["result"]["winner_position_u32"],
-                    "study_action": actual["result"]["study_action_u32"],
-                    "candidate": actual["result"]["final_candidate_sha256"],
-                    "gallery": [{"index": row["gallery_index_u32"],
-                                 "after_match": row["after_match_sha256"],
-                                 "score": row["score_i32"],
-                                 "accepted": row["accepted"],
-                                 "evaluated": row["evaluated"],
-                                 "valid": row["valid"]}
-                                for row in actual["result"]["gallery"]],
-                }
-                differences = difference(expected, native, all_differences=True)
-                native_check = {"name": "native-parity",
-                                "status": "fail" if differences else "pass",
-                                "detail": differences or "all comparable native outputs match"}
+                                            prelude, template_map,
+                                            args.approved_dll_sha256, prefix)
+                native_check = {"name": native_name,
+                                "status": "pending", "detail": ""}
+                pending_native.append({
+                    "case": case,
+                    "check": native_check,
+                    "runtime": runtime,
+                    "processed": processed,
+                    "final": final,
+                    "template_map": template_map,
+                })
             checks.append(native_check)
             candidate = runtime.get("candidate_sha256")
             if candidate is None:
@@ -1559,11 +1621,65 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                     } for row in runtime.get("gallery", [])],
                 },
             })
+        if pending_native:
+            actual_records = execute_native_batch(
+                Path(args.native_runner).resolve(), pending_native, dll, state)
+            for pending, actual in zip(pending_native, actual_records):
+                runtime = pending["runtime"]
+                if args.compare_current:
+                    case = pending["case"]
+                    current = execute_runner(
+                        Path(args.current_runner).resolve(),
+                        validate_corpus(str(case["root"])), case["case_id"],
+                        Path(args.repo).expanduser().resolve(), None)
+                    try:
+                        expected = runtime_record_projection(current)
+                    except HarnessError as error:
+                        pending["check"].update({
+                            "status": "fail",
+                            "detail": f"current runner output is incomplete: {error}",
+                        })
+                        continue
+                else:
+                    expected = {
+                        "quality": runtime["quality_i32"],
+                        "coverage": runtime["coverage_i32"],
+                        "processed": sha256_bytes(pgm_payload(
+                            pending["processed"], raw=False)),
+                        "records": runtime["probe_record_count_u32"],
+                        "score": runtime["score_i32"],
+                        "accepted": runtime["status_u32"] == 0,
+                        "winner_index": runtime["winner_index_u32"],
+                        "winner_position": min(runtime["winner_position_u64"], UINT32_MAX),
+                        "study_action": runtime["study_action_u32"],
+                        "candidate": (native_template_sha256(pending["final"])
+                                      if pending["final"] else runtime["candidate_sha256"]),
+                        "gallery": [],
+                    }
+                    for position, row in enumerate(runtime["gallery"]):
+                        after_match = artifact_with_digest(
+                            pending["template_map"].get(("after-match", position), []),
+                            row["after_match_sha256"])
+                        expected["gallery"].append({
+                            "index": row["gallery_index_u32"],
+                            "after_match": (native_template_sha256(after_match)
+                                            if after_match else row["after_match_sha256"]),
+                            "score": row["score_i32"],
+                            "accepted": row["accepted"],
+                            "evaluated": row["evaluated"],
+                            "valid": row["valid"],
+                        })
+                native = runtime_record_projection(actual)
+                differences = difference(expected, native, all_differences=True)
+                pending["check"].update({
+                    "status": "fail" if differences else "pass",
+                    "detail": differences or "all comparable native outputs match",
+                })
         native_checks = [check for operation in operations for check in operation["checks"]
-                         if check["name"] == "native-parity"]
+                          if check["name"] == native_name]
         native_compared = sum(check["status"] in {"pass", "fail"}
                               for check in native_checks)
-        authority_supplied = dll is not None
+        authority_supplied = dll is not None and prefix is not None
         readiness_failed = authority_supplied and native_compared == 0
         readiness = {
             "native_authority_supplied": authority_supplied,
@@ -1578,13 +1694,27 @@ def run_validate_dump(args: argparse.Namespace) -> None:
         skipped = sum(check["status"] == "skipped" for operation in operations
                       for check in operation["checks"])
         report = {"schema": "milan-parity-dump-report/v1", "policy": POLICY,
+                  "native_lifetime": "generation",
+                  "native_comparison": "current" if args.compare_current else "capture",
+                  "native_selection": {
+                      "action_epochs": sorted(selected_epochs),
+                      "generations": sorted(selected_generations),
+                  },
                   "inventory_sha256": inventory_sha256,
                   "campaign_readiness": readiness, "operations": operations,
                   "summary": {"fail": failures,
                               "pass": passes,
                               "skipped": skipped}}
+        selection = ""
+        if selected_epochs or selected_generations:
+            selection = "-target-" + sha256_bytes(canonical({
+                "action_epochs": sorted(selected_epochs),
+                "comparison": "current" if args.compare_current else "capture",
+                "generations": sorted(selected_generations),
+            }))[:12]
         output = Path(args.report).expanduser().resolve() if args.report else (
-            state / "reports" / f"dump-{inventory_sha256[:16]}.json")
+            state / "reports" /
+            f"dump-{inventory_sha256[:16]}{selection}.json")
         write_atomic(output, canonical(report))
         print(f"milan_parity_dump={'fail' if failures else 'pass'} operations={len(operations)} "
               f"checks={passes}/{failures}/{skipped}")
@@ -1840,6 +1970,20 @@ def build_parser() -> argparse.ArgumentParser:
                                         os.environ.get("WINEPREFIX")))
     validate_dump.add_argument("--native-runner",
                                default=str(Path(__file__).resolve().parent / "native-runner"))
+    validate_dump.add_argument(
+        "--native-epoch", action="append", default=[], type=int,
+        help="Replay only operations with this action epoch (repeatable)")
+    validate_dump.add_argument(
+        "--native-generation", action="append", default=[], type=int,
+        help="Replay only operations in this generation (repeatable)")
+    validate_dump.add_argument(
+        "--compare-current", action="store_true",
+        help="Compare selected operations from rebuilt current source against native")
+    validate_dump.add_argument(
+        "--current-runner",
+        default=str(Path(__file__).resolve().parent / "current-runner"))
+    validate_dump.add_argument(
+        "--repo", default=str(Path(__file__).resolve().parents[2]))
     validate_dump.add_argument("--state-root")
     validate_dump.add_argument("--report")
 

--- a/tools/milan-parity/milan_parity.py
+++ b/tools/milan-parity/milan_parity.py
@@ -1315,7 +1315,7 @@ def print_dump_summary(report: dict[str, Any], output: Path) -> None:
     compared = [operation for operation in operations
                 if any(check["name"] == "native-parity" and check["status"] == "pass"
                        for check in operation["checks"])]
-    if compared:
+    if compared and report["native_comparison"] == "capture":
         actions: dict[int, int] = {}
         queue_transitions: dict[str, int] = {}
         scores = []
@@ -1399,6 +1399,11 @@ def run_validate_dump(args: argparse.Namespace) -> None:
     dump = ensure_private_directory(Path(args.dump_dir))
     selected_epochs = set(args.native_epoch)
     selected_generations = set(args.native_generation)
+    selected_session = args.native_session
+    if selected_session is not None and not valid_capture_session_id(selected_session):
+        raise HarnessError("--native-session must be a lowercase version-4 UUID")
+    if selected_session is not None and not (selected_epochs or selected_generations):
+        raise HarnessError("--native-session requires --native-epoch or --native-generation")
     if args.compare_current and not (selected_epochs or selected_generations):
         raise HarnessError("--compare-current requires --native-epoch or --native-generation")
     dll = Path(args.dll).expanduser().resolve() if args.dll else None
@@ -1518,6 +1523,28 @@ def run_validate_dump(args: argparse.Namespace) -> None:
     timestamps = [timestamp for timestamp, _, _ in runtimes]
     if len(timestamps) != len(set(timestamps)):
         raise HarnessError("runtime chronology is ambiguous because timestamps are duplicated")
+    numerically_selected_v2 = {
+        runtime["capture_session_id"] for _, _, runtime in runtimes
+        if runtime["schema"] == "goodix53x5-runtime-debug/v2" and
+        (not selected_epochs or runtime["action_epoch_u64"] in selected_epochs) and
+        (not selected_generations or
+         runtime["generation_id_u64"] in selected_generations)
+    }
+    if targeted_native and selected_session is None:
+        if len(numerically_selected_v2) > 1:
+            raise HarnessError(
+                "targeted runtime-debug v2 selection matches multiple capture sessions; "
+                "select one with --native-session")
+        if numerically_selected_v2:
+            selected_session = next(iter(numerically_selected_v2))
+    elif selected_session is not None and selected_session not in numerically_selected_v2:
+        raise HarnessError(
+            "requested epoch/generation selection does not match --native-session")
+    native_selection = {
+        "action_epochs": sorted(selected_epochs),
+        "capture_session_id": selected_session,
+        "generations": sorted(selected_generations),
+    }
     operations = []
     pending_native: list[dict[str, Any]] = []
     native_name = "native-parity"
@@ -1578,6 +1605,8 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                 "purpose_u32": 0, "sensor_subtype_u16": 12, "tcode_u16": 121,
             }
             native_selected = (
+                (selected_session is None or
+                 runtime.get("capture_session_id") == selected_session) and
                 (not selected_epochs or runtime["action_epoch_u64"] in selected_epochs) and
                 (not selected_generations or
                  runtime["generation_id_u64"] in selected_generations)
@@ -1730,21 +1759,17 @@ def run_validate_dump(args: argparse.Namespace) -> None:
         report = {"schema": "milan-parity-dump-report/v1", "policy": POLICY,
                   "native_lifetime": "generation",
                   "native_comparison": "current" if args.compare_current else "capture",
-                  "native_selection": {
-                      "action_epochs": sorted(selected_epochs),
-                      "generations": sorted(selected_generations),
-                  },
+                  "native_selection": native_selection,
                   "inventory_sha256": inventory_sha256,
                   "campaign_readiness": readiness, "operations": operations,
                   "summary": {"fail": failures,
                               "pass": passes,
                               "skipped": skipped}}
         selection = ""
-        if selected_epochs or selected_generations:
+        if targeted_native:
             selection = "-target-" + sha256_bytes(canonical({
-                "action_epochs": sorted(selected_epochs),
+                **native_selection,
                 "comparison": "current" if args.compare_current else "capture",
-                "generations": sorted(selected_generations),
             }))[:12]
         output = Path(args.report).expanduser().resolve() if args.report else (
             state / "reports" /
@@ -2004,6 +2029,9 @@ def build_parser() -> argparse.ArgumentParser:
                                         os.environ.get("WINEPREFIX")))
     validate_dump.add_argument("--native-runner",
                                default=str(Path(__file__).resolve().parent / "native-runner"))
+    validate_dump.add_argument(
+        "--native-session",
+        help="Replay only runtime-debug v2 operations from this capture-session UUID")
     validate_dump.add_argument(
         "--native-epoch", action="append", default=[], type=int,
         help="Replay only operations with this action epoch (repeatable)")

--- a/tools/milan-parity/native-runner
+++ b/tools/milan-parity/native-runner
@@ -21,6 +21,7 @@ CORPUS_SCHEMA = "milan-parity-corpus/v1"
 CASE_SCHEMA = "milan-parity-case/v1"
 RECORD_SCHEMA = "milan-parity-record/v1"
 NATIVE_REPLAY_SCHEMA = "milan-parity-native-replay/v1"
+NATIVE_BATCH_SCHEMA = "milan-parity-native-batch/v1"
 AUTHORITY_MODEL = "canonical-zero-layered-v1"
 ENROLLMENT_AUTHORITY = "defined-byte-deterministic-replacement-v1"
 POLICY = {
@@ -433,23 +434,133 @@ def packed_input_identity(path: Path):
     return output_identity(path)
 
 
-def run_dll_authority(tool: Path, root: Path, case, native, inputs, dll: Path):
-    setup, preludes, live, template, gallery_index, queue_occupied = inputs
-    prefix = wine_prefix(native)
+def record_from_output(output: Path, case, inputs):
+    _, preludes, _, template, gallery_index, queue_occupied = inputs
+    oracle = require_object(load_json(output / "oracle-result.json",
+                                      "Wine oracle result"),
+                            "Wine oracle result")
+    expected_contract = {
+        "schema": "milan-parity-native-oracle/v1", "profile": 9,
+        "subtype": 12, "purpose": 0, "anti_fake_mode": 1,
+        "recognition_mode": 1, "normal_extraction": True,
+        "normal_antifake": True, "source_index": 2288, "sentinel": 0,
+        "in_range_bytes_preserved": True, "shadow_payload_bytes": 2289,
+        "matrix_header_size_field": 2288, "dll_allocator_owned": True,
+        "normal_destructor_compatible": True, "prelude_frames": len(preludes),
+        "hook_hits": 1,
+    }
+    if any(oracle.get(key) != value for key, value in expected_contract.items()):
+        raise RunnerError("Wine oracle did not prove the fixed normal-boundary contract")
+    processed_size, processed_hash = output_identity(output / "processed.u8")
+    loaded_size, loaded_hash = output_identity(output / "loaded-before-match.bin")
+    matched_size, matched_hash = output_identity(output / "after-match.bin")
+    studied_size, studied_hash = output_identity(output / "after-study.bin")
+    persistent_size, persistent_hash = output_identity(output / "next-persistent.bin")
+    _, expected_loaded_hash = packed_input_identity(template)
+    if processed_size != 108 * 88 or loaded_hash != expected_loaded_hash:
+        raise RunnerError("Wine oracle preprocessing or loaded-template identity differs")
+    identify = require_object(oracle.get("identify"), "Wine identify result")
+    preprocess = require_object(oracle.get("preprocess"), "Wine preprocess result")
+    study = require_object(oracle.get("study"), "Wine study result")
+    queue = require_object(oracle.get("queue"), "Wine queue result")
+    matched = identify.get("matched_index") == 0
+    if (identify.get("status") != 0 or
+            identify.get("matched_index") not in {0, UINT32_MAX} or
+            matched != (identify.get("score", 0) > 0)):
+        raise RunnerError("Wine identify score, decision, or index is inconsistent")
+    expected_called = matched
+    if (study.get("called") is not expected_called or
+            not isinstance(study.get("update"), int) or
+            not 0 <= study["update"] <= 5):
+        raise RunnerError("Wine study call or update code is inconsistent")
+    advanced = expected_called and study["update"] > 0
+    if (queue.get("injected") is not bool(queue_occupied) or
+            queue.get("occupied_before_study") != queue_occupied or
+            not isinstance(queue.get("occupied_after_study"), int) or
+            isinstance(queue.get("occupied_after_study"), bool) or
+            queue["occupied_after_study"] not in {0, 1}):
+        raise RunnerError("Wine queue injection or consumption differs")
+    if oracle.get("persistence_advanced") is not advanced:
+        raise RunnerError("Wine persistence gate is inconsistent")
+    if advanced:
+        if (persistent_size, persistent_hash) != (studied_size, studied_hash):
+            raise RunnerError("positive study update did not advance persistence")
+    elif (persistent_size, persistent_hash) != (loaded_size, loaded_hash):
+        raise RunnerError("non-positive study update changed persistence")
+
+    phases = [
+        {"name": "stage-01-preprocess",
+         "outputs": {"coverage_i32": preprocess["coverage"],
+                     "processed_image_sha256": processed_hash,
+                     "quality_i32": preprocess["quality"],
+                     "status_i32": preprocess["status"]}},
+        {"name": "stage-01-extract-antifake",
+         "outputs": {"active_record_count_u32": oracle["active_record_count"]}},
+        {"name": "stage-01-study",
+         "outputs": {"final_candidate_sha256": persistent_hash if advanced else None,
+                     "study_action_u32": study["update"]}},
+    ]
+    accepted = matched
+    status = 0 if accepted else 1
+    record = {
+        "schema": RECORD_SCHEMA,
+        "case_id": case["id"],
+        "policy": POLICY,
+        "phases": phases,
+        "result": {
+            "accepted": accepted,
+            "final_candidate_sha256": persistent_hash if advanced else None,
+            "gallery": [{"accepted": accepted,
+                         "after_match_sha256": matched_hash,
+                         "evaluated": True,
+                         "gallery_index_u32": gallery_index,
+                         "gallery_position_u64": 0,
+                         "score_i32": identify["score"], "valid": True}],
+            "score_i32": identify["score"], "status_u32": status,
+            "study_action_u32": study["update"],
+            "winner_index_u32": gallery_index if accepted else UINT32_MAX,
+            "winner_position_u32": 0 if accepted else UINT32_MAX,
+        },
+    }
+    return validate_record(record, case["id"], "native DLL record")
+
+
+def run_dll_authority_batch(tool: Path, jobs, dll: Path):
+    if not jobs:
+        return []
+    prefixes = {wine_prefix(native) for _, native, _ in jobs}
+    if len(prefixes) != 1:
+        raise RunnerError("batched authority jobs must use one Wine prefix")
+    prefix = prefixes.pop()
     wine_value = os.environ.get("MILAN_PARITY_WINE", "wine")
     wine = shutil.which(wine_value)
     if not wine:
         raise RunnerError("Wine executable is unavailable")
     executable = backend_executable(tool)
-    operation = "study"
     lock_path = cache_root() / ("wine-prefix-" + hashlib.sha256(
         str(prefix).encode("utf-8")).hexdigest() + ".lock")
     work_parent = cache_root() / "work"
     work_parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     with lock_path.open("a+b") as lock, tempfile.TemporaryDirectory(
-            prefix="milan-parity-native-", dir=work_parent) as temporary_value:
+            prefix="milan-parity-native-batch-", dir=work_parent) as temporary_value:
         fcntl.flock(lock, fcntl.LOCK_EX)
-        output = Path(temporary_value).resolve()
+        temporary = Path(temporary_value).resolve()
+        outputs = []
+        lines = []
+        for position, (case, _, inputs) in enumerate(jobs):
+            setup, preludes, live, template, _, queue_occupied = inputs
+            output = temporary / f"output-{position:04d}"
+            output.mkdir(mode=0o700)
+            outputs.append(output)
+            fields = [windows_path(output), windows_path(setup), windows_path(live),
+                      windows_path(template), str(queue_occupied)]
+            fields.extend(f"{purpose}:{windows_path(prelude)}"
+                          for prelude, purpose in preludes)
+            if any("\t" in field or "\r" in field or "\n" in field for field in fields):
+                raise RunnerError("batch authority paths contain unsupported control characters")
+            lines.append("\t".join(fields))
+        manifest = temporary / "manifest.tsv"
+        manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
         environment = os.environ.copy()
         environment.update({
             "WINEPREFIX": str(prefix),
@@ -457,112 +568,25 @@ def run_dll_authority(tool: Path, root: Path, case, native, inputs, dll: Path):
             "WINEDEBUG": "-all",
             "WINEDLLOVERRIDES": "winemenubuilder.exe=d",
         })
-        command = [wine, windows_path(executable), operation, windows_path(dll),
-                    windows_path(output), windows_path(setup), windows_path(live),
-                    windows_path(template), str(queue_occupied),
-                    *(f"{purpose}:{windows_path(prelude)}"
-                      for prelude, purpose in preludes)]
+        command = [wine, windows_path(executable), "batch", windows_path(dll),
+                   windows_path(manifest)]
         process = subprocess.run(command, env=environment, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE, check=False, timeout=300)
+                                 stderr=subprocess.PIPE, check=False, timeout=3600)
         if process.returncode:
-            raise RunnerError(f"Wine DLL authority failed with status {process.returncode}")
-        oracle = require_object(load_json(output / "oracle-result.json",
-                                          "Wine oracle result"),
-                                "Wine oracle result")
-        expected_contract = {
-            "schema": "milan-parity-native-oracle/v1", "profile": 9,
-            "subtype": 12, "purpose": 0, "anti_fake_mode": 1,
-            "recognition_mode": 1, "normal_extraction": True,
-            "normal_antifake": True, "source_index": 2288, "sentinel": 0,
-            "in_range_bytes_preserved": True, "shadow_payload_bytes": 2289,
-            "matrix_header_size_field": 2288, "dll_allocator_owned": True,
-            "normal_destructor_compatible": True, "prelude_frames": len(preludes),
-            "hook_hits": 1,
-        }
-        if any(oracle.get(key) != value for key, value in expected_contract.items()):
-            raise RunnerError("Wine oracle did not prove the fixed normal-boundary contract")
-        processed_size, processed_hash = output_identity(output / "processed.u8")
-        loaded_size, loaded_hash = output_identity(output / "loaded-before-match.bin")
-        matched_size, matched_hash = output_identity(output / "after-match.bin")
-        studied_size, studied_hash = output_identity(output / "after-study.bin")
-        persistent_size, persistent_hash = output_identity(
-            output / "next-persistent.bin")
-        _, expected_loaded_hash = packed_input_identity(template)
-        if processed_size != 108 * 88 or loaded_hash != expected_loaded_hash:
-            raise RunnerError("Wine oracle preprocessing or loaded-template identity differs")
-        identify = require_object(oracle.get("identify"), "Wine identify result")
-        preprocess = require_object(oracle.get("preprocess"), "Wine preprocess result")
-        study = require_object(oracle.get("study"), "Wine study result")
-        queue = require_object(oracle.get("queue"), "Wine queue result")
-        matched = identify.get("matched_index") == 0
-        if (identify.get("status") != 0 or
-                identify.get("matched_index") not in {0, UINT32_MAX} or
-                matched != (identify.get("score", 0) > 0)):
-            raise RunnerError("Wine identify score, decision, or index is inconsistent")
-        expected_called = matched
-        if (study.get("called") is not expected_called or
-                not isinstance(study.get("update"), int) or
-                not 0 <= study["update"] <= 5):
-            raise RunnerError("Wine study call or update code is inconsistent")
-        advanced = expected_called and study["update"] > 0
-        if (queue.get("injected") is not bool(queue_occupied) or
-                queue.get("occupied_before_study") != queue_occupied or
-                not isinstance(queue.get("occupied_after_study"), int) or
-                isinstance(queue.get("occupied_after_study"), bool) or
-                queue["occupied_after_study"] not in {0, 1}):
-            raise RunnerError("Wine queue injection or consumption differs")
-        if oracle.get("persistence_advanced") is not advanced:
-            raise RunnerError("Wine persistence gate is inconsistent")
-        if advanced:
-            if (persistent_size, persistent_hash) != (studied_size, studied_hash):
-                raise RunnerError("positive study update did not advance persistence")
-        elif (persistent_size, persistent_hash) != (loaded_size, loaded_hash):
-            raise RunnerError("non-positive study update changed persistence")
-
-        phases = [
-            {"name": "stage-01-preprocess",
-             "outputs": {"coverage_i32": preprocess["coverage"],
-                          "processed_image_sha256": processed_hash,
-                          "quality_i32": preprocess["quality"],
-                          "status_i32": preprocess["status"]}},
-            {"name": "stage-01-extract-antifake",
-             "outputs": {"active_record_count_u32": oracle["active_record_count"]}},
-            {"name": "stage-01-study",
-             "outputs": {"final_candidate_sha256": persistent_hash if advanced else None,
-                          "study_action_u32": study["update"]}},
-        ]
-        accepted = matched
-        status = 0 if accepted else 1
-        record = {
-            "schema": RECORD_SCHEMA,
-            "case_id": case["id"],
-            "policy": POLICY,
-            "phases": phases,
-            "result": {
-                "accepted": accepted,
-                "final_candidate_sha256": persistent_hash if advanced else None,
-                "gallery": [{"accepted": accepted,
-                              "after_match_sha256": matched_hash,
-                              "evaluated": True,
-                             "gallery_index_u32": gallery_index,
-                             "gallery_position_u64": 0,
-                             "score_i32": identify["score"], "valid": True}],
-                "score_i32": identify["score"], "status_u32": status,
-                "study_action_u32": study["update"],
-                "winner_index_u32": gallery_index if accepted else UINT32_MAX,
-                "winner_position_u32": 0 if accepted else UINT32_MAX,
-            },
-        }
-        return validate_record(record, case["id"], "native DLL record")
+            diagnostic = process.stderr.decode("utf-8", "replace").strip()
+            raise RunnerError(
+                f"Wine DLL batch authority failed with status {process.returncode}: {diagnostic}")
+        return [record_from_output(output, case, inputs)
+                for output, (case, _, inputs) in zip(outputs, jobs)]
 
 
-def run_dll_gallery(tool: Path, root: Path, case, native, entries, dll: Path):
-    records = []
-    for entry in entries:
-        record = run_dll_authority(tool, root, case, native, entry, dll)
-        records.append(record)
-        if record["result"]["accepted"]:
-            break
+def combine_gallery_records(case, records):
+    if not records:
+        raise RunnerError("native DLL gallery produced no records")
+    accepted_position = next((position for position, record in enumerate(records)
+                              if record["result"]["accepted"]), None)
+    if accepted_position is not None:
+        records = records[:accepted_position + 1]
     phases = records[0]["phases"][:2] + records[-1]["phases"][2:]
     for record in records[1:]:
         if record["phases"][:2] != records[0]["phases"][:2]:
@@ -584,19 +608,80 @@ def run_dll_gallery(tool: Path, root: Path, case, native, entries, dll: Path):
                            case["id"], "native DLL gallery record")
 
 
+def run_dll_gallery(tool: Path, case, native, entries, dll: Path):
+    records = []
+    for entry in entries:
+        record = run_dll_authority_batch(tool, [(case, native, entry)], dll)[0]
+        records.append(record)
+        if record["result"]["accepted"]:
+            break
+    return combine_gallery_records(case, records)
+
+
+def run_batch_authority(tool: Path, batch_path: Path, dll: Path):
+    batch = require_object(load_canonical(batch_path, "native batch"), "native batch")
+    descriptors = batch.get("jobs")
+    if (batch.get("schema") != NATIVE_BATCH_SCHEMA or
+            not isinstance(descriptors, list) or not descriptors or len(descriptors) > 4096):
+        raise RunnerError("native batch schema or jobs are invalid")
+    if not dll.is_file() or dll.is_symlink():
+        raise RunnerError("explicit DLL is unavailable for native batch")
+    dll_digest = sha256_file(dll)
+    cases = []
+    for position, descriptor in enumerate(descriptors):
+        descriptor = require_object(descriptor, f"native batch job {position}")
+        root_value = descriptor.get("corpus")
+        case_id = descriptor.get("case")
+        if not isinstance(root_value, str) or not isinstance(case_id, str):
+            raise RunnerError(f"native batch job {position} is missing corpus or case")
+        root = Path(root_value).expanduser().resolve()
+        case, verified = load_case(root, case_id)
+        _, native, entries = native_contract(case, verified)
+        if entries is None:
+            raise RunnerError("native batch does not support enrollment authority")
+        if native["dll_sha256"] != dll_digest:
+            raise RunnerError("native batch job DLL identity differs")
+        cases.append((case, native, entries))
+    records_by_case = [[] for _ in cases]
+    for gallery_position in range(max(len(entries) for _, _, entries in cases)):
+        jobs = []
+        job_cases = []
+        for case_position, (case, native, entries) in enumerate(cases):
+            if (gallery_position >= len(entries) or
+                    (records_by_case[case_position] and
+                     records_by_case[case_position][-1]["result"]["accepted"])):
+                continue
+            jobs.append((case, native, entries[gallery_position]))
+            job_cases.append(case_position)
+        for case_position, record in zip(
+                job_cases, run_dll_authority_batch(tool, jobs, dll)):
+            records_by_case[case_position].append(record)
+    combined = [combine_gallery_records(case, records)
+                for (case, _, _), records in zip(cases, records_by_case)]
+    return {"schema": NATIVE_BATCH_SCHEMA, "records": combined}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="native-runner")
     parser.add_argument("--corpus")
     parser.add_argument("--case")
+    parser.add_argument("--batch")
     parser.add_argument("--dll")
     parser.add_argument("--provenance", action="store_true")
     args = parser.parse_args()
 
     tool = Path(__file__).resolve().parent
     if args.provenance:
-        if args.corpus or args.case:
-            raise RunnerError("--provenance does not accept corpus or case")
+        if args.corpus or args.case or args.batch:
+            raise RunnerError("--provenance does not accept corpus, case, or batch")
         sys.stdout.buffer.write(canonical(provenance(tool, args.dll)))
+        return 0
+    if args.batch:
+        if args.corpus or args.case or not args.dll:
+            raise RunnerError("--batch accepts only --batch PATH and --dll PATH")
+        dll = Path(args.dll).expanduser().resolve()
+        result = run_batch_authority(tool, Path(args.batch).expanduser().resolve(), dll)
+        sys.stdout.buffer.write(canonical(result))
         return 0
     if not args.corpus or not args.case or not args.dll:
         raise RunnerError("--corpus, --case, and --dll are required")
@@ -609,7 +694,7 @@ def main() -> int:
     if case["operation"] == "enroll":
         record = run_enrollment_authority(root, args.case, dll, native)
     else:
-        record = run_dll_gallery(tool, root, case, native, inputs, dll)
+        record = run_dll_gallery(tool, case, native, inputs, dll)
     sys.stdout.buffer.write(canonical(record))
     return 0
 

--- a/tools/milan-parity/native/native-oracle.c
+++ b/tools/milan-parity/native/native-oracle.c
@@ -9,6 +9,7 @@
 #include <windows.h>
 
 #include <stddef.h>
+#include <process.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -710,18 +711,172 @@ out:
   return ok;
 }
 
+static char *
+read_manifest_line (FILE *input)
+{
+  size_t capacity = 4096;
+  size_t length = 0;
+  char *line = malloc (capacity);
+  int byte;
+
+  if (!line)
+    return NULL;
+  while ((byte = fgetc (input)) != EOF && byte != '\n')
+    {
+      if (length + 1 >= capacity)
+        {
+          char *grown;
+
+          if (capacity >= 16 * 1024 * 1024)
+            {
+              free (line);
+              return NULL;
+            }
+          capacity *= 2;
+          grown = realloc (line, capacity);
+          if (!grown)
+            {
+              free (line);
+              return NULL;
+            }
+          line = grown;
+        }
+      line[length++] = (char) byte;
+    }
+  if (byte == EOF && length == 0)
+    {
+      free (line);
+      return NULL;
+    }
+  if (length && line[length - 1] == '\r')
+    length--;
+  line[length] = '\0';
+  return line;
+}
+
+static wchar_t *
+utf8_to_wide (const char *value)
+{
+  int length;
+  wchar_t *wide;
+
+  if (!value || !*value)
+    return NULL;
+  length = MultiByteToWideChar (CP_UTF8, MB_ERR_INVALID_CHARS, value, -1,
+                                NULL, 0);
+  if (length <= 0)
+    return NULL;
+  wide = malloc ((size_t) length * sizeof (*wide));
+  if (!wide ||
+      MultiByteToWideChar (CP_UTF8, MB_ERR_INVALID_CHARS, value, -1,
+                           wide, length) != length)
+    {
+      free (wide);
+      return NULL;
+    }
+  return wide;
+}
+
+static int
+run_batch (const wchar_t *dll_path, const wchar_t *manifest_path)
+{
+  FILE *manifest = _wfopen (manifest_path, L"rb");
+  wchar_t executable[32768];
+  size_t line_number = 0;
+  int ok = 0;
+
+  if (!manifest)
+    return 0;
+  if (!GetModuleFileNameW (NULL, executable,
+                           sizeof (executable) / sizeof (executable[0])))
+    {
+      fclose (manifest);
+      return 0;
+    }
+  for (;;)
+    {
+      char *line = read_manifest_line (manifest);
+      char *fields[264];
+      wchar_t *wide[264] = { 0 };
+      const wchar_t *child_argv[272];
+      int field_count = 0;
+
+      if (!line)
+        {
+          ok = feof (manifest) != 0;
+          break;
+        }
+      line_number++;
+      fields[field_count++] = line;
+      for (char *cursor = line; *cursor; cursor++)
+        if (*cursor == '\t')
+          {
+            *cursor = '\0';
+            if (field_count >= (int) (sizeof (fields) / sizeof (fields[0])))
+              goto line_out;
+            fields[field_count++] = cursor + 1;
+          }
+      if (field_count < 5 ||
+          (strcmp (fields[4], "0") != 0 && strcmp (fields[4], "1") != 0))
+        goto line_out;
+      for (int i = 0; i < field_count; i++)
+        {
+          if (i == 4)
+            continue;
+          wide[i] = utf8_to_wide (fields[i]);
+          if (!wide[i])
+            goto line_out;
+        }
+      child_argv[0] = executable;
+      child_argv[1] = L"study";
+      child_argv[2] = dll_path;
+      child_argv[3] = wide[0];
+      child_argv[4] = wide[1];
+      child_argv[5] = wide[2];
+      child_argv[6] = wide[3];
+      child_argv[7] = fields[4][0] == '1' ? L"1" : L"0";
+      for (int i = 5; i < field_count; i++)
+        child_argv[i + 3] = wide[i];
+      child_argv[field_count + 3] = NULL;
+      if (_wspawnv (_P_WAIT, executable, child_argv) != 0)
+        goto line_out;
+      for (int i = 0; i < field_count; i++)
+        free (wide[i]);
+      free (line);
+      continue;
+
+line_out:
+      fwprintf (stderr, L"batch replay failed at line %llu\n",
+                (unsigned long long) line_number);
+      for (int i = 0; i < field_count; i++)
+        free (wide[i]);
+      free (line);
+      break;
+    }
+  fclose (manifest);
+  return ok;
+}
+
 int
 wmain (int argc, wchar_t **argv)
 {
   int study_enabled;
 
   setvbuf (stdout, NULL, _IONBF, 0);
+  if (argc == 4 && wcscmp (argv[1], L"batch") == 0)
+    {
+      if (!run_batch (argv[2], argv[3]))
+        return 1;
+      return 0;
+    }
   if (argc < 8 ||
       (wcscmp (argv[1], L"identify") != 0 &&
        wcscmp (argv[1], L"study") != 0))
     {
       fwprintf (stderr,
-                L"usage: %ls identify|study DLL OUTPUT BASE LIVE TEMPLATE ENQUEUE [PURPOSE:PRELUDE...]\n",
+                L"usage: %ls identify|study DLL OUTPUT BASE LIVE TEMPLATE ENQUEUE [PURPOSE:PRELUDE...]\n"
+                L"       %ls batch DLL MANIFEST\n",
+                argv[0],
                 argv[0]);
       return 2;
     }


### PR DESCRIPTION
## Summary

- batch native preprocessing, matching, and study requests so captured-dump validation avoids repeated Wine and DLL startup overhead
- add targeted generation and epoch selectors for comparing a rebuilt current runner directly with the native implementation
- keep full captured-driver audits as the default while requiring selectors for `--compare-current` to prevent accidental complete source replays
- separate targeted reports from complete audit reports and retain deterministic parity output
- document the optimized complete-audit and targeted source-validation workflows

## Validation

- validated complete captured-driver dump auditing against the native DLL
- validated targeted current-versus-native comparisons by generation and action epoch
- confirmed native checks execute the DLL rather than reusing stored results

## Stack

This is the top layer of the profile 9 FDT refresh stack and contains parity-tooling changes only.