### PR TITLE
Align Milan profile 9 runtime parity

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -42,9 +42,11 @@ typedef struct
 static void
 goodix_auth_log_runtime_result (FpDevice                       *dev,
                                 GoodixAuthTaskData              *data,
-                                const GoodixMilanRuntimeOutput *output)
+                                const GoodixMilanRuntimeOutput *output,
+                                gboolean driver_cancellation_observed)
 {
-  goodix_debug_log_runtime_result (dev, 0, &data->debug_metadata, output);
+  goodix_debug_log_runtime_result (dev, 0, &data->debug_metadata, output,
+                                   driver_cancellation_observed);
 }
 #else
 #define goodix_auth_log_runtime_result(...) G_STMT_START { } G_STMT_END
@@ -63,6 +65,8 @@ goodix_auth_task_data_free (GoodixAuthTaskData *data)
   if (!data)
     return;
   goodix_milan_runtime_input_free (data->runtime_input);
+  GOODIX53X5_DEBUG_ONLY (
+    goodix_debug_clear_runtime_metadata (&data->debug_metadata);)
   g_clear_pointer (&data->originals, g_ptr_array_unref);
   g_free (data);
 }
@@ -255,7 +259,7 @@ goodix_auth_task_done (GObject      *source_object,
   if (!action_owned)
     {
       if (output)
-        goodix_auth_log_runtime_result (dev, data, output);
+        goodix_auth_log_runtime_result (dev, data, output, FALSE);
       goodix_milan_runtime_output_free (output);
       g_clear_pointer (&self->captured_raw_image, g_free);
       if (task_owned && self->profile9_fdt.owner)
@@ -264,10 +268,21 @@ goodix_auth_task_done (GObject      *source_object,
       return;
     }
 
+  if (generation_current && output &&
+      output->action_epoch == data->action_epoch &&
+      output->generation_id == data->generation_id &&
+      output->preprocess_state_valid)
+    {
+      self->milan_generation->state = output->preprocess_state;
+      self->milan_generation->profile_state = output->profile_state;
+      if (data->action == FPI_DEVICE_ACTION_IDENTIFY)
+        goodix_milan_generation_note_identify_prelude (self->milan_generation);
+    }
+
   if (cancelled)
     {
       if (output)
-        goodix_auth_log_runtime_result (dev, data, output);
+        goodix_auth_log_runtime_result (dev, data, output, TRUE);
       goodix_milan_runtime_output_free (output);
       g_clear_pointer (&self->captured_raw_image, g_free);
       goodix_scan_set_disposition (dev, GOODIX_SCAN_DISPOSITION_CANCELLED,
@@ -288,14 +303,6 @@ goodix_auth_task_done (GObject      *source_object,
                        FP_DEVICE_ERROR_GENERAL,
                        "Native Milan auth task returned invalid output"));
       return;
-    }
-
-  if (generation_current && output->preprocess_state_valid)
-    {
-      self->milan_generation->state = output->preprocess_state;
-      self->milan_generation->profile_state = output->profile_state;
-      if (data->action == FPI_DEVICE_ACTION_IDENTIFY)
-        goodix_milan_generation_note_identify_prelude (self->milan_generation);
     }
 
   GOODIX53X5_DEBUG_ONLY (goodix_auth_set_processed_image (self, output);)
@@ -387,7 +394,7 @@ goodix_auth_task_done (GObject      *source_object,
           data->action == FPI_DEVICE_ACTION_IDENTIFY ? "identify" : "verify",
           output->score, output->winner_index, output->study_action,
           output->quality, output->coverage);
-  goodix_auth_log_runtime_result (dev, data, output);
+  goodix_auth_log_runtime_result (dev, data, output, FALSE);
 out:
   goodix_milan_runtime_output_free (output);
 #ifdef GOODIX53X5_DEBUG

--- a/drivers/goodix53x5/device/debug.c
+++ b/drivers/goodix53x5/device/debug.c
@@ -824,8 +824,7 @@ goodix_debug_log_runtime_result (FpDevice                         *dev,
     G_GUINT64_FORMAT ",\"coverage_i32\":",
     self->debug_capture_session_id, chronology);
   if (output->preprocess_attempted)
-    g_string_append_printf (record, "%d",
-                            output->preprocess_completed ? output->coverage : 0);
+    g_string_append_printf (record, "%d", output->coverage);
   else
     g_string_append (record, "null");
   g_string_append_printf (
@@ -974,8 +973,7 @@ goodix_debug_log_runtime_result (FpDevice                         *dev,
     "\"quality_i32\":",
     output->probe_record_count, (guint) output->purpose);
   if (output->preprocess_attempted)
-    g_string_append_printf (record, "%d",
-                            output->preprocess_completed ? output->quality : 0);
+    g_string_append_printf (record, "%d", output->quality);
   else
     g_string_append (record, "null");
   g_string_append_printf (

--- a/drivers/goodix53x5/device/debug.c
+++ b/drivers/goodix53x5/device/debug.c
@@ -26,6 +26,14 @@
 #include <unistd.h>
 #include <glib/gstdio.h>
 
+#define GOODIX53X5_BUILD_ID_MARKER "goodix53x5-build-id-v1:"
+#define GOODIX53X5_SOURCE_ID_MARKER "goodix53x5-source-id-v1:"
+
+static const gchar goodix_debug_build_id_marker[] __attribute__((used)) =
+  GOODIX53X5_BUILD_ID_MARKER GOODIX53X5_DEBUG_BUILD_ID;
+static const gchar goodix_debug_source_id_marker[] __attribute__((used)) =
+  GOODIX53X5_SOURCE_ID_MARKER GOODIX53X5_DEBUG_SOURCE_ID;
+
 typedef enum
 {
   GOODIX_DUMP_PROBES_NONE,
@@ -61,7 +69,7 @@ goodix_debug_ensure_dump_dir (const gchar *dump_dir)
   return TRUE;
 }
 
-static void
+static gboolean
 goodix_debug_write_dump (const gchar      *prefix,
                           guint32           crc,
                           const GByteArray *buf,
@@ -71,6 +79,9 @@ goodix_debug_write_dump (const gchar      *prefix,
   g_autofree gchar *path = NULL;
   gint fd = -1;
   gint64 stamp = g_get_real_time ();
+  gsize written = 0;
+  gboolean created = FALSE;
+  gboolean published = TRUE;
 
   for (guint attempt = 0; attempt < 1000 && fd < 0; attempt++)
     {
@@ -78,57 +89,273 @@ goodix_debug_write_dump (const gchar      *prefix,
       path = g_strdup_printf ("%s/%s-%" G_GINT64_FORMAT "-%08x.%s",
                               dump_dir, prefix, stamp + attempt, crc, extension);
       fd = g_open (path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
-      if (fd < 0 && errno != EEXIST)
+      if (fd >= 0)
+        created = TRUE;
+      else if (errno != EEXIST)
         break;
     }
-  if (fd < 0 || write (fd, buf->data, buf->len) != (ssize_t) buf->len ||
-      fsync (fd) != 0 || close (fd) != 0)
+  while (fd >= 0 && written < buf->len)
+    {
+      ssize_t count = write (fd, buf->data + written, buf->len - written);
+
+      if (count < 0 && errno == EINTR)
+        continue;
+      if (count <= 0)
+        {
+          if (count == 0)
+            errno = EIO;
+          break;
+        }
+      written += count;
+    }
+  if (fd < 0 || written != buf->len || fsync (fd) != 0)
+    published = FALSE;
+  if (fd >= 0 && close (fd) != 0)
+    published = FALSE;
+  fd = -1;
+  if (!published)
     {
       gint saved_errno = errno;
 
-      if (fd >= 0)
-        close (fd);
-      fp_warn ("Failed to publish %s: %s", path, g_strerror (saved_errno));
-      return;
+      if (created && path)
+        g_unlink (path);
+      fp_warn ("Failed to publish %s: %s", path ? path : prefix,
+               g_strerror (saved_errno));
+      return FALSE;
     }
 
   fp_dbg ("Dumped %s (%u bytes)", path, (unsigned) buf->len);
+  return TRUE;
+}
+
+typedef struct
+{
+  gchar   *basename;
+  guint64  bytes;
+  gchar   *encoding;
+  gchar    sha256[65];
+} GoodixDebugArtifact;
+
+typedef struct
+{
+  GoodixDebugArtifact *after_match;
+  GoodixDebugArtifact *input;
+} GoodixDebugGalleryArtifacts;
+
+static void
+goodix_debug_artifact_free (GoodixDebugArtifact *artifact)
+{
+  if (!artifact)
+    return;
+  g_free (artifact->basename);
+  g_free (artifact->encoding);
+  g_free (artifact);
 }
 
 static void
-goodix_debug_write_gbytes (const gchar *prefix,
-                           GBytes      *source,
-                           const gchar *extension)
+goodix_debug_gallery_artifacts_free (GoodixDebugGalleryArtifacts *artifacts)
 {
-  gconstpointer data;
-  gsize size;
-  g_autoptr(GByteArray) bytes = NULL;
-
-  if (!source)
+  if (!artifacts)
     return;
-  data = g_bytes_get_data (source, &size);
-  bytes = g_byte_array_sized_new (size);
-  g_byte_array_append (bytes, data, size);
-  goodix_debug_write_dump (
-    prefix, goodix_crypto_crc32_mpeg2 (data, size), bytes, extension);
+  goodix_debug_artifact_free (artifacts->after_match);
+  goodix_debug_artifact_free (artifacts->input);
+  g_free (artifacts);
 }
 
-static gchar *
-goodix_debug_raw12_sha256 (const guint16 *image)
+static gboolean
+goodix_debug_env_enabled (const gchar *name)
 {
-  g_autoptr(GChecksum) checksum = NULL;
+  const gchar *value = g_getenv (name);
+
+  return value != NULL && value[0] != '\0' && g_strcmp0 (value, "0") != 0;
+}
+
+static gboolean
+goodix_debug_valid_sha256 (const gchar *value)
+{
+  if (!value || strlen (value) != 64)
+    return FALSE;
+  for (guint i = 0; i < 64; i++)
+    if (!g_ascii_isdigit (value[i]) &&
+        !(value[i] >= 'a' && value[i] <= 'f'))
+      return FALSE;
+  return TRUE;
+}
+
+static GBytes *
+goodix_debug_raw12_le_bytes (const guint16 *image)
+{
+  guint8 *data;
 
   if (!image)
     return NULL;
-  checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  data = g_malloc (GOODIX_SENSOR_PIXELS * 2);
   for (gsize i = 0; i < GOODIX_SENSOR_PIXELS; i++)
     {
       const guint16 value = image[i] & 0x0fff;
-      const guint8 bytes[2] = { value >> 8, value & 0xff };
 
-      g_checksum_update (checksum, bytes, sizeof (bytes));
+      data[i * 2] = value & 0xff;
+      data[i * 2 + 1] = value >> 8;
     }
-  return g_strdup (g_checksum_get_string (checksum));
+  return g_bytes_new_take (data, GOODIX_SENSOR_PIXELS * 2);
+}
+
+static GoodixDebugArtifact *
+goodix_debug_publish_artifact (const gchar *prefix,
+                               GBytes      *source,
+                               const gchar *encoding)
+{
+  const gchar *dump_dir = goodix_debug_dump_dir ();
+  g_autofree gchar *path = NULL;
+  g_autofree gchar *basename = NULL;
+  g_autofree gchar *sha256 = NULL;
+  gconstpointer data;
+  gsize size;
+  gint fd = -1;
+  gint64 stamp = g_get_real_time ();
+  gsize written = 0;
+  gboolean created = FALSE;
+  gboolean published = TRUE;
+
+  if (!source || !dump_dir)
+    return NULL;
+  data = g_bytes_get_data (source, &size);
+  sha256 = g_compute_checksum_for_data (G_CHECKSUM_SHA256, data, size);
+  for (guint attempt = 0; attempt < 1000 && fd < 0; attempt++)
+    {
+      g_free (basename);
+      g_free (path);
+      basename = g_strdup_printf (
+        "%s-%" G_GINT64_FORMAT "-%08x.bin", prefix, stamp + attempt,
+        goodix_crypto_crc32_mpeg2 (data, size));
+      path = g_build_filename (dump_dir, basename, NULL);
+      fd = g_open (path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+      if (fd >= 0)
+        created = TRUE;
+      else if (errno != EEXIST)
+        break;
+    }
+  while (fd >= 0 && written < size)
+    {
+      ssize_t count = write (fd, (const guint8 *) data + written,
+                             size - written);
+
+      if (count < 0 && errno == EINTR)
+        continue;
+      if (count <= 0)
+        {
+          if (count == 0)
+            errno = EIO;
+          break;
+        }
+      written += count;
+    }
+  if (fd < 0 || written != size || fsync (fd) != 0)
+    published = FALSE;
+  if (fd >= 0 && close (fd) != 0)
+    published = FALSE;
+  fd = -1;
+  if (!published)
+    {
+      gint saved_errno = errno;
+
+      if (created && path)
+        g_unlink (path);
+      fp_warn ("Failed to publish runtime artifact %s: %s",
+               path ? path : prefix, g_strerror (saved_errno));
+      return NULL;
+    }
+
+  GoodixDebugArtifact *artifact = g_new0 (GoodixDebugArtifact, 1);
+
+  artifact->basename = g_steal_pointer (&basename);
+  artifact->bytes = size;
+  artifact->encoding = g_strdup (encoding);
+  g_strlcpy (artifact->sha256, sha256, sizeof (artifact->sha256));
+  return artifact;
+}
+
+static void
+goodix_debug_json_string (GString     *json,
+                          const gchar *value)
+{
+  const gchar *cursor = value ? value : "";
+
+  g_string_append_c (json, '"');
+  while (*cursor)
+    {
+      gunichar character = g_utf8_get_char_validated (cursor, -1);
+
+      if (character == (gunichar) -1 || character == (gunichar) -2)
+        {
+          g_string_append (json, "\\ufffd");
+          cursor++;
+          continue;
+        }
+      switch (character)
+        {
+        case '"': g_string_append (json, "\\\""); break;
+        case '\\': g_string_append (json, "\\\\"); break;
+        case '\b': g_string_append (json, "\\b"); break;
+        case '\f': g_string_append (json, "\\f"); break;
+        case '\n': g_string_append (json, "\\n"); break;
+        case '\r': g_string_append (json, "\\r"); break;
+        case '\t': g_string_append (json, "\\t"); break;
+        default:
+          if (character < 0x20 || character > 0x7e)
+            {
+              if (character <= 0xffff)
+                g_string_append_printf (json, "\\u%04x", character);
+              else
+                {
+                  guint32 adjusted = character - 0x10000;
+
+                  g_string_append_printf (json, "\\u%04x\\u%04x",
+                                          0xd800 + (adjusted >> 10),
+                                          0xdc00 + (adjusted & 0x3ff));
+                }
+            }
+          else
+            g_string_append_c (json, character);
+          break;
+        }
+      cursor = g_utf8_next_char (cursor);
+    }
+  g_string_append_c (json, '"');
+}
+
+static void
+goodix_debug_json_artifact (GString                   *json,
+                            const GoodixDebugArtifact *artifact)
+{
+  if (!artifact)
+    {
+      g_string_append (json, "null");
+      return;
+    }
+  g_string_append (json, "{\"basename\":");
+  goodix_debug_json_string (json, artifact->basename);
+  g_string_append_printf (json, ",\"bytes_u64\":%" G_GUINT64_FORMAT
+                          ",\"encoding\":", artifact->bytes);
+  goodix_debug_json_string (json, artifact->encoding);
+  g_string_append (json, ",\"sha256\":");
+  goodix_debug_json_string (json, artifact->sha256);
+  g_string_append_c (json, '}');
+}
+
+static void
+goodix_debug_json_error (GString      *json,
+                         const GError *error)
+{
+  if (!error)
+    {
+      g_string_append (json, "null");
+      return;
+    }
+  g_string_append_printf (json, "{\"code_i32\":%d,\"domain_u32\":%u,"
+                          "\"message\":", error->code, error->domain);
+  goodix_debug_json_string (json, error->message);
+  g_string_append_c (json, '}');
 }
 
 void
@@ -384,63 +611,130 @@ goodix_debug_timing_open_done (FpiDeviceGoodix53x5 *self,
 
 void
 goodix_debug_capture_runtime_metadata (GoodixDebugRuntimeMetadata *metadata,
-                                       FpiDeviceAction             action,
-                                       const guint16              *setup_tx_on,
-                                       const guint16              *live_raw,
-                                       guint64 generation_use_index)
+                                        FpiDeviceAction             action,
+                                        const guint16              *setup_tx_on,
+                                        const guint16              *live_raw,
+                                        guint64 generation_use_index)
 {
-  g_autofree gchar *setup_txon_sha256 = NULL;
-  g_autofree gchar *live_raw_sha256 = NULL;
-
   g_return_if_fail (metadata != NULL);
   g_return_if_fail (setup_tx_on != NULL);
   g_return_if_fail (live_raw != NULL);
 
-  setup_txon_sha256 = goodix_debug_raw12_sha256 (setup_tx_on);
-  live_raw_sha256 = goodix_debug_raw12_sha256 (live_raw);
+  goodix_debug_clear_runtime_metadata (metadata);
   metadata->action = action;
   metadata->generation_use_index = generation_use_index;
-  g_strlcpy (metadata->setup_txon_sha256, setup_txon_sha256,
-             sizeof (metadata->setup_txon_sha256));
-  g_strlcpy (metadata->live_raw_sha256, live_raw_sha256,
-             sizeof (metadata->live_raw_sha256));
+  metadata->setup_tx_on = goodix_debug_raw12_le_bytes (setup_tx_on);
+  metadata->live_raw = goodix_debug_raw12_le_bytes (live_raw);
+}
+
+void
+goodix_debug_clear_runtime_metadata (GoodixDebugRuntimeMetadata *metadata)
+{
+  if (!metadata)
+    return;
+  g_clear_pointer (&metadata->setup_tx_on, g_bytes_unref);
+  g_clear_pointer (&metadata->live_raw, g_bytes_unref);
 }
 
 void
 goodix_debug_log_runtime_result (FpDevice                         *dev,
-                                 guint                             stage,
-                                 const GoodixDebugRuntimeMetadata *metadata,
-                                 const GoodixMilanRuntimeOutput   *output)
+                                  guint                             stage,
+                                  const GoodixDebugRuntimeMetadata *metadata,
+                                  const GoodixMilanRuntimeOutput   *output,
+                                  gboolean driver_cancellation_observed)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
-  const gchar *value = g_getenv ("GOODIX53X5_LOG_DIAGNOSTICS");
-  g_autofree gchar *probe_sha256 = NULL;
-  g_autofree gchar *candidate_sha256 = NULL;
-  g_autofree gchar *processed_image_sha256 = NULL;
+  const gchar *dump_dir = goodix_debug_dump_dir ();
+  g_autofree gchar *common_prefix = NULL;
+  g_autofree gchar *operation_id = NULL;
   g_autofree gchar *prefix = NULL;
+  g_autoptr(GPtrArray) gallery_artifacts = NULL;
   g_autoptr(GString) record = NULL;
   g_autoptr(GByteArray) bytes = NULL;
+  g_autoptr(GBytes) final_candidate = NULL;
+  GoodixDebugArtifact *final_candidate_artifact = NULL;
+  GoodixDebugArtifact *live_raw_artifact = NULL;
+  GoodixDebugArtifact *native_probe_artifact = NULL;
+  GoodixDebugArtifact *processed_image_artifact = NULL;
+  GoodixDebugArtifact *setup_tx_on_artifact = NULL;
   const gchar *action_name;
   gchar *record_data;
   gsize record_len;
-  gboolean dump_templates;
+  guint64 chronology;
+  gboolean runtime_cancelled;
 
-  if (value == NULL || value[0] == '\0' || g_strcmp0 (value, "0") == 0 ||
+  if (!goodix_debug_env_enabled ("GOODIX53X5_LOG_DIAGNOSTICS") ||
+      !goodix_debug_env_enabled ("GOODIX53X5_DUMP_TEMPLATES") || !dump_dir ||
       metadata == NULL || output == NULL)
     return;
+  if (!goodix_debug_valid_sha256 (
+        goodix_debug_build_id_marker + sizeof (GOODIX53X5_BUILD_ID_MARKER) - 1) ||
+      !goodix_debug_valid_sha256 (
+        goodix_debug_source_id_marker + sizeof (GOODIX53X5_SOURCE_ID_MARKER) - 1))
+    {
+      fp_warn ("Refusing runtime v3 emission with invalid build provenance");
+      return;
+    }
+  if (!metadata->setup_tx_on || !metadata->live_raw ||
+      !goodix_debug_ensure_dump_dir (dump_dir))
+    return;
+  if (self->debug_chronology == G_MAXUINT64)
+    {
+      fp_warn ("Runtime debug chronology exhausted");
+      return;
+    }
+  chronology = self->debug_chronology + 1;
   action_name = goodix_debug_action_name (metadata->action);
-  value = g_getenv ("GOODIX53X5_DUMP_TEMPLATES");
-  dump_templates = value != NULL && value[0] != '\0' &&
-                   g_strcmp0 (value, "0") != 0;
-  if (output->probe_template)
-    probe_sha256 = g_compute_checksum_for_bytes (
-      G_CHECKSUM_SHA256, output->probe_template);
+  common_prefix = g_strdup_printf (
+    "runtime-artifact-%s-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT
+    "-%u-%" G_GUINT64_FORMAT,
+    self->debug_capture_session_id, action_name, output->action_epoch,
+    output->generation_id, stage, chronology);
+  operation_id = g_strdup_printf ("%s/%s/%" G_GUINT64_FORMAT,
+                                  self->debug_capture_session_id, action_name,
+                                  output->action_epoch);
+
+#define PUBLISH_ARTIFACT(role, source, encoding) G_STMT_START { \
+  g_clear_pointer (&prefix, g_free); \
+  prefix = g_strdup_printf ("%s-%s", common_prefix, #role); \
+  role##_artifact = goodix_debug_publish_artifact (prefix, source, encoding); \
+} G_STMT_END
+  PUBLISH_ARTIFACT (setup_tx_on, metadata->setup_tx_on,
+                    "raw-u16le-12-108x88");
+  PUBLISH_ARTIFACT (live_raw, metadata->live_raw, "raw-u16le-12-108x88");
+  PUBLISH_ARTIFACT (processed_image, output->processed_image,
+                    "raw-u8-108x88");
+  PUBLISH_ARTIFACT (native_probe, output->probe_template,
+                    "goodix-milan-native-template");
   if (output->final_candidate)
-    candidate_sha256 = g_compute_checksum_for_bytes (
-      G_CHECKSUM_SHA256, output->final_candidate);
-  if (output->processed_image)
-    processed_image_sha256 = g_compute_checksum_for_bytes (
-      G_CHECKSUM_SHA256, output->processed_image);
+    final_candidate = g_bytes_ref (output->final_candidate);
+  PUBLISH_ARTIFACT (final_candidate, final_candidate,
+                    "goodix-milan-native-template");
+#undef PUBLISH_ARTIFACT
+
+  g_clear_pointer (&prefix, g_free);
+  gallery_artifacts = g_ptr_array_new_with_free_func (
+    (GDestroyNotify) goodix_debug_gallery_artifacts_free);
+  for (guint i = 0; i < output->gallery_results->len; i++)
+    {
+      GoodixMilanRuntimeGalleryResult *result =
+        g_ptr_array_index (output->gallery_results, i);
+      GoodixDebugGalleryArtifacts *artifacts = g_new0 (
+        GoodixDebugGalleryArtifacts, 1);
+
+      prefix = g_strdup_printf ("%s-gallery-%" G_GSIZE_FORMAT "-input",
+                                common_prefix, result->gallery_position);
+      artifacts->input = goodix_debug_publish_artifact (
+        prefix, result->input_template, "goodix-milan-native-template");
+      g_clear_pointer (&prefix, g_free);
+      prefix = g_strdup_printf ("%s-gallery-%" G_GSIZE_FORMAT "-after-match",
+                                common_prefix, result->gallery_position);
+      artifacts->after_match = goodix_debug_publish_artifact (
+        prefix, result->after_match_template, "goodix-milan-native-template");
+      g_ptr_array_add (gallery_artifacts, artifacts);
+      g_clear_pointer (&prefix, g_free);
+    }
+
   fp_info ("diagnostic[%s] epoch=%" G_GUINT64_FORMAT
            " generation=%" G_GUINT64_FORMAT
            " stage=%u purpose=%u status=%u quality=%d coverage=%d "
@@ -460,21 +754,90 @@ goodix_debug_log_runtime_result (FpDevice                         *dev,
            output->cancellation.cancelled_gallery_position,
            output->error ? output->error->domain : 0,
            output->error ? output->error->code : 0,
-           output->learning_error ? output->learning_error->domain : 0,
-           output->learning_error ? output->learning_error->code : 0);
+            output->learning_error ? output->learning_error->domain : 0,
+            output->learning_error ? output->learning_error->code : 0);
+
+  runtime_cancelled = output->status == GOODIX_MILAN_RUNTIME_CANCELLED ||
+                      output->cancellation.cancelled_at !=
+                        GOODIX_MILAN_RUNTIME_CHECKPOINT_NONE;
   record = g_string_new (NULL);
+  g_string_append (record, "{\"action\":");
+  goodix_debug_json_string (record, action_name);
+  g_string_append_printf (record,
+                          ",\"action_epoch_u64\":%" G_GUINT64_FORMAT
+                          ",\"anti_fake_mode\":1,\"artifacts\":{"
+                          "\"final_candidate\":", output->action_epoch);
+  goodix_debug_json_artifact (record, final_candidate_artifact);
+  g_string_append (record, ",\"gallery\":[");
+  for (guint i = 0; i < gallery_artifacts->len; i++)
+    {
+      GoodixDebugGalleryArtifacts *artifacts =
+        g_ptr_array_index (gallery_artifacts, i);
+      GoodixMilanRuntimeGalleryResult *result =
+        g_ptr_array_index (output->gallery_results, i);
+
+      if (i)
+        g_string_append_c (record, ',');
+      g_string_append (record, "{\"after_match\":");
+      goodix_debug_json_artifact (record, artifacts->after_match);
+      g_string_append_printf (record,
+                              ",\"gallery_position_u64\":%"
+                              G_GSIZE_FORMAT ",\"input\":",
+                              result->gallery_position);
+      goodix_debug_json_artifact (record, artifacts->input);
+      g_string_append_c (record, '}');
+    }
+  g_string_append (record, "],\"live_raw\":");
+  goodix_debug_json_artifact (record, live_raw_artifact);
+  g_string_append (record, ",\"native_probe\":");
+  goodix_debug_json_artifact (record, native_probe_artifact);
+  g_string_append (record, ",\"processed_image\":");
+  goodix_debug_json_artifact (record, processed_image_artifact);
+  g_string_append (record, ",\"setup_tx_on\":");
+  goodix_debug_json_artifact (record, setup_tx_on_artifact);
+  g_string_append (record, "},\"boundary_policy\":\"canonical-zero-v1\","
+                           "\"build_id\":\"");
+  g_string_append (record,
+                   goodix_debug_build_id_marker +
+                     sizeof (GOODIX53X5_BUILD_ID_MARKER) - 1);
+  g_string_append (record, "\",\"cancellation\":{\"driver_observed\":");
+  g_string_append (record, driver_cancellation_observed ? "true" : "false");
+  g_string_append (record, ",\"runtime_checkpoint_u32\":");
+  if (runtime_cancelled)
+    g_string_append_printf (record, "%u",
+                            (guint) output->cancellation.cancelled_at);
+  else
+    g_string_append (record, "null");
+  g_string_append (record, ",\"runtime_gallery_position_u64\":");
+  if (runtime_cancelled &&
+      output->cancellation.cancelled_gallery_position != G_MAXSIZE)
+    g_string_append_printf (
+      record, "%" G_GSIZE_FORMAT,
+      output->cancellation.cancelled_gallery_position);
+  else
+    g_string_append (record, "null");
+  g_string_append (record, ",\"runtime_observed\":");
+  g_string_append (record, runtime_cancelled ? "true" : "false");
   g_string_append_printf (
     record,
-    "{\"action\":\"%s\",\"action_epoch_u64\":%" G_GUINT64_FORMAT
-    ",\"candidate_sha256\":%s%s%s,\"capture_session_id\":\"%s\","
-    "\"coverage_i32\":%d,"
-    "\"dac_high_u16\":%u,\"dac_low_u16\":%u,"
-    "\"evaluated_gallery_u32\":%u,\"gallery\":[",
-    action_name,
-    output->action_epoch, candidate_sha256 ? "\"" : "null",
-    candidate_sha256 ? candidate_sha256 : "", candidate_sha256 ? "\"" : "",
-    self->debug_capture_session_id,
-    output->coverage, output->dac_high, output->dac_low,
+    "},\"capture_session_id\":\"%s\",\"chronology_u64\":%"
+    G_GUINT64_FORMAT ",\"coverage_i32\":",
+    self->debug_capture_session_id, chronology);
+  if (output->preprocess_attempted)
+    g_string_append_printf (record, "%d",
+                            output->preprocess_completed ? output->coverage : 0);
+  else
+    g_string_append (record, "null");
+  g_string_append_printf (
+    record,
+    ",\"dac_high_u16\":%u,\"dac_low_u16\":%u,\"errors\":{"
+    "\"learning\":", output->dac_high, output->dac_low);
+  goodix_debug_json_error (record, output->learning_error);
+  g_string_append (record, ",\"runtime\":");
+  goodix_debug_json_error (record, output->error);
+  g_string_append_printf (
+    record,
+    "},\"evaluated_gallery_u32\":%u,\"gallery\":[",
     output->evaluated_gallery_count);
   for (guint i = 0; i < output->gallery_results->len; i++)
     {
@@ -483,111 +846,185 @@ goodix_debug_log_runtime_result (FpDevice                         *dev,
 
       if (i != 0)
         g_string_append_c (record, ',');
+      g_string_append (record, "{\"accepted\":");
+      g_string_append (record, result->evaluated
+                                 ? (result->accepted ? "true" : "false")
+                                 : "null");
+      g_string_append (record, ",\"after_match_sha256\":");
+      if (result->after_match_sha256[0])
+        goodix_debug_json_string (record, result->after_match_sha256);
+      else
+        g_string_append (record, "null");
       g_string_append_printf (
         record,
-        "{\"accepted\":%s,\"after_match_sha256\":%s%s%s,"
-        "\"evaluated\":%s,\"gallery_index_u32\":%u,"
+        ",\"evaluated\":%s,\"gallery_index_u32\":%u,"
         "\"gallery_position_u64\":%" G_GSIZE_FORMAT
-        ",\"input_template_sha256\":%s%s%s,"
-        "\"matched_feature_u64\":%" G_GSIZE_FORMAT
-        ",\"queue_counter_u32\":%u,\"queue_eligible_i32\":%d,"
-        "\"queue_occupied_after_u64\":%" G_GSIZE_FORMAT
-        ",\"queue_occupied_before_u64\":%" G_GSIZE_FORMAT
-        ",\"queue_state_u32\":%u,\"score_i32\":%d,\"valid\":%s}",
-        result->accepted ? "true" : "false",
-        result->after_match_sha256[0] ? "\"" : "null",
-        result->after_match_sha256,
-        result->after_match_sha256[0] ? "\"" : "",
+        ",\"input_template_sha256\":",
         result->evaluated ? "true" : "false", result->gallery_index,
-        result->gallery_position,
-        result->input_template_sha256[0] ? "\"" : "null",
-        result->input_template_sha256,
-        result->input_template_sha256[0] ? "\"" : "",
-        result->match_result.matched_feature_index,
-        result->queue_counter_before_match,
-        result->match_result.study_control.queue_candidate_eligible,
-        result->queue_occupied_after_match,
-        result->queue_occupied_before_match,
-        result->queue_state_before_match, result->score,
-        result->valid ? "true" : "false");
+        result->gallery_position);
+      if (result->input_template_sha256[0])
+        goodix_debug_json_string (record, result->input_template_sha256);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"lifecycle_update_feature_mask_u64\":");
+      if (result->evaluated)
+        g_string_append_printf (
+          record, "%" G_GUINT64_FORMAT,
+          result->match_result.lifecycle_update_feature_mask);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"matched_feature_u64\":");
+      if (result->evaluated)
+        g_string_append_printf (record, "%" G_GSIZE_FORMAT,
+                                result->match_result.matched_feature_index);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_counter_after_study_u32\":");
+      if (result->queue_after_study_observed)
+        g_string_append_printf (record, "%u",
+                                result->queue_counter_after_study);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_counter_before_match_u32\":");
+      if (result->queue_before_match_observed)
+        g_string_append_printf (record, "%u",
+                                result->queue_counter_before_match);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_eligible_i32\":");
+      if (result->evaluated)
+        g_string_append_printf (
+          record, "%d",
+          result->match_result.study_control.queue_candidate_eligible);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_occupied_after_match_u64\":");
+      if (result->queue_after_match_observed)
+        g_string_append_printf (record, "%" G_GSIZE_FORMAT,
+                                result->queue_occupied_after_match);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_occupied_after_study_u64\":");
+      if (result->queue_after_study_observed)
+        g_string_append_printf (record, "%" G_GSIZE_FORMAT,
+                                result->queue_occupied_after_study);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_occupied_before_match_u64\":");
+      if (result->queue_before_match_observed)
+        g_string_append_printf (record, "%" G_GSIZE_FORMAT,
+                                result->queue_occupied_before_match);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_state_after_study_u32\":");
+      if (result->queue_after_study_observed)
+        g_string_append_printf (record, "%u", result->queue_state_after_study);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"queue_state_before_match_u32\":");
+      if (result->queue_before_match_observed)
+        g_string_append_printf (record, "%u", result->queue_state_before_match);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"score_i32\":");
+      if (result->evaluated)
+        g_string_append_printf (record, "%d", result->score);
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"valid\":");
+      if (result->validation_observed)
+        g_string_append (record, result->valid ? "true" : "false");
+      else
+        g_string_append (record, "null");
+      g_string_append (record, ",\"validation_error\":");
+      goodix_debug_json_error (record, result->validation_error);
+      g_string_append_c (record, '}');
     }
   g_string_append_printf (
     record,
     "],\"generation_id_u64\":%" G_GUINT64_FORMAT
     ",\"generation_use_index_u64\":%" G_GUINT64_FORMAT
-    ",\"live_raw_sha256\":%s%s%s,"
-    "\"partition0_count_u32\":%u,\"partition1_count_u32\":%u,"
-    "\"probe_record_count_u32\":%u,\"probe_sha256\":%s%s%s,"
-    "\"processed_image_sha256\":%s%s%s,"
-    "\"profile_u16\":%u,\"purpose_u32\":%u,\"quality_i32\":%d,"
-    "\"schema\":\"goodix53x5-runtime-debug/v2\",\"score_i32\":%d,"
-    "\"sensor_subtype_u16\":%u,\"setup_txon_sha256\":%s%s%s,"
-    "\"stage_u32\":%u,\"status_u32\":%u,"
-    "\"study_action_u32\":%u,\"tcode_u16\":%u,"
-    "\"winner_index_u32\":%u,\"winner_position_u64\":%" G_GSIZE_FORMAT "}\n",
-    output->generation_id,
-    metadata->generation_use_index,
-    "\"", metadata->live_raw_sha256, "\"",
-    output->probe_partition0_count,
-    output->probe_partition1_count, output->probe_record_count,
-    probe_sha256 ? "\"" : "null",
-    probe_sha256 ? probe_sha256 : "", probe_sha256 ? "\"" : "",
-    processed_image_sha256 ? "\"" : "null",
-    processed_image_sha256 ? processed_image_sha256 : "",
-    processed_image_sha256 ? "\"" : "",
-    output->profile, (guint) output->purpose, output->quality, output->score,
-    output->sensor_subtype,
-    "\"", metadata->setup_txon_sha256, "\"",
-    stage, (guint) output->status,
-    (guint) output->study_action, output->tcode, output->winner_index,
-    output->winner_position);
+    ",\"invalid_gallery_u32\":%u,\"lifecycle\":{"
+    "\"extraction\":{\"attempted\":%s,\"completed\":%s},"
+    "\"preprocess\":{\"attempted\":%s,\"completed\":%s},"
+    "\"study\":{\"attempted\":%s,\"completed\":%s}},"
+    "\"operation_id\":",
+    output->generation_id, metadata->generation_use_index,
+    output->invalid_gallery_count,
+    output->extraction_attempted ? "true" : "false",
+    output->extraction_completed ? "true" : "false",
+    output->preprocess_attempted ? "true" : "false",
+    output->preprocess_completed ? "true" : "false",
+    output->study_attempted ? "true" : "false",
+    output->study_completed ? "true" : "false");
+  goodix_debug_json_string (record, operation_id);
+  g_string_append_printf (
+    record,
+    ",\"partition0_count_u32\":%u,\"partition1_count_u32\":%u,"
+    "\"preprocess_status_i32\":",
+    output->probe_partition0_count, output->probe_partition1_count);
+  if (output->preprocess_status_available)
+    g_string_append_printf (record, "%d", output->preprocess_status);
+  else
+    g_string_append (record, "null");
+  g_string_append_printf (
+    record,
+    ",\"print_schema\":4,\"probe_record_count_u32\":%u,\"profile_u16\":9,"
+    "\"purpose_u32\":%u,"
+    "\"quality_i32\":",
+    output->probe_record_count, (guint) output->purpose);
+  if (output->preprocess_attempted)
+    g_string_append_printf (record, "%d",
+                            output->preprocess_completed ? output->quality : 0);
+  else
+    g_string_append (record, "null");
+  g_string_append_printf (
+    record,
+    ",\"schema\":\"goodix53x5-runtime-debug/v3\",\"score_i32\":");
+  if (output->evaluated_gallery_count > 0)
+    g_string_append_printf (record, "%d", output->score);
+  else
+    g_string_append (record, "null");
+  g_string_append_printf (
+    record,
+    ",\"sensor_subtype_u16\":12,\"stage_u32\":%u,\"status_u32\":%u,"
+    "\"study_action_u32\":",
+    stage, (guint) output->status);
+  if (output->study_attempted)
+    g_string_append_printf (record, "%u", (guint) output->study_action);
+  else
+    g_string_append (record, "null");
+  g_string_append_printf (
+    record,
+    ",\"tcode_u16\":%u,\"valid_gallery_u32\":%u,"
+    "\"winner_index_u32\":",
+    output->tcode, output->valid_gallery_count);
+  if (output->winner_position != G_MAXSIZE)
+    g_string_append_printf (record, "%u", output->winner_index);
+  else
+    g_string_append (record, "null");
+  g_string_append (record, ",\"winner_position_u64\":");
+  if (output->winner_position != G_MAXSIZE)
+    g_string_append_printf (record, "%" G_GSIZE_FORMAT,
+                            output->winner_position);
+  else
+    g_string_append (record, "null");
+  g_string_append (record, "}\n");
   prefix = g_strdup_printf (
-    "runtime-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT "-%u",
-    action_name,
-    output->action_epoch, output->generation_id, stage);
+    "runtime-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT "-%u-%"
+    G_GUINT64_FORMAT,
+    action_name, output->action_epoch, output->generation_id, stage,
+    chronology);
   record_len = record->len;
   record_data = g_string_free (g_steal_pointer (&record), FALSE);
   bytes = g_byte_array_new_take ((guint8 *) record_data, record_len);
-  goodix_debug_write_dump (
-    prefix, goodix_crypto_crc32_mpeg2 (bytes->data, bytes->len), bytes, "json");
-  if (dump_templates)
-    {
-      g_autofree gchar *template_prefix = NULL;
-
-      template_prefix = g_strdup_printf (
-        "template-probe-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT "-%u",
-        action_name,
-        output->action_epoch, output->generation_id, stage);
-      goodix_debug_write_gbytes (template_prefix, output->probe_template, "bin");
-      g_clear_pointer (&template_prefix, g_free);
-      template_prefix = g_strdup_printf (
-        "template-final-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT "-%u",
-        action_name,
-        output->action_epoch, output->generation_id, stage);
-      goodix_debug_write_gbytes (template_prefix, output->final_candidate, "bin");
-      for (guint i = 0; i < output->gallery_results->len; i++)
-        {
-          GoodixMilanRuntimeGalleryResult *result =
-            g_ptr_array_index (output->gallery_results, i);
-
-          g_clear_pointer (&template_prefix, g_free);
-          template_prefix = g_strdup_printf (
-            "template-input-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT
-            "-%u-%" G_GSIZE_FORMAT,
-            action_name,
-            output->action_epoch, output->generation_id, stage,
-            result->gallery_position);
-          goodix_debug_write_gbytes (
-            template_prefix, result->input_template, "bin");
-          g_clear_pointer (&template_prefix, g_free);
-          template_prefix = g_strdup_printf (
-            "template-after-match-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT
-            "-%u-%" G_GSIZE_FORMAT,
-            action_name,
-            output->action_epoch, output->generation_id, stage,
-            result->gallery_position);
-          goodix_debug_write_gbytes (
-            template_prefix, result->after_match_template, "bin");
-        }
-    }
+  if (goodix_debug_write_dump (
+        prefix, goodix_crypto_crc32_mpeg2 (bytes->data, bytes->len), bytes,
+        "json"))
+    self->debug_chronology = chronology;
+  goodix_debug_artifact_free (final_candidate_artifact);
+  goodix_debug_artifact_free (live_raw_artifact);
+  goodix_debug_artifact_free (native_probe_artifact);
+  goodix_debug_artifact_free (processed_image_artifact);
+  goodix_debug_artifact_free (setup_tx_on_artifact);
 }

--- a/drivers/goodix53x5/device/debug.h
+++ b/drivers/goodix53x5/device/debug.h
@@ -18,16 +18,16 @@ typedef struct _GoodixMilanRuntimeOutput GoodixMilanRuntimeOutput;
 #ifdef GOODIX53X5_DEBUG
 
 /* The diagnostic build recognizes:
- * GOODIX53X5_DUMP_DIR, GOODIX53X5_DUMP_PROBES, GOODIX53X5_LOG_TIMING, and
- * GOODIX53X5_LOG_DIAGNOSTICS. */
+ * GOODIX53X5_DUMP_DIR, GOODIX53X5_DUMP_PROBES, GOODIX53X5_DUMP_TEMPLATES,
+ * GOODIX53X5_LOG_TIMING, and GOODIX53X5_LOG_DIAGNOSTICS. */
 #define GOODIX53X5_DEBUG_ONLY(...) __VA_ARGS__
 
 typedef struct
 {
   FpiDeviceAction action;
   guint64         generation_use_index;
-  gchar           setup_txon_sha256[65];
-  gchar           live_raw_sha256[65];
+  GBytes         *setup_tx_on;
+  GBytes         *live_raw;
 } GoodixDebugRuntimeMetadata;
 
 typedef struct
@@ -90,11 +90,14 @@ void goodix_debug_capture_runtime_metadata (
   const guint16              *setup_tx_on,
   const guint16              *live_raw,
   guint64                     generation_use_index);
+void goodix_debug_clear_runtime_metadata (
+  GoodixDebugRuntimeMetadata *metadata);
 void goodix_debug_log_runtime_result (
   FpDevice                       *dev,
   guint                           stage,
   const GoodixDebugRuntimeMetadata *metadata,
-  const GoodixMilanRuntimeOutput *output);
+  const GoodixMilanRuntimeOutput *output,
+  gboolean                        driver_cancellation_observed);
 
 #else
 
@@ -111,6 +114,7 @@ void goodix_debug_log_runtime_result (
 #define goodix_debug_timing_action_done(...) G_STMT_START { } G_STMT_END
 #define goodix_debug_timing_open_state(...) G_STMT_START { } G_STMT_END
 #define goodix_debug_timing_open_done(...) G_STMT_START { } G_STMT_END
+#define goodix_debug_clear_runtime_metadata(...) G_STMT_START { } G_STMT_END
 #define goodix_debug_log_runtime_result(...) G_STMT_START { } G_STMT_END
 
 #endif

--- a/drivers/goodix53x5/device/enroll.c
+++ b/drivers/goodix53x5/device/enroll.c
@@ -42,10 +42,12 @@ typedef struct
 static void
 goodix_enroll_log_runtime_result (FpDevice                         *dev,
                                   GoodixEnrollTaskData              *data,
-                                  const GoodixMilanRuntimeOutput   *output)
+                                  const GoodixMilanRuntimeOutput   *output,
+                                  gboolean driver_cancellation_observed)
 {
   goodix_debug_log_runtime_result (dev, data->stage + 1,
-                                   &data->debug_metadata, output);
+                                    &data->debug_metadata, output,
+                                    driver_cancellation_observed);
 }
 #else
 #define goodix_enroll_log_runtime_result(...) G_STMT_START { } G_STMT_END
@@ -57,6 +59,8 @@ goodix_enroll_task_data_free (GoodixEnrollTaskData *data)
   if (!data)
     return;
   goodix_milan_runtime_input_free (data->runtime_input);
+  GOODIX53X5_DEBUG_ONLY (
+    goodix_debug_clear_runtime_metadata (&data->debug_metadata);)
   g_free (data);
 }
 
@@ -142,7 +146,7 @@ goodix_enroll_task_done (GObject      *source_object,
   if (!action_owned)
     {
       if (output)
-        goodix_enroll_log_runtime_result (dev, data, output);
+        goodix_enroll_log_runtime_result (dev, data, output, FALSE);
       goodix_milan_runtime_output_free (output);
       g_clear_pointer (&self->captured_raw_image, g_free);
       if (task_owned && self->profile9_fdt.owner)
@@ -151,10 +155,19 @@ goodix_enroll_task_done (GObject      *source_object,
       return;
     }
 
+  if (generation_current && output &&
+      output->action_epoch == data->action_epoch &&
+      output->generation_id == data->generation_id &&
+      output->preprocess_state_valid)
+    {
+      self->milan_generation->state = output->preprocess_state;
+      self->milan_generation->profile_state = output->profile_state;
+    }
+
   if (cancelled)
     {
       if (output)
-        goodix_enroll_log_runtime_result (dev, data, output);
+        goodix_enroll_log_runtime_result (dev, data, output, TRUE);
       goodix_milan_runtime_output_free (output);
       g_clear_pointer (&self->captured_raw_image, g_free);
       goodix_scan_set_disposition (dev, GOODIX_SCAN_DISPOSITION_CANCELLED,
@@ -177,11 +190,6 @@ goodix_enroll_task_done (GObject      *source_object,
       return;
     }
 
-  if (generation_current && output->preprocess_state_valid)
-    {
-      self->milan_generation->state = output->preprocess_state;
-      self->milan_generation->profile_state = output->profile_state;
-    }
   GOODIX53X5_DEBUG_ONLY (goodix_enroll_set_processed_image (self, output);)
   enrollment_admitted = goodix_milan_runtime_enrollment_admitted (output);
 
@@ -263,7 +271,7 @@ goodix_enroll_task_done (GObject      *source_object,
       GError *error = fpi_device_error_new_msg (
         FP_DEVICE_ERROR_GENERAL, "Native Milan enrollment extraction failed");
 
-      goodix_enroll_log_runtime_result (dev, data, output);
+      goodix_enroll_log_runtime_result (dev, data, output, FALSE);
       goodix_milan_runtime_output_free (output);
 #ifdef GOODIX53X5_DEBUG
       g_clear_pointer (&self->captured_image, g_free);
@@ -273,7 +281,7 @@ goodix_enroll_task_done (GObject      *source_object,
       return;
     }
 
-  goodix_enroll_log_runtime_result (dev, data, output);
+  goodix_enroll_log_runtime_result (dev, data, output, FALSE);
   goodix_milan_runtime_output_free (output);
 #ifdef GOODIX53X5_DEBUG
   g_clear_pointer (&self->captured_image, g_free);

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -159,6 +159,7 @@ struct _FpiDeviceGoodix53x5
 #ifdef GOODIX53X5_DEBUG
   GoodixDebugTiming debug_timing;
   gchar             debug_capture_session_id[37];
+  guint64           debug_chronology;
 #endif
 
   /* Enrollment tracking */

--- a/drivers/goodix53x5/meson.build
+++ b/drivers/goodix53x5/meson.build
@@ -58,6 +58,18 @@ goodix53x5_sources = files(
 
 goodix53x5_cflags = [ '-I' + meson.current_source_dir() ]
 if get_option('goodix53x5_debug')
+    goodix53x5_debug_build_id = get_option('goodix53x5_debug_build_id')
+    goodix53x5_debug_source_id = get_option('goodix53x5_debug_source_id')
+    if goodix53x5_debug_build_id == ''
+        error('goodix53x5_debug requires goodix53x5_debug_build_id')
+    endif
+    if goodix53x5_debug_source_id == ''
+        error('goodix53x5_debug requires goodix53x5_debug_source_id')
+    endif
     goodix53x5_sources += files('device/debug.c')
-    goodix53x5_cflags += [ '-DGOODIX53X5_DEBUG' ]
+    goodix53x5_cflags += [
+        '-DGOODIX53X5_DEBUG',
+        '-DGOODIX53X5_DEBUG_BUILD_ID="' + goodix53x5_debug_build_id + '"',
+        '-DGOODIX53X5_DEBUG_SOURCE_ID="' + goodix53x5_debug_source_id + '"',
+    ]
 endif

--- a/drivers/goodix53x5/milan/antifake/construction.c
+++ b/drivers/goodix53x5/milan/antifake/construction.c
@@ -116,6 +116,8 @@ milan_antifake_build_class (
       columns > SIZE_MAX / rows)
     return -1;
   count = rows * columns;
+  if (count > SIZE_MAX / sizeof(*residual))
+    return -1;
   residual = malloc (count * sizeof(*residual));
   mask = malloc (count);
   classes = malloc (count);

--- a/drivers/goodix53x5/milan/antifake/signal.c
+++ b/drivers/goodix53x5/milan/antifake/signal.c
@@ -24,11 +24,16 @@ goodix_milan_antifake_residual (
   uint16_t        chip_type,
   uint16_t       *residual)
 {
+  size_t count;
+
   if (!calibration || !raw_frame || !residual || rows < 2 || columns < 2 ||
       columns > SIZE_MAX / rows)
     return -1;
+  count = rows * columns;
+  if (count > SIZE_MAX / sizeof(*residual))
+    return -1;
 
-  memset (residual, 0, rows * columns * sizeof(*residual));
+  memset (residual, 0, count * sizeof(*residual));
   for (size_t row = 1; row + 1 < rows; row++)
     for (size_t column = 1; column + 1 < columns; column++)
       {
@@ -166,24 +171,40 @@ goodix_milan_antifake_impulse_filter (
           }
         if (sorted_roughness[4] * 5 <= roughness[4] * 2)
           {
-            ptrdiff_t center_x = (ptrdiff_t) column;
-            ptrdiff_t center_y = (ptrdiff_t) row;
             uint16_t neighborhood[9];
             size_t neighborhood_index = 0;
+            size_t count = rows * columns;
 
-            if (center_x < 1)
-              center_x = 1;
-            if (center_x > (ptrdiff_t) columns - 2)
-              center_x = (ptrdiff_t) columns - 2;
-            if (center_y < 1)
-              center_y = 1;
-            if (center_y > (ptrdiff_t) rows - 2)
-              center_y = (ptrdiff_t) rows - 2;
-            for (ptrdiff_t dy = -1; dy <= 1; dy++)
-              for (ptrdiff_t dx = -1; dx <= 1; dx++)
-                neighborhood[neighborhood_index++] =
-                  residual[(size_t) (center_y + dy) * columns +
-                           (size_t) (center_x + dx)];
+            /*
+             * Vendor replacement uses flat adjacency, so edge columns intentionally
+             * wrap; only allocation-end offsets use the safe coordinate-clamped
+             * fallback.
+             */
+            if (pixel >= columns + 1 && pixel + columns + 1 < count)
+              for (ptrdiff_t dy = -1; dy <= 1; dy++)
+                for (ptrdiff_t dx = -1; dx <= 1; dx++)
+                  neighborhood[neighborhood_index++] = residual[
+                    (size_t) ((ptrdiff_t) pixel +
+                              dy * (ptrdiff_t) columns + dx)];
+            else
+              {
+                ptrdiff_t center_x = (ptrdiff_t) column;
+                ptrdiff_t center_y = (ptrdiff_t) row;
+
+                if (center_x < 1)
+                  center_x = 1;
+                if (center_x > (ptrdiff_t) columns - 2)
+                  center_x = (ptrdiff_t) columns - 2;
+                if (center_y < 1)
+                  center_y = 1;
+                if (center_y > (ptrdiff_t) rows - 2)
+                  center_y = (ptrdiff_t) rows - 2;
+                for (ptrdiff_t dy = -1; dy <= 1; dy++)
+                  for (ptrdiff_t dx = -1; dx <= 1; dx++)
+                    neighborhood[neighborhood_index++] =
+                      residual[(size_t) (center_y + dy) * columns +
+                               (size_t) (center_x + dx)];
+              }
             residual[pixel] = antifake_median9_u16 (neighborhood);
           }
       }

--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -23,6 +23,9 @@
 #define MILAN_FIXED_ONE UINT32_C(0x2000)
 #define MILAN_PROFILE9_SETUP_OFFSET UINT16_C(7095)
 #define MILAN_PROFILE9_UPDATE_BASE UINT16_C(9000)
+#define MILAN_PROFILE9_RAW_ADMISSION_SAMPLE_MIN_EXCLUSIVE UINT16_C(100)
+#define MILAN_PROFILE9_RAW_ADMISSION_SAMPLE_MAX_EXCLUSIVE UINT16_C(0x0ed8)
+#define MILAN_PROFILE9_RAW_ADMISSION_REQUIRED_PERCENT 15
 
 static const uint16_t milan_update_kernel[5] = {
   7869, 15328, 19142, 15328, 7869,
@@ -55,6 +58,9 @@ static void profile9_update_source (const uint16_t *normalized_live,
 static int profile9_normalize_live (uint16_t *frame,
                                     size_t    rows,
                                     size_t    columns);
+static int milan_profile9_live_frame_admitted (const uint16_t *frame,
+                                                size_t          rows,
+                                                size_t          columns);
 static void milan_profile9_encode_metadata (uint8_t       *image,
                                             const uint8_t *mask,
                                             size_t         rows,
@@ -145,6 +151,8 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
        purpose != GOODIX_MILAN_PURPOSE_ENROLL) ||
       !output || !quality || !coverage)
     return -1;
+  *quality = 0;
+  *coverage = 0;
   setup_map = malloc (count * sizeof(*setup_map));
   normalized_live = malloc (count * sizeof(*normalized_live));
   difference = malloc (count * sizeof(*difference));
@@ -162,14 +170,24 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
       !contrast_mask || !selection_mask)
     goto out;
 
+  memcpy (setup_map, setup_frame, count * sizeof(*setup_map));
+  memcpy (normalized_live, live_frame, count * sizeof(*normalized_live));
   for (size_t i = 0; i < count; i++)
     {
-      if (setup_frame[i] > MILAN_ADC_MAX || live_frame[i] > MILAN_ADC_MAX)
-        goto out;
+      if (setup_map[i] > MILAN_ADC_MAX)
+        setup_map[i] = MILAN_ADC_MAX;
+      if (normalized_live[i] > MILAN_ADC_MAX)
+        normalized_live[i] = MILAN_ADC_MAX;
     }
-  memcpy (normalized_live, live_frame, count * sizeof(*normalized_live));
+  if (!milan_profile9_live_frame_admitted (
+        normalized_live, GOODIX_MILAN_SENSOR_ROWS,
+        GOODIX_MILAN_SENSOR_COLUMNS))
+    {
+      result = GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION;
+      goto out;
+    }
   if (goodix_milan_preprocess_make_setup_map (
-        setup_frame, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
+        setup_map, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
         setup_map, &rounded_mean) != 0 ||
       profile9_normalize_live (
         normalized_live, GOODIX_MILAN_SENSOR_ROWS,
@@ -225,7 +243,7 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
   admitted_percent = (uint16_t) (admitted_pixels * 100 / count);
 
   if (goodix_milan_profile9_build_broken_mask (
-        state, difference, normalized_live, contrast_mask,
+        state, difference, setup_map, normalized_live, contrast_mask,
         GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, broken_mask,
         NULL, &metadata_mode, &apply_metadata_mask) != 0)
     goto out;
@@ -283,6 +301,29 @@ static int
 is_invalid_border_sample (uint16_t sample)
 {
   return sample == 0 || sample == MILAN_ADC_MAX;
+}
+
+static int
+milan_profile9_live_frame_admitted (const uint16_t *frame,
+                                     size_t          rows,
+                                     size_t          columns)
+{
+  size_t samples = 0;
+  size_t admitted = 0;
+
+  if (!frame || rows <= 4 || columns <= 4)
+    return 0;
+  for (size_t row = 2; row < rows - 2; row++)
+    for (size_t column = 2; column < columns - 2; column++)
+      {
+        uint16_t sample = frame[row * columns + column];
+
+        samples++;
+        admitted += sample > MILAN_PROFILE9_RAW_ADMISSION_SAMPLE_MIN_EXCLUSIVE &&
+                    sample < MILAN_PROFILE9_RAW_ADMISSION_SAMPLE_MAX_EXCLUSIVE;
+      }
+  return samples * MILAN_PROFILE9_RAW_ADMISSION_REQUIRED_PERCENT <
+         admitted * 100;
 }
 
 int

--- a/drivers/goodix53x5/milan/match/info-private.h
+++ b/drivers/goodix53x5/milan/match/info-private.h
@@ -18,6 +18,7 @@ typedef struct
   int quality;
   int coverage;
   int32_t optional_c7;
+  GoodixMilanExtractionAuxiliaryState auxiliary;
 } GoodixMilanExtractionMetadata;
 
 typedef struct
@@ -43,7 +44,8 @@ struct _GoodixMatchInfo
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanExtractionMetadata, quality) == 0);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanExtractionMetadata, coverage) == 4);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanExtractionMetadata, optional_c7) == 8);
-G_STATIC_ASSERT (sizeof(GoodixMilanExtractionMetadata) == 12);
+G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanExtractionMetadata, auxiliary) == 12);
+G_STATIC_ASSERT (sizeof(GoodixMilanExtractionMetadata) == 16);
 G_STATIC_ASSERT (G_ALIGNOF (GoodixMilanExtractionMetadata) == 4);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanFeatureBitmaps, high_bitmap) == 0);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMilanFeatureBitmaps, enhanced_bitmap) == 286);
@@ -65,5 +67,20 @@ G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMatchInfo, extraction_metadata) == 8112)
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMatchInfo, extraction_metadata.quality) == 8112);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMatchInfo, extraction_metadata.coverage) == 8116);
 G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMatchInfo, extraction_metadata.optional_c7) == 8120);
+G_STATIC_ASSERT (G_STRUCT_OFFSET (GoodixMatchInfo, extraction_metadata.auxiliary) == 8124);
 G_STATIC_ASSERT (sizeof(GoodixMatchInfo) == 8128);
 G_STATIC_ASSERT (G_ALIGNOF (GoodixMatchInfo) == 8);
+
+int goodix_milan_match_info_result (
+  const GoodixMatchInfo          *probe,
+  const uint8_t                 *enrolled_template,
+  size_t                         enrolled_template_size,
+  const GoodixMilanFeatureRecord *const live_records[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  const size_t                   live_record_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  const size_t                   live_partition_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  size_t                         triggering_index,
+  GoodixMilanMatchResult        *match_result
+#ifdef GOODIX53X5_DEBUG
+  , GoodixMilanMatchDiagnostics *diagnostics
+#endif
+  );

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -49,9 +49,262 @@ goodix_match_record_limit (guint16 sensor_subtype,
   return ((size_t) coverage * configured_limit + 50) / 100;
 }
 
+static void
+goodix_match_retain_class_components (
+  guint8 mask[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
+  guint  maximum_label,
+  guint  strict_size_floor,
+  gint  *labels,
+  gint  *queue)
+{
+  guint component_sizes[72] = { 0 };
+  guint selected_labels[3] = { 0 };
+  guint label_count = 0;
+
+  memset (labels, 0xff,
+          GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS * sizeof(*labels));
+  for (guint seed = 0;
+       seed < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
+       seed++)
+    {
+      guint begin = 0;
+      guint end = 0;
+
+      if (labels[seed] != -1)
+        continue;
+      if (mask[seed] == 0)
+        {
+          labels[seed] = 0;
+          continue;
+        }
+      if (label_count == maximum_label)
+        break;
+      label_count++;
+      labels[seed] = (gint) label_count;
+      queue[end++] = (gint) seed;
+      while (begin < end)
+        {
+          gint current = queue[begin++];
+          gint row = current / GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
+          gint column = current % GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
+          static const gint dx[4] = { -1, 0, 1, 0 };
+          static const gint dy[4] = { 0, -1, 0, 1 };
+
+          component_sizes[label_count]++;
+          for (guint direction = 0; direction < 4; direction++)
+            {
+              gint x = column + dx[direction];
+              gint y = row + dy[direction];
+              gint neighbor;
+
+              if (x < 0 ||
+                  x >= GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS ||
+                  y < 0 || y >= GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS)
+                continue;
+              neighbor =
+                y * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS + x;
+              if (labels[neighbor] != -1)
+                continue;
+              if (mask[neighbor] == 0)
+                {
+                  labels[neighbor] = 0;
+                  continue;
+                }
+              labels[neighbor] = (gint) label_count;
+              queue[end++] = neighbor;
+            }
+        }
+    }
+
+  for (guint slot = 0; slot < G_N_ELEMENTS (selected_labels); slot++)
+    {
+      guint best_size = strict_size_floor;
+
+      for (guint label = 1; label <= label_count; label++)
+        if (component_sizes[label] > best_size)
+          {
+            selected_labels[slot] = label;
+            best_size = component_sizes[label];
+          }
+      if (selected_labels[slot] != 0)
+        component_sizes[selected_labels[slot]] = 0;
+    }
+
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    mask[i] = (selected_labels[0] != 0 &&
+               labels[i] == (gint) selected_labels[0]) ||
+              (selected_labels[1] != 0 &&
+               labels[i] == (gint) selected_labels[1]) ||
+              (selected_labels[2] != 0 &&
+               labels[i] == (gint) selected_labels[2])
+                ? UINT8_MAX : 0;
+}
+
+static gint32
+goodix_match_update_extraction_classification (
+  GoodixMilanExtractionClassificationState *state,
+  const guint8 classification_source[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
+  const guint8 cropped_primary_contrast[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
+  const guint8 auxiliary[3],
+  gint         coverage,
+  gint32       entry_low_class,
+  gint32       entry_high_class)
+{
+  g_autofree guint8 *component_mask = g_malloc (
+    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  g_autofree guint8 *current_classes = g_malloc0 (
+    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  g_autofree guint8 *stable_classes = g_malloc0 (
+    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  g_autofree gint *labels = g_new (gint,
+                                   GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  g_autofree gint *queue = g_new (gint,
+                                  GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  guint stable_class1_count = 0;
+  guint stable_class2_count = 0;
+  gint32 current_class = auxiliary[0];
+  gint32 high_class;
+  gint32 packed;
+  gboolean append;
+
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    component_mask[i] = classification_source[i] < 0x80 ? UINT8_MAX : 0;
+  goodix_match_retain_class_components (
+    component_mask, 71, 500, labels, queue);
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    if (component_mask[i] != 0)
+      current_classes[i] = 1;
+
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    component_mask[i] = classification_source[i] >= 0x80 &&
+                         cropped_primary_contrast[i] != 0 ? UINT8_MAX : 0;
+  goodix_match_retain_class_components (
+    component_mask, 71, 500, labels, queue);
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    if (component_mask[i] != 0)
+      current_classes[i] = 2;
+
+  if (state->retained_count == 3)
+    for (guint class_value = 1; class_value <= 2; class_value++)
+      {
+        for (guint i = 0;
+             i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
+             i++)
+          component_mask[i] =
+            current_classes[i] == class_value &&
+            state->retained_class_planes[0][i] == class_value &&
+            state->retained_class_planes[1][i] == class_value &&
+            state->retained_class_planes[2][i] == class_value
+              ? UINT8_MAX : 0;
+        goodix_match_retain_class_components (
+          component_mask, 31, 350, labels, queue);
+        for (guint i = 0;
+             i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
+             i++)
+          if (component_mask[i] != 0 && stable_classes[i] == 0)
+            stable_classes[i] = (guint8) class_value;
+      }
+
+  for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
+    {
+      stable_class1_count += stable_classes[i] == 1;
+      stable_class2_count += stable_classes[i] == 2;
+    }
+  if (stable_class1_count > 600)
+    {
+      if (current_class <= 2)
+        current_class += 3;
+    }
+  else if (stable_class2_count > 600)
+    {
+      if (current_class == 0)
+        current_class = 3;
+    }
+  else if ((stable_class1_count > 300 || stable_class2_count > 300) &&
+           current_class == 0)
+    current_class = 2;
+
+  high_class = MAX (entry_high_class, current_class);
+  if (high_class < 2 && auxiliary[2] > 0)
+    high_class++;
+  if (auxiliary[1] == 2)
+    high_class = MAX (high_class, state->prior_merged_high_class);
+  else if (high_class > 1 || current_class > 1 || auxiliary[2] > 1)
+    {
+      if (state->high_class_hysteresis < 5)
+        state->high_class_hysteresis++;
+    }
+  else if (state->high_class_hysteresis != 0)
+    state->high_class_hysteresis--;
+  state->prior_merged_high_class = high_class;
+  if (state->high_class_hysteresis >= 3)
+    high_class = MAX (high_class, 1);
+  packed = high_class * 0x100 + entry_low_class;
+
+  if (auxiliary[1] == 2)
+    append = state->prior_coverage < 75;
+  else
+    {
+      state->prior_coverage = coverage;
+      append = coverage >= 75;
+    }
+  if (append)
+    {
+      if (state->retained_count < 3)
+        memcpy (state->retained_class_planes[state->retained_count],
+                current_classes,
+                GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+      else
+        {
+          memcpy (state->retained_class_planes[0],
+                  state->retained_class_planes[1],
+                  GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+          memcpy (state->retained_class_planes[1],
+                  state->retained_class_planes[2],
+                  GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+          memcpy (state->retained_class_planes[2], current_classes,
+                  GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+        }
+      if (state->retained_count < 3)
+        state->retained_count++;
+    }
+  return packed;
+}
+
+static void
+goodix_match_decode_entry_classes (const guint8 *image,
+                                   gint32       *packed,
+                                   gint32       *low_class,
+                                   gint32       *high_class)
+{
+  static const gint32 low_classes[4] = { 0, 2, 2, 3 };
+  static const gint32 high_classes[8] = { 0, 1, 2, 4, 5, 5, 0, 0 };
+  const guint metadata_start = GOODIX_MILAN_SENSOR_COLUMNS - 8;
+  guint32 raw_low;
+  guint32 raw_high;
+
+  *packed = 0;
+  *low_class = 0;
+  *high_class = 0;
+  for (guint column = 0; column < metadata_start; column++)
+    if ((image[column] & 1) != (column & 1))
+      return;
+  raw_low = (image[metadata_start] & 1) != 0
+              ? ((image[metadata_start + 1] & 1) != 0 ? 2 : 1)
+              : ((image[metadata_start + 1] & 1) != 0 ? 3 : 0);
+  raw_high = (image[metadata_start + 3] & 1) |
+             ((image[metadata_start + 4] & 1) << 1) |
+             ((image[metadata_start + 5] & 1) << 2);
+  *packed = (gint32) (raw_low + (raw_high << 8));
+  *low_class = low_classes[raw_low];
+  *high_class = high_classes[raw_high];
+}
+
 static GoodixMilanExtractionStatus goodix_match_extract_planes (
   const guint8  *image,
-  const guint8  *antifake_classification_plane,
+  const guint8  *primary_contrast_plane,
+  GoodixMilanExtractionClassificationState *classification_state,
+  const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
   const guint16 *calibration,
   const guint16 *raw_frame,
   guint16        t_code,
@@ -81,13 +334,13 @@ goodix_match_hash_projection (
 #endif
 
 GoodixMatchInfo *
-goodix_match_extract_native (const guint8                     *image,
-                             const GoodixMilanPreprocessState *preprocess_state,
-                             const guint16                    *raw_frame,
-                             guint16                           t_code,
-                             guint16                           dac_high,
-                             guint16                           dac_low,
-                             guint16                           sensor_subtype)
+goodix_match_extract_native (const guint8               *image,
+                             GoodixMilanPreprocessState *preprocess_state,
+                             const guint16              *raw_frame,
+                             guint16                     t_code,
+                             guint16                     dac_high,
+                             guint16                     dac_low,
+                             guint16                     sensor_subtype)
 {
   GoodixMatchInfo *info = NULL;
 
@@ -99,14 +352,14 @@ goodix_match_extract_native (const guint8                     *image,
 
 GoodixMilanExtractionStatus
 goodix_match_extract_native_result (
-  const guint8                     *image,
-  const GoodixMilanPreprocessState *preprocess_state,
-  const guint16                    *raw_frame,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype,
-  GoodixMatchInfo                 **info)
+  const guint8               *image,
+  GoodixMilanPreprocessState *preprocess_state,
+  const guint16              *raw_frame,
+  guint16                     t_code,
+  guint16                     dac_high,
+  guint16                     dac_low,
+  guint16                     sensor_subtype,
+  GoodixMatchInfo           **info)
 {
   if (info)
     *info = NULL;
@@ -115,7 +368,9 @@ goodix_match_extract_native_result (
     return GOODIX_MILAN_EXTRACTION_INVALID;
 
   return goodix_match_extract_planes (
-    image, preprocess_state->primary_contrast, preprocess_state->setup_map,
+    image, preprocess_state->primary_contrast,
+    &preprocess_state->extraction_classification,
+    &preprocess_state->extraction_auxiliary, preprocess_state->setup_map,
     raw_frame, t_code, dac_high, dac_low, sensor_subtype,
     preprocess_state->selected_refined, info
 #ifdef GOODIX53X5_DEBUG
@@ -127,14 +382,14 @@ goodix_match_extract_native_result (
 #ifdef GOODIX53X5_DEBUG
 GoodixMilanExtractionStatus
 goodix_match_extract_native_result_debug (
-  const guint8                     *image,
-  const GoodixMilanPreprocessState *preprocess_state,
-  const guint16                    *raw_frame,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype,
-  GoodixMatchInfo                 **info,
+  const guint8               *image,
+  GoodixMilanPreprocessState *preprocess_state,
+  const guint16              *raw_frame,
+  guint16                     t_code,
+  guint16                     dac_high,
+  guint16                     dac_low,
+  guint16                     sensor_subtype,
+  GoodixMatchInfo           **info,
   GoodixMilanExtractionDiagnostics *diagnostics)
 {
   if (info)
@@ -146,7 +401,9 @@ goodix_match_extract_native_result_debug (
     return GOODIX_MILAN_EXTRACTION_INVALID;
 
   return goodix_match_extract_planes (
-    image, preprocess_state->primary_contrast, preprocess_state->setup_map,
+    image, preprocess_state->primary_contrast,
+    &preprocess_state->extraction_classification,
+    &preprocess_state->extraction_auxiliary, preprocess_state->setup_map,
     raw_frame, t_code, dac_high, dac_low, sensor_subtype,
     preprocess_state->selected_refined, info, diagnostics);
 }
@@ -154,7 +411,9 @@ goodix_match_extract_native_result_debug (
 
 static GoodixMilanExtractionStatus
 goodix_match_extract_planes (const guint8  *image,
-                             const guint8  *antifake_classification_plane,
+                             const guint8  *primary_contrast_plane,
+                             GoodixMilanExtractionClassificationState *classification_state,
+                             const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
                              const guint16 *calibration,
                              const guint16 *raw_frame,
                              guint16        t_code,
@@ -173,6 +432,7 @@ goodix_match_extract_planes (const guint8  *image,
   g_autofree GoodixMilanAntifakeBlob *diagnostic_antifake = NULL;
 #endif
   guint8 *cropped = NULL;
+  guint8 *cropped_primary_contrast = NULL;
   guint8 *high = NULL;
   guint8 *low = NULL;
   guint8 *feature_mask = NULL;
@@ -192,20 +452,29 @@ goodix_match_extract_planes (const guint8  *image,
   size_t feature_element_size = 0;
   size_t milan_template_size = 0;
   guint8 enhanced_threshold;
+  guint8 auxiliary[3];
+  gint32 entry_low_class;
+  gint32 entry_high_class;
   int quality;
   int coverage;
   GoodixMilanExtractionStatus status = GOODIX_MILAN_EXTRACTION_INVALID;
 
   *result = NULL;
-  if (!image || !antifake_classification_plane)
+  if (!image || !primary_contrast_plane || !classification_state ||
+      !auxiliary_state)
     return status;
+  auxiliary[0] = auxiliary_state->primary_histogram_state;
+  auxiliary[1] = auxiliary_state->prior_selected_plane;
+  auxiliary[2] = auxiliary_state->promoted_secondary_histogram_state;
   info = g_new0 (GoodixMatchInfo, 1);
-  cropped = g_malloc (104 * 88);
+  cropped = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  cropped_primary_contrast = g_malloc (
+    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   high = g_malloc0 (286);
   low = g_malloc0 (286);
   feature_mask = g_malloc0 (52 * 44);
-  orientation = g_malloc (104 * 88);
-  enhanced = g_malloc (104 * 88);
+  orientation = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
+  enhanced = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   enhanced_bitmap = g_malloc0 (286);
   inline_mask = g_malloc0 (72);
   antifake = g_malloc0 (sizeof(*antifake));
@@ -213,9 +482,20 @@ goodix_match_extract_planes (const guint8  *image,
   feature_element = g_malloc (7945 + 150 * 32 + GOODIX_MILAN_OPTIONAL_C7_LEN);
   milan_template = g_malloc (7945 + 150 * 32 + GOODIX_MILAN_OPTIONAL_C7_LEN +
                              1433);
-  for (size_t row = 0; row < 88; row++)
-    memcpy (cropped + row * 104,
-            image + row * GOODIX_MILAN_SENSOR_COLUMNS + 2, 104);
+  for (size_t row = 0;
+       row < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS;
+       row++)
+    {
+      memcpy (cropped +
+                row * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
+              image + row * GOODIX_MILAN_SENSOR_COLUMNS + 2,
+              GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS);
+      memcpy (cropped_primary_contrast +
+                row * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
+              primary_contrast_plane +
+                row * GOODIX_MILAN_SENSOR_COLUMNS + 2,
+              GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS);
+    }
   if (goodix_milan_preprocess_quality (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
         &quality, &coverage) != 0)
@@ -228,15 +508,25 @@ goodix_match_extract_planes (const guint8  *image,
         cropped, 88, 104, orientation, enhanced) != 0 ||
       goodix_milan_feature_enhanced_bitmap (
         enhanced, feature_mask, 88, 104, enhanced_bitmap,
-        &enhanced_threshold) != 0 ||
-      goodix_milan_feature_extract_records_mode (
+        &enhanced_threshold) != 0)
+    goto out;
+  if (sensor_subtype == 12)
+    {
+      goodix_match_decode_entry_classes (
+        image, &fields.optional_c7, &entry_low_class, &entry_high_class);
+      /* Native commits history before record extraction, anti-fake, or packing
+       * failures. */
+      fields.optional_c7 = goodix_match_update_extraction_classification (
+        classification_state, cropped, cropped_primary_contrast, auxiliary,
+        coverage, entry_low_class, entry_high_class);
+    }
+  if (goodix_milan_feature_extract_records_mode (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, records,
-        record_limit,
-        &record_count, &zero_count, 1) != 0)
+        record_limit, &record_count, &zero_count, 1) != 0)
     goto out;
   if (calibration && raw_frame &&
       goodix_milan_antifake_build (
-        calibration, raw_frame, antifake_classification_plane, feature_mask,
+        calibration, raw_frame, primary_contrast_plane, feature_mask,
         52 * 44,
         GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, t_code, dac_high,
         dac_low,
@@ -249,7 +539,7 @@ goodix_match_extract_planes (const guint8  *image,
     {
       GoodixMilanAntifakeBoundaryResult boundary = { 0 };
       int diagnostic_status = goodix_milan_antifake_build_with_boundary (
-        calibration, raw_frame, antifake_classification_plane, feature_mask,
+        calibration, raw_frame, primary_contrast_plane, feature_mask,
         52 * 44, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, t_code,
         dac_high, dac_low, sensor_subtype, calibration_scalar, diagnostic_antifake,
         sizeof(*diagnostic_antifake), &boundary);
@@ -276,30 +566,6 @@ goodix_match_extract_planes (const guint8  *image,
   fields.tagged_values[2] = (int32_t) zero_count;
   fields.tagged_values[3] = quality;
   fields.tagged_values[4] = coverage;
-  if (sensor_subtype == 12)
-    {
-      size_t metadata_start = GOODIX_MILAN_SENSOR_COLUMNS - 8;
-      gboolean metadata_present = TRUE;
-
-      for (size_t column = 0; column < metadata_start; column++)
-        if ((image[column] & 1) != (column & 1))
-          {
-            metadata_present = FALSE;
-            break;
-          }
-      if (metadata_present)
-        {
-          guint32 low_bits = image[metadata_start] & 1;
-          guint32 high_bits = image[metadata_start + 1] & 1;
-          guint32 low_value = low_bits ? (high_bits ? 2 : 1)
-                                       : (high_bits ? 3 : 0);
-          guint32 high_value = (image[metadata_start + 3] & 1) |
-                               ((image[metadata_start + 4] & 1) << 1) |
-                               ((image[metadata_start + 5] & 1) << 2);
-
-          fields.optional_c7 = (int32_t) (low_value + (high_value << 8));
-        }
-    }
   if (goodix_milan_template_pack_feature_element (
         high, enhanced_bitmap, inline_mask, low, records, record_count,
         antifake, &fields, feature_element,
@@ -328,6 +594,7 @@ goodix_match_extract_planes (const guint8  *image,
   info->extraction_metadata.quality = quality;
   info->extraction_metadata.coverage = coverage;
   info->extraction_metadata.optional_c7 = fields.optional_c7;
+  info->extraction_metadata.auxiliary = *auxiliary_state;
   records = NULL;
   status = GOODIX_MILAN_EXTRACTION_OK;
 
@@ -343,6 +610,7 @@ out:
   g_free (feature_mask);
   g_free (low);
   g_free (high);
+  g_free (cropped_primary_contrast);
   g_free (cropped);
   if (!info->template)
     g_clear_pointer (&info, g_free);
@@ -414,9 +682,7 @@ goodix_match_info_copy (GoodixMatchInfo       *destination,
   memcpy (copy.inline_mask, source->inline_mask, sizeof(copy.inline_mask));
   memcpy (copy.rescue_mask, source->rescue_mask, sizeof(copy.rescue_mask));
   memcpy (&copy.antifake, &source->antifake, sizeof(copy.antifake));
-  copy.extraction_metadata.quality = source->extraction_metadata.quality;
-  copy.extraction_metadata.coverage = source->extraction_metadata.coverage;
-  copy.extraction_metadata.optional_c7 = source->extraction_metadata.optional_c7;
+  copy.extraction_metadata = source->extraction_metadata;
 
   goodix_match_info_clear (destination);
   *destination = copy;

--- a/drivers/goodix53x5/milan/match/lifecycle.c
+++ b/drivers/goodix53x5/milan/match/lifecycle.c
@@ -109,23 +109,9 @@ goodix_match_serialized_feature_result_internal (
     }
   matched_milan = normalized_milan;
 
-#ifdef GOODIX53X5_DEBUG
-  if (goodix_milan_match_probe_result_debug (
-#else
-  if (goodix_milan_match_probe_result (
-#endif
-        probe_info->feature_bitmaps.high_bitmap,
-        probe_info->feature_bitmaps.enhanced_bitmap,
-        probe_info->feature_bitmaps.low_bitmap,
-        probe_info->inline_mask,
-        probe_info->rescue_mask,
-        probe_info->records, (size_t) probe_info->record_count,
-        (size_t) probe_info->partition_count,
-        probe_info->extraction_metadata.quality,
-        probe_info->extraction_metadata.coverage,
-        probe_info->extraction_metadata.optional_c7,
-        &probe_info->antifake,
-        matched_milan, normalized_milan_len, match_result
+  if (goodix_milan_match_info_result (
+        probe_info, matched_milan, normalized_milan_len, NULL, NULL, NULL,
+        SIZE_MAX, match_result
 #ifdef GOODIX53X5_DEBUG
         , diagnostics
 #endif

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -14,6 +14,7 @@
 #include "milan/match/candidate.h"
 #include "milan/match/correspondence.h"
 #include "milan/match/geometry.h"
+#include "milan/match/info-private.h"
 #include "milan/match/overlap.h"
 #include "milan/match/fallback.h"
 #include "milan/match/policy.h"
@@ -32,6 +33,11 @@ typedef enum
   MILAN_MATCH_RANK_OWNER_PRIMARY,
   MILAN_MATCH_RANK_OWNER_ALTERNATE,
 } MilanMatchRankOwner;
+
+enum
+{
+  MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE = -1,
+};
 
 typedef struct
 {
@@ -587,7 +593,7 @@ milan_match_apply_secondary (
       int32_t alternate_topology;
       int32_t alternate_geometric;
       int select_transform = 0;
-              int32_t sibling_scale_penalty;
+      int32_t sibling_scale_penalty;
       int32_t sibling_orthogonality;
       int32_t sibling_strong_orthogonality;
 
@@ -689,6 +695,7 @@ milan_match_prepared_probe (
   const uint8_t                   probe_rescue_mask[308],
   const GoodixMilanFeatureRecord *probe_records,
   size_t                          probe_record_count,
+  int32_t                         probe_primary_histogram_class,
   int32_t                         image_quality,
   int32_t                         image_coverage,
   const GoodixMilanAntifakeBlob  *probe_antifake,
@@ -834,7 +841,8 @@ milan_match_prepared_probe (
           matcher_policy.configuration[14] = (int32_t) triggering_index;
         }
       goodix_milan_matcher_late_context_init (
-        &late_policy_context, probe_feature->fields.optional_c7);
+        &late_policy_context, probe_feature->fields.optional_c7,
+        probe_primary_histogram_class);
       sibling_tail_hamming_limit =
         matcher_policy.configuration[GOODIX_MILAN_MATCHER_CONFIGURATION_OFFSET +
                               GOODIX_MILAN_MATCHER_TAIL_HAMMING_LIMIT_INDEX];
@@ -970,9 +978,6 @@ milan_match_prepared_probe (
                 enrolled->metadata.sensor_type == 12 ? 42 : 31,
                  enrolled->metadata.sensor_type == 12 ? &direct_candidate : NULL) != 0)
         continue;
-      if (enrolled->metadata.sensor_type == 12)
-        {
-        }
       milan_match_apply_secondary (
         enrolled_records, feature.record_count, enrolled_partition_count,
         probe_records, probe_record_count, probe_partition_count,
@@ -1554,7 +1559,7 @@ milan_match_prepared_probe (
         matcher_policy.configuration[13] == 1 &&
         late_policy_context.probe_low_class == 0 && image_coverage > 65 &&
         image_quality > 15 && late_policy_context.accumulated_high_class < 4 &&
-        late_policy_status_counter < 3 &&
+        late_policy_context.probe_primary_histogram_class < 3 &&
         enrolled->metadata.queue_state == 0;
 #ifdef GOODIX53X5_DEBUG
       if (diagnostics)
@@ -1659,6 +1664,25 @@ milan_match_prepared_probe (
       result = 0;
       if (goodix_milan_match_selection_blocking_override (&match_selection))
         *score = -65536;
+      goto out;
+    }
+
+  if (enrolled->metadata.sensor_type == 12 &&
+      !match_selection.score_latched &&
+      (late_policy_context.accumulated_high_class >= 4 ||
+       late_policy_context.probe_primary_histogram_class >= 2))
+    {
+      *score = goodix_milan_match_selection_blocking_override (&match_selection)
+                 ? -65536 : 0;
+      result = 0;
+      goto out;
+    }
+  if (enrolled->metadata.sensor_type == 12 &&
+      !match_selection.score_latched &&
+      matcher_policy.configuration[13] == 0)
+    {
+      *score = 0;
+      result = 0;
       goto out;
     }
 
@@ -1912,6 +1936,7 @@ milan_match_probe_result_internal (
   int32_t                        image_quality,
   int32_t                        image_coverage,
   int32_t                        probe_optional_c7,
+  int32_t                        probe_primary_histogram_class,
   const GoodixMilanAntifakeBlob *probe_antifake,
   int                            caller_blocking_enabled,
   const uint8_t                 *enrolled_template,
@@ -1950,7 +1975,8 @@ milan_match_probe_result_internal (
   probe_feature.antifake = probe_antifake;
   result = milan_match_prepared_probe (
     &probe_feature, probe_rescue_mask, probe_records, probe_record_count,
-    image_quality, image_coverage, probe_antifake, caller_blocking_enabled,
+    probe_primary_histogram_class, image_quality, image_coverage, probe_antifake,
+    caller_blocking_enabled,
     enrolled_template,
     enrolled_template_size, live_records, live_record_counts,
     live_partition_counts, triggering_index,
@@ -1979,6 +2005,43 @@ milan_match_probe_result_internal (
 }
 
 int
+goodix_milan_match_info_result (
+  const GoodixMatchInfo          *probe,
+  const uint8_t                 *enrolled_template,
+  size_t                         enrolled_template_size,
+  const GoodixMilanFeatureRecord *const live_records[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  const size_t                   live_record_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  const size_t                   live_partition_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
+  size_t                         triggering_index,
+  GoodixMilanMatchResult        *match_result
+#ifdef GOODIX53X5_DEBUG
+  , GoodixMilanMatchDiagnostics *diagnostics
+#endif
+  )
+{
+  if (!probe)
+    return -1;
+
+  return milan_match_probe_result_internal (
+    probe->feature_bitmaps.high_bitmap,
+    probe->feature_bitmaps.enhanced_bitmap,
+    probe->feature_bitmaps.low_bitmap, probe->inline_mask, probe->rescue_mask,
+    probe->records, (size_t) probe->record_count,
+    (size_t) probe->partition_count, probe->extraction_metadata.quality,
+    probe->extraction_metadata.coverage,
+    probe->extraction_metadata.optional_c7,
+    probe->extraction_metadata.auxiliary.primary_histogram_state,
+    live_records ? NULL : &probe->antifake, live_records == NULL,
+    enrolled_template, enrolled_template_size,
+    live_records, live_record_counts, live_partition_counts, triggering_index,
+    match_result
+#ifdef GOODIX53X5_DEBUG
+    , diagnostics
+#endif
+    );
+}
+
+int
 goodix_milan_match_probe_result (
   const uint8_t                  probe_high_bitmap[286],
   const uint8_t                  probe_enhanced_bitmap[286],
@@ -2000,6 +2063,7 @@ goodix_milan_match_probe_result (
     probe_high_bitmap, probe_enhanced_bitmap, probe_low_bitmap,
     probe_inline_mask, probe_rescue_mask, probe_records, probe_record_count,
     probe_partition_count, image_quality, image_coverage, probe_optional_c7,
+    MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE,
     probe_antifake, probe_antifake != NULL,
     enrolled_template, enrolled_template_size, NULL, NULL, NULL, SIZE_MAX,
     match_result
@@ -2033,10 +2097,12 @@ goodix_milan_match_probe_result_debug (
     probe_high_bitmap, probe_enhanced_bitmap, probe_low_bitmap,
     probe_inline_mask, probe_rescue_mask, probe_records, probe_record_count,
     probe_partition_count, image_quality, image_coverage, probe_optional_c7,
+    MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE,
     probe_antifake, probe_antifake != NULL,
     enrolled_template, enrolled_template_size, NULL, NULL, NULL, SIZE_MAX,
     match_result, diagnostics);
 }
+
 #endif
 
 int
@@ -2064,6 +2130,7 @@ goodix_milan_match_live_probe_result (
     probe_high_bitmap, probe_enhanced_bitmap, probe_low_bitmap,
     probe_inline_mask, probe_rescue_mask, probe_records, probe_record_count,
     probe_partition_count, image_quality, image_coverage, probe_optional_c7,
+    MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE,
     NULL, 0, enrolled_template, enrolled_template_size, live_records,
     live_record_counts, live_partition_counts, triggering_index,
     match_result
@@ -2100,6 +2167,7 @@ goodix_milan_match_live_probe_result_debug (
     probe_high_bitmap, probe_enhanced_bitmap, probe_low_bitmap,
     probe_inline_mask, probe_rescue_mask, probe_records, probe_record_count,
     probe_partition_count, image_quality, image_coverage, probe_optional_c7,
+    MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE,
     NULL, 0, enrolled_template, enrolled_template_size, live_records,
     live_record_counts, live_partition_counts, triggering_index,
     match_result, diagnostics);

--- a/drivers/goodix53x5/milan/match/match.h
+++ b/drivers/goodix53x5/milan/match/match.h
@@ -63,34 +63,34 @@ typedef enum
 } GoodixMilanStudyAction;
 
 GoodixMatchInfo *goodix_match_extract_native (
-  const guint8                     *image,
-  const GoodixMilanPreprocessState *preprocess_state,
-  const guint16                    *raw_frame,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype);
+  const guint8               *image,
+  GoodixMilanPreprocessState *preprocess_state,
+  const guint16              *raw_frame,
+  guint16                     t_code,
+  guint16                     dac_high,
+  guint16                     dac_low,
+  guint16                     sensor_subtype);
 
 GoodixMilanExtractionStatus goodix_match_extract_native_result (
-  const guint8                     *image,
-  const GoodixMilanPreprocessState *preprocess_state,
-  const guint16                    *raw_frame,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype,
-  GoodixMatchInfo                 **info);
+  const guint8               *image,
+  GoodixMilanPreprocessState *preprocess_state,
+  const guint16              *raw_frame,
+  guint16                     t_code,
+  guint16                     dac_high,
+  guint16                     dac_low,
+  guint16                     sensor_subtype,
+  GoodixMatchInfo           **info);
 
 #ifdef GOODIX53X5_DEBUG
 GoodixMilanExtractionStatus goodix_match_extract_native_result_debug (
-  const guint8                     *image,
-  const GoodixMilanPreprocessState *preprocess_state,
-  const guint16                    *raw_frame,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype,
-  GoodixMatchInfo                 **info,
+  const guint8               *image,
+  GoodixMilanPreprocessState *preprocess_state,
+  const guint16              *raw_frame,
+  guint16                     t_code,
+  guint16                     dac_high,
+  guint16                     dac_low,
+  guint16                     sensor_subtype,
+  GoodixMatchInfo           **info,
   GoodixMilanExtractionDiagnostics *diagnostics);
 #endif
 

--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -1042,10 +1042,16 @@ decode_packed_c7 (int32_t  packed_c7,
 void
 goodix_milan_matcher_late_context_init (
   GoodixMilanMatcherLateContext *context,
-  int32_t                        packed_probe_c7)
+  int32_t                        packed_probe_c7,
+  int32_t                        probe_primary_histogram_class)
 {
   decode_packed_c7 (packed_probe_c7, &context->probe_low_class,
                     &context->accumulated_high_class);
+  /* Object-aware production paths provide the independent histogram class;
+   * raw legacy APIs fall back to the decoded packed-c7 low class. */
+  context->probe_primary_histogram_class =
+    probe_primary_histogram_class < 0
+      ? context->probe_low_class : probe_primary_histogram_class;
 }
 
 void
@@ -1060,7 +1066,7 @@ goodix_milan_matcher_late_context_derive (
   decode_packed_c7 (packed_feature_c7, &feature_low_class,
                     &feature_high_class);
   state[0] = context->accumulated_high_class;
-  state[1] = context->probe_low_class;
+  state[1] = context->probe_primary_histogram_class;
   state[2] = context->accumulated_high_class + feature_high_class;
   if (state[2] > 5)
     state[2] = 5;

--- a/drivers/goodix53x5/milan/match/policy.h
+++ b/drivers/goodix53x5/milan/match/policy.h
@@ -21,6 +21,7 @@ typedef struct
 {
   int32_t accumulated_high_class;
   int32_t probe_low_class;
+  int32_t probe_primary_histogram_class;
 } GoodixMilanMatcherLateContext;
 
 enum
@@ -58,7 +59,8 @@ void goodix_milan_matcher_policy_apply_late_veto (
 
 void goodix_milan_matcher_late_context_init (
   GoodixMilanMatcherLateContext *context,
-  int32_t                        packed_probe_c7);
+  int32_t                        packed_probe_c7,
+  int32_t                        probe_primary_histogram_class);
 
 void goodix_milan_matcher_late_context_derive (
   GoodixMilanMatcherLateContext *context,

--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -356,18 +356,14 @@ goodix_match_live_gallery_result (GoodixMatchInfo                 *probe,
         live_partition_counts[i] =
           (size_t) context->live_features[i]->partition_count;
       }
-  if (goodix_milan_match_live_probe_result (
-        probe->feature_bitmaps.high_bitmap,
-        probe->feature_bitmaps.enhanced_bitmap,
-        probe->feature_bitmaps.low_bitmap,
-        probe->inline_mask, probe->rescue_mask, probe->records,
-        (size_t) probe->record_count, (size_t) probe->partition_count,
-        probe->extraction_metadata.quality,
-        probe->extraction_metadata.coverage,
-        probe->extraction_metadata.optional_c7, current_milan,
-        current_milan_size, live_records,
+  if (goodix_milan_match_info_result (
+        probe, current_milan, current_milan_size, live_records,
         live_record_counts, live_partition_counts, triggering_index,
-        match_result) != 0)
+        match_result
+#ifdef GOODIX53X5_DEBUG
+        , NULL
+#endif
+        ) != 0)
     return GOODIX_SIGFM_TEMPLATE_INVALID;
 
   if (match_result->score > 0 &&

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -20,6 +20,12 @@
 #define GOODIX_MILAN_SENSOR_COLUMNS 108
 #define GOODIX_MILAN_SENSOR_PIXELS \
   (GOODIX_MILAN_SENSOR_ROWS * GOODIX_MILAN_SENSOR_COLUMNS)
+#define GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS 88
+#define GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS 104
+#define GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS \
+  (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS * \
+   GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS)
+#define GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION 0x29aa
 #define GOODIX_MILAN_PREPROCESS_RETRY 0x7531
 #define GOODIX_MILAN_ANTIFAKE_AMBIGUOUS 1
 #define GOODIX_MILAN_ANTIFAKE_SIZE 0x1abcU
@@ -251,6 +257,23 @@ typedef struct
 
 typedef struct
 {
+  uint8_t  retained_class_planes[3]
+                                [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
+  uint32_t retained_count;
+  int32_t  prior_coverage;
+  uint32_t high_class_hysteresis;
+  int32_t  prior_merged_high_class;
+} GoodixMilanExtractionClassificationState;
+
+typedef struct
+{
+  uint8_t primary_histogram_state;
+  uint8_t prior_selected_plane;
+  uint8_t promoted_secondary_histogram_state;
+} GoodixMilanExtractionAuxiliaryState;
+
+typedef struct
+{
   uint16_t setup_map[GOODIX_MILAN_SENSOR_PIXELS];
   uint16_t calibration_map[GOODIX_MILAN_SENSOR_PIXELS];
   uint16_t coarse_reference[GOODIX_MILAN_SENSOR_PIXELS / 4];
@@ -273,6 +296,11 @@ typedef struct
   int32_t  primary_contrast_valid;
   int32_t  selected_refined;
   GoodixMilanPostRenderObservations post_render;
+  /* Retained planes/hysteresis persist in generation-owned preprocess state.
+   * Auxiliary bytes describe the latest completed preprocessing call and feed
+   * extraction/matcher policy. */
+  GoodixMilanExtractionClassificationState extraction_classification;
+  GoodixMilanExtractionAuxiliaryState extraction_auxiliary;
 } GoodixMilanPreprocessState;
 
 _Static_assert (sizeof (GoodixMilanProfile9ClassCounts) == 12,
@@ -368,7 +396,31 @@ _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
                   offsetof (GoodixMilanPostRenderObservations, status) == 147392,
                 "Milan preprocess post-render status moved");
-_Static_assert (sizeof (GoodixMilanPreprocessState) == 147396,
+_Static_assert (sizeof (GoodixMilanExtractionClassificationState) == 27472,
+                "Milan extraction classification state size changed");
+_Static_assert (_Alignof (GoodixMilanExtractionClassificationState) == 4,
+                "Milan extraction classification state alignment changed");
+_Static_assert (offsetof (GoodixMilanPreprocessState,
+                          extraction_classification) == 147396,
+                "Milan extraction classification state moved");
+_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
+                          retained_count) == 27456,
+                "Milan extraction retained count moved");
+_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
+                          prior_coverage) == 27460,
+                "Milan extraction prior coverage moved");
+_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
+                          high_class_hysteresis) == 27464,
+                "Milan extraction hysteresis moved");
+_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
+                          prior_merged_high_class) == 27468,
+                "Milan extraction prior high class moved");
+_Static_assert (sizeof (GoodixMilanExtractionAuxiliaryState) == 3,
+                "Milan extraction auxiliary state size changed");
+_Static_assert (offsetof (GoodixMilanPreprocessState,
+                          extraction_auxiliary) == 174868,
+                "Milan extraction auxiliary state moved");
+_Static_assert (sizeof (GoodixMilanPreprocessState) == 174872,
                 "Milan preprocess state size changed");
 _Static_assert (_Alignof (GoodixMilanPreprocessState) == 4,
                 "Milan preprocess state alignment changed");
@@ -421,6 +473,7 @@ int goodix_milan_profile9_build_contrast_mask (
 int goodix_milan_profile9_build_broken_mask (
   GoodixMilanPreprocessState *state,
   const uint16_t             *difference,
+  const uint16_t             *setup_map,
   const uint16_t             *normalized_live,
   const uint8_t              *contrast_mask,
   size_t                      rows,

--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -111,6 +111,342 @@ milan_profile9_erode_valid (const uint8_t *source,
     }
 }
 
+typedef struct
+{
+  int32_t histogram[256];
+  int64_t total_weight;
+  int     mode_bin;
+  int     range;
+  int     minimum;
+  int     sample_count;
+} MilanProfile9Histogram;
+
+static void
+milan_profile9_build_histogram (const uint16_t       *image,
+                                const uint8_t        *valid,
+                                size_t                count,
+                                MilanProfile9Histogram *state)
+{
+  int minimum = INT16_MAX;
+  int maximum = 0;
+
+  memset (state, 0, sizeof(*state));
+  for (size_t i = 0; i < count; i++)
+    if (valid[i] != 0)
+      {
+        int value = (int16_t) image[i];
+
+        if (value < minimum)
+          minimum = value;
+        if (value > maximum)
+          maximum = value;
+        state->sample_count++;
+      }
+  state->minimum = minimum;
+  state->range = (int16_t) (maximum - minimum);
+  if (state->range <= 0)
+    return;
+
+  for (size_t i = 0; i < count; i++)
+    if (valid[i] != 0)
+      {
+        int scaled = ((int16_t) image[i] - minimum) * 255;
+        int bin = scaled / state->range;
+        int remainder = scaled - bin * state->range;
+
+        state->histogram[bin] += state->range - remainder;
+        if (bin < 255)
+          state->histogram[bin + 1] += remainder;
+      }
+  int32_t mode_weight = 0;
+  for (int bin = 0; bin < 256; bin++)
+    {
+      if (state->histogram[bin] > mode_weight)
+        {
+          mode_weight = state->histogram[bin];
+          state->mode_bin = bin;
+        }
+      state->total_weight += state->histogram[bin];
+    }
+}
+
+static void
+milan_profile9_clip_histogram (const uint16_t             *image,
+                               const uint8_t              *valid,
+                               size_t                      count,
+                               const MilanProfile9Histogram *input,
+                               MilanProfile9Histogram       *output)
+{
+  int64_t low_target = input->total_weight * 5 / 1000;
+  int64_t high_target = input->total_weight * 995 / 1000;
+  int64_t cumulative = 0;
+  int low_bin = 0;
+  int high_bin = 0;
+  int low_found = 0;
+
+  memset (output, 0, sizeof(*output));
+  output->sample_count = input->sample_count;
+  for (int bin = 0; bin < 256; bin++)
+    {
+      cumulative += input->histogram[bin];
+      if (low_found == 0 && cumulative >= low_target)
+        {
+          low_bin = bin;
+          low_found = 1;
+        }
+      if (cumulative >= high_target)
+        {
+          high_bin = bin;
+          break;
+        }
+    }
+  int low = input->minimum + input->range * low_bin / 255;
+  int high = input->minimum + input->range * high_bin / 255;
+
+  output->minimum = low;
+  output->range = (int16_t) (high - low);
+  if (output->range <= 0)
+    return;
+  for (size_t i = 0; i < count; i++)
+    {
+      int sample = (int16_t) image[i];
+
+      if (valid[i] != 0 && sample > low && sample < high)
+        {
+          int scaled = (sample - low) * 255;
+          int bin = scaled / output->range;
+          int remainder = scaled - bin * output->range;
+
+          output->histogram[bin] += output->range - remainder;
+          if (bin < 255)
+            output->histogram[bin + 1] += remainder;
+        }
+    }
+  int32_t mode_weight = 0;
+  for (int bin = 0; bin < 256; bin++)
+    {
+      if (output->histogram[bin] > mode_weight)
+        {
+          mode_weight = output->histogram[bin];
+          output->mode_bin = bin;
+        }
+      output->total_weight += output->histogram[bin];
+    }
+}
+
+static void
+milan_profile9_smooth_histogram (const int32_t input[256],
+                                 unsigned      shift,
+                                 int32_t       smooth[256],
+                                 int32_t       box[256])
+{
+  int32_t current[256];
+  int32_t next[256];
+
+  for (int bin = 0; bin < 256; bin++)
+    current[bin] = input[bin] >> shift;
+  memset (box, 0, 256 * sizeof(*box));
+  for (int pass = 0; pass < 2; pass++)
+    {
+      for (int bin = 0; bin < 256; bin++)
+        if (bin >= 10 && bin <= 245)
+          {
+            int32_t sum = 0;
+
+            for (int offset = -10; offset <= 10; offset++)
+              sum += current[bin + offset];
+            next[bin] = (sum + 10) / 21;
+            if (pass == 1)
+              box[bin] = sum;
+          }
+        else
+          next[bin] = current[bin];
+      memcpy (current, next, sizeof(current));
+    }
+  for (int bin = 0; bin < 10; bin++)
+    current[bin] = current[10];
+  for (int bin = 246; bin < 256; bin++)
+    current[bin] = current[245];
+  memcpy (smooth, current, sizeof(current));
+}
+
+static int
+milan_profile9_histogram_global_peak (const int32_t box[256])
+{
+  int32_t maximum = 0;
+  int peak = 0;
+
+  for (int bin = 0; bin < 256; bin++)
+    if (box[bin] > maximum)
+      {
+        maximum = box[bin];
+        peak = bin;
+      }
+  return peak;
+}
+
+static int32_t
+milan_profile9_histogram_valley (const int32_t box[256],
+                                 int           first,
+                                 int           second)
+{
+  int lower = first < second ? first : second;
+  int upper = first > second ? first : second;
+  int32_t valley = box[lower];
+
+  for (int bin = lower; bin < upper; bin++)
+    if (box[bin] < valley)
+      valley = box[bin];
+  return valley;
+}
+
+static int
+milan_profile9_histogram_local_maximum (const int32_t smooth[256],
+                                        int           bin)
+{
+  for (int distance = 10; distance > 0; distance--)
+    if (smooth[bin] < smooth[bin - distance] ||
+        smooth[bin] < smooth[bin + distance])
+      return 0;
+  return 1;
+}
+
+static uint8_t
+milan_profile9_primary_histogram_state (
+  const MilanProfile9Histogram *clipped)
+{
+  int32_t smooth[256];
+  int32_t box[256];
+  uint8_t state = 0;
+
+  if (clipped->sample_count < 10 || clipped->range <= 0)
+    return 0;
+  milan_profile9_smooth_histogram (
+    clipped->histogram, 4, smooth, box);
+  int global_peak = milan_profile9_histogram_global_peak (box);
+  int width_floor = smooth[global_peak] * 20 / 100;
+  int upper = global_peak;
+  int lower = global_peak;
+
+  while (upper < 246 && smooth[upper] >= width_floor)
+    upper++;
+  while (lower > 9 && smooth[lower] >= width_floor)
+    lower--;
+  int width = upper - lower;
+  if ((width > 180 && clipped->range > 1200) ||
+      (width > 200 && clipped->range > 1000) ||
+      (width > 230 && clipped->range > 800))
+    state = 1;
+
+  int high_peak = 128;
+  int low_peak = 128;
+  int32_t high_value = smooth[128] * 2 + 1;
+  int32_t low_value = high_value;
+
+  for (int bin = 128; bin <= 245; bin++)
+    if (smooth[bin] > high_value)
+      {
+        high_value = smooth[bin];
+        high_peak = bin;
+      }
+  for (int bin = 128; bin >= 10; bin--)
+    if (smooth[bin] > low_value)
+      {
+        low_value = smooth[bin];
+        low_peak = bin;
+      }
+  if (clipped->range > 1000 && high_peak - low_peak > 210 &&
+      (int64_t) box[low_peak] * 100 >
+        (clipped->total_weight >> 4) * 10)
+    {
+      int64_t ratio = ((int64_t) box[low_peak] * 100 + 100) /
+                      (box[high_peak] + 1);
+
+      if (ratio >= 31 && ratio <= 332)
+        state = 1;
+    }
+
+  int exclusion = 51200 / clipped->range;
+  for (int bin = 10; bin <= 245; bin++)
+    {
+      if (bin >= global_peak - exclusion &&
+          bin <= global_peak + exclusion)
+        continue;
+      if (!milan_profile9_histogram_local_maximum (smooth, bin))
+        continue;
+      int32_t prominence = smooth[bin] - smooth[global_peak] / 150;
+      if (smooth[bin - 10] > prominence || smooth[bin + 10] > prominence ||
+          (int64_t) box[bin] * 100 < (int64_t) box[global_peak] * 30)
+        continue;
+      int32_t valley = milan_profile9_histogram_valley (
+        box, bin, global_peak);
+      if ((int64_t) valley * 100 <= (int64_t) box[bin] * 85 &&
+          (int64_t) valley * 100 <= (int64_t) box[global_peak] * 60)
+        return 2;
+    }
+  return state;
+}
+
+static uint8_t
+milan_profile9_secondary_histogram_state (
+  const MilanProfile9Histogram *clipped)
+{
+  int32_t smooth[256];
+  int32_t box[256];
+
+  if (clipped->mode_bin < 10 || clipped->mode_bin > 251 ||
+      clipped->range <= 0)
+    return 0;
+  milan_profile9_smooth_histogram (
+    clipped->histogram, 5, smooth, box);
+  int global_peak = milan_profile9_histogram_global_peak (box);
+  if ((int64_t) box[global_peak] * 100 >
+      (clipped->total_weight >> 5) * 35)
+    return 0;
+
+  int exclusion = 128000 / clipped->range;
+  for (int bin = 10; bin <= 245; bin++)
+    {
+      if (bin >= global_peak - exclusion &&
+          bin <= global_peak + exclusion)
+        continue;
+      if (!milan_profile9_histogram_local_maximum (smooth, bin))
+        continue;
+      int32_t candidate_reduction = smooth[bin] * 5 / 100;
+      int32_t peak_reduction = smooth[global_peak] / 100;
+      int32_t reduction = candidate_reduction > peak_reduction
+                            ? candidate_reduction : peak_reduction;
+      int32_t prominence = smooth[bin] - reduction;
+      if (smooth[bin - 10] > prominence || smooth[bin + 10] > prominence ||
+          (int64_t) box[bin] * 100 < (int64_t) box[global_peak] * 25)
+        continue;
+      int32_t valley = milan_profile9_histogram_valley (
+        box, bin, global_peak);
+      if ((int64_t) valley * 100 <= (int64_t) box[bin] * 85 &&
+          (int64_t) valley * 100 <= (int64_t) box[global_peak] * 60)
+        return 1;
+    }
+  return 0;
+}
+
+static uint8_t
+milan_profile9_histogram_state (const uint16_t *image,
+                                const uint8_t  *valid,
+                                size_t          count,
+                                int             primary)
+{
+  MilanProfile9Histogram input;
+  MilanProfile9Histogram clipped;
+
+  milan_profile9_build_histogram (image, valid, count, &input);
+  if (input.range <= 0)
+    return 0;
+  milan_profile9_clip_histogram (
+    image, valid, count, &input, &clipped);
+  return primary != 0 ? milan_profile9_primary_histogram_state (&clipped)
+                      : milan_profile9_secondary_histogram_state (&clipped);
+}
+
 static void
 milan_profile9_histogram_thresholds (const uint16_t *image,
                                      const uint8_t  *valid,
@@ -734,7 +1070,7 @@ milan_profile9_update_history (GoodixMilanPreprocessState *state,
 
   if (!current)
     return;
-  if (state->profile9_history_count == 0)
+  if (state->sample_count < 2)
     {
       state->profile9_history_count = 0;
       state->profile9_history_mask_threshold = 60;
@@ -789,17 +1125,235 @@ out:
   free (current);
 }
 
+static int
+milan_profile9_prepare_history (GoodixMilanPreprocessState *state,
+                                const uint16_t             *prepared,
+                                const uint8_t              *contrast_mask,
+                                size_t                      count,
+                                uint8_t                     prior_selected_plane)
+{
+  if (prior_selected_plane == 2)
+    return 0;
+  if (state->profile9_history_count == 0 && state->sample_count > 1)
+    {
+      uint32_t retained_count = state->sample_count < 21
+                                  ? state->sample_count : 21;
+
+      memcpy (state->profile9_history_reference, state->calibration_map,
+              count * sizeof(*state->profile9_history_reference));
+      memset (state->profile9_reference_age, (uint8_t) retained_count, count);
+      state->profile9_history_count = retained_count;
+      return 1;
+    }
+  milan_profile9_update_history (state, prepared, contrast_mask, count);
+  return 0;
+}
+
+static void
+milan_profile9_build_history_qualified (
+  const GoodixMilanPreprocessState *state,
+  const uint8_t                    *valid,
+  size_t                            rows,
+  size_t                            columns,
+  uint8_t                          *qualified)
+{
+  memset (qualified, 0, rows * columns);
+  for (size_t row = 3; row + 3 < rows; row++)
+    for (size_t column = 3; column + 3 < columns; column++)
+      {
+        size_t i = row * columns + column;
+
+        qualified[i] = valid[i] != 0 &&
+                       state->profile9_reference_age[i] * 100 >=
+                         state->profile9_history_count * 50;
+      }
+}
+
+static uint8_t
+milan_profile9_secondary_count_state (const uint16_t *source,
+                                      const uint8_t  *qualified,
+                                      size_t          rows,
+                                      size_t          columns)
+{
+  static const int dx[8] = { -1, 1, 0, 0, -1, -1, 1, 1 };
+  static const int dy[8] = { 0, 0, -1, 1, -1, 1, -1, 1 };
+  size_t count = rows * columns;
+  uint16_t *gradient = calloc (count, sizeof(*gradient));
+  int16_t *direction = malloc (count * sizeof(*direction));
+  uint16_t *scores = calloc (count, sizeof(*scores));
+  uint64_t sum = 0;
+  size_t samples = 0;
+  size_t selected = 0;
+  uint8_t result = 0;
+
+  if (!gradient || !direction || !scores)
+    goto out;
+  for (size_t row = 0; row < rows; row++)
+    for (size_t column = 0; column < columns; column++)
+      {
+        size_t i = row * columns + column;
+
+        direction[i] = -1;
+        if (qualified[i] == 0)
+          continue;
+        for (int candidate = 0; candidate < 8; candidate++)
+          {
+            int x = (int) column + dx[candidate];
+            int y = (int) row + dy[candidate];
+            size_t neighbor;
+            int16_t delta;
+
+            if (x < 0 || x >= (int) columns || y < 0 || y >= (int) rows)
+              continue;
+            neighbor = (size_t) y * columns + (size_t) x;
+            if (qualified[neighbor] == 0)
+              continue;
+            delta = (int16_t) ((uint16_t) source[i] - source[neighbor]);
+            if (delta > (int16_t) gradient[i])
+              {
+                gradient[i] = (uint16_t) delta;
+                direction[i] = (int16_t) candidate;
+              }
+          }
+      }
+  for (size_t i = 0; i < count; i++)
+    if (qualified[i] != 0)
+      {
+        int current = (int) i;
+        uint16_t score = 0;
+
+        for (int step = 0; step < 4; step++)
+          {
+            int candidate = direction[current];
+
+            if (candidate < 0)
+              break;
+            score = (uint16_t) (score + gradient[current]);
+            current += dy[candidate] * (int) columns + dx[candidate];
+          }
+        scores[i] = score;
+        if (score > 0 && score < 400)
+          {
+            sum += score;
+            samples++;
+          }
+      }
+  int threshold = 0;
+  if (samples != 0)
+    {
+      int average = (int) ((sum + samples / 2) / samples);
+
+      threshold = average * 512 >> 8;
+      if (threshold < 400)
+        threshold = 400;
+    }
+  for (size_t i = 0; i < count; i++)
+    selected += scores[i] > threshold;
+  if (selected > 600)
+    result = 2;
+  else if (selected > 300)
+    result = 1;
+
+out:
+  free (scores);
+  free (direction);
+  free (gradient);
+  return result;
+}
+
+static uint8_t
+milan_profile9_directional_state (const uint16_t *normalized_live,
+                                  const uint8_t  *valid,
+                                  size_t          rows,
+                                  size_t          columns,
+                                  size_t          reference_count)
+{
+  size_t count = rows * columns;
+  uint16_t *left = calloc (count, sizeof(*left));
+  uint16_t *right = calloc (count, sizeof(*right));
+  uint16_t *up = calloc (count, sizeof(*up));
+  uint16_t *down = calloc (count, sizeof(*down));
+  size_t strict_count = 0;
+  size_t combined_count = 0;
+  uint8_t result = 0;
+
+  if (!left || !right || !up || !down)
+    goto out;
+  for (size_t row = 0; row < rows; row++)
+    {
+      uint16_t run = 0;
+
+      for (size_t column = 0; column < columns; column++)
+        {
+          size_t i = row * columns + column;
+
+          left[i] = run;
+          run = valid[i] != 0 ? (uint16_t) (run + 1) : 0;
+        }
+      run = 0;
+      for (size_t column = columns; column-- > 0;)
+        {
+          size_t i = row * columns + column;
+
+          right[i] = run;
+          run = valid[i] != 0 ? (uint16_t) (run + 1) : 0;
+        }
+    }
+  for (size_t column = 0; column < columns; column++)
+    {
+      uint16_t run = 0;
+
+      for (size_t row = 0; row < rows; row++)
+        {
+          size_t i = row * columns + column;
+
+          up[i] = run;
+          run = valid[i] != 0 ? (uint16_t) (run + 1) : 0;
+        }
+      run = 0;
+      for (size_t row = rows; row-- > 0;)
+        {
+          size_t i = row * columns + column;
+
+          down[i] = run;
+          run = valid[i] != 0 ? (uint16_t) (run + 1) : 0;
+        }
+    }
+  for (size_t i = 0; i < count; i++)
+    {
+      int all4 = left[i] >= 6 && right[i] >= 6 &&
+                 up[i] >= 6 && down[i] >= 6;
+      int opposite_pair = (left[i] >= 6 && right[i] >= 6) ||
+                          (up[i] >= 6 && down[i] >= 6);
+      int strong = normalized_live[i] > 3800;
+
+      strict_count += strong && all4;
+      combined_count += (valid[i] == 0 && all4) ||
+                        (strong && opposite_pair);
+    }
+  if (strict_count * 10 > reference_count)
+    result = 2;
+  else if ((strict_count + combined_count) * 10 > reference_count)
+    result = 1;
+
+out:
+  free (down);
+  free (up);
+  free (right);
+  free (left);
+  return result;
+}
+
 static void
 milan_profile9_temporal_class3 (GoodixMilanPreprocessState *state,
-                                const uint8_t              *valid,
-                                size_t                      rows,
-                                size_t                      columns,
+                                 const uint8_t              *qualified,
+                                 size_t                      rows,
+                                 size_t                      columns,
                                 uint8_t                    *classes)
 {
   static const int dx[8] = { -1, 1, 0, 0, -1, -1, 1, 1 };
   static const int dy[8] = { 0, 0, -1, 1, -1, 1, -1, 1 };
   size_t count = rows * columns;
-  uint8_t *qualified = calloc (count, 1);
   uint16_t *gradient = calloc (count, sizeof(*gradient));
   int16_t *direction = malloc (count * sizeof(*direction));
   uint16_t *scores = calloc (count, sizeof(*scores));
@@ -810,17 +1364,8 @@ milan_profile9_temporal_class3 (GoodixMilanPreprocessState *state,
   size_t samples = 0;
   size_t selected = 0;
 
-  if (!qualified || !gradient || !direction || !scores || !mask)
+  if (!gradient || !direction || !scores || !mask)
     goto out;
-  for (size_t row = 3; row + 3 < rows; row++)
-    for (size_t column = 3; column + 3 < columns; column++)
-      {
-        size_t i = row * columns + column;
-
-        qualified[i] = valid[i] != 0 &&
-                       state->profile9_reference_age[i] * 100 >=
-                         state->profile9_history_count * 50;
-      }
   milan_profile9_histogram_thresholds (
     state->profile9_history_reference, qualified, count, &threshold, &unused);
   for (size_t row = 0; row < rows; row++)
@@ -915,13 +1460,13 @@ out:
   free (scores);
   free (direction);
   free (gradient);
-  free (qualified);
 }
 
 int
 goodix_milan_profile9_build_broken_mask (
   GoodixMilanPreprocessState *state,
   const uint16_t             *difference,
+  const uint16_t             *setup_map,
   const uint16_t             *normalized_live,
   const uint8_t              *contrast_mask,
   size_t                      rows,
@@ -938,7 +1483,9 @@ goodix_milan_profile9_build_broken_mask (
   static const int dx[8] = { -1, 1, 0, 0, -1, -1, 1, 1 };
   static const int dy[8] = { 0, 0, -1, 1, -1, 1, -1, 1 };
   size_t count;
+  uint16_t *prepared = NULL;
   uint8_t *valid = NULL;
+  uint8_t *history_qualified = NULL;
   uint16_t *blurred = NULL;
   uint16_t *gradient = NULL;
   int16_t *direction = NULL;
@@ -950,16 +1497,25 @@ goodix_milan_profile9_build_broken_mask (
   int low;
   int high;
   size_t active_count = 0;
+  uint8_t prior_selected_plane;
+  uint8_t primary_histogram_state;
+  uint8_t secondary_histogram_state = 0;
+  uint8_t secondary_count_state = 0;
+  uint8_t directional_state;
+  int history_initialized;
   int result = -1;
 
-  if (!state || !difference || !normalized_live || !contrast_mask ||
+  if (!state || !difference || !setup_map || !normalized_live || !contrast_mask ||
       !broken_mask || !mode || !apply_mask || rows < 3 || columns < 3 ||
       columns > SIZE_MAX / rows || rows * columns > GOODIX_MILAN_SENSOR_PIXELS)
     return -1;
   count = rows * columns;
+  prior_selected_plane = (uint8_t) state->selected_refined;
   for (size_t i = 0; i < count; i++)
     active_count += contrast_mask[i] != 0;
+  prepared = malloc (count * sizeof(*prepared));
   valid = malloc (count);
+  history_qualified = calloc (count, 1);
   blurred = malloc (count * sizeof(*blurred));
   gradient = calloc (count, sizeof(*gradient));
   direction = malloc (count * sizeof(*direction));
@@ -968,14 +1524,27 @@ goodix_milan_profile9_build_broken_mask (
   edge_map = calloc (count, sizeof(*edge_map));
   adaptive = malloc (count);
   class2_scores = calloc (count, sizeof(*class2_scores));
-  if (!valid || !blurred || !gradient || !direction || !scores ||
-      !edge_blurred || !edge_map || !adaptive || !class2_scores)
+  if (!prepared || !valid || !history_qualified || !blurred || !gradient ||
+      !direction || !scores || !edge_blurred || !edge_map || !adaptive ||
+      !class2_scores)
     goto out;
 
+  if (setup_map[0] < 4096)
+    for (size_t i = 0; i < count; i++)
+      {
+        int value = (int) setup_map[i] - normalized_live[i] + 3000;
+
+        prepared[i] = value > 0 ? (uint16_t) value : 0;
+      }
+  else
+    memcpy (prepared, difference, count * sizeof(*prepared));
   milan_profile9_erode_valid (contrast_mask, valid, rows, columns, 8);
-  milan_profile9_update_history (state, difference, contrast_mask, count);
+  history_initialized = milan_profile9_prepare_history (
+    state, prepared, contrast_mask, count, prior_selected_plane);
   milan_profile9_filter_q16 (
-    difference, rows, columns, primary_kernel, 3, blurred);
+    prepared, rows, columns, primary_kernel, 3, blurred);
+  primary_histogram_state = milan_profile9_histogram_state (
+    blurred, valid, count, 1);
   milan_profile9_histogram_thresholds (blurred, valid, count, &low, &high);
   for (size_t row = 0; row < rows; row++)
     for (size_t column = 0; column < columns; column++)
@@ -1143,9 +1712,35 @@ goodix_milan_profile9_build_broken_mask (
     if (class2_scores[i] > class2_threshold && broken_mask[i] < 3)
       broken_mask[i] = 2;
 
+  if (primary_histogram_state < 2)
+    {
+      size_t classified_count = 0;
+
+      for (size_t i = 0; i < count; i++)
+        if (broken_mask[i] != 0)
+          {
+            classified_count++;
+          }
+      if (classified_count * 100 > active_count * 30)
+        {
+          primary_histogram_state = 2;
+        }
+    }
   if (state->profile9_history_count > 20)
-    milan_profile9_temporal_class3 (
-      state, valid, rows, columns, broken_mask);
+    {
+      milan_profile9_build_history_qualified (
+        state, valid, rows, columns, history_qualified);
+      secondary_histogram_state = milan_profile9_histogram_state (
+        state->profile9_history_reference, history_qualified, count, 0);
+      secondary_count_state = milan_profile9_secondary_count_state (
+        state->profile9_history_reference, history_qualified, rows, columns);
+      if (secondary_histogram_state == 0 && secondary_count_state == 0 &&
+          !history_initialized)
+        secondary_histogram_state = milan_profile9_histogram_state (
+          state->calibration_map, history_qualified, count, 0);
+      milan_profile9_temporal_class3 (
+        state, history_qualified, rows, columns, broken_mask);
+    }
 
   for (size_t row = 3; row + 3 < rows; row++)
     for (size_t column = 3; column + 3 < columns; column++)
@@ -1155,6 +1750,11 @@ goodix_milan_profile9_build_broken_mask (
         if (normalized_live[index] < 50)
           broken_mask[index] = 3;
       }
+
+  directional_state = milan_profile9_directional_state (
+    normalized_live, valid, rows, columns, active_count);
+  if (primary_histogram_state == 2 || directional_state == 2)
+    secondary_histogram_state++;
 
   size_t class1_count = 0;
   size_t class2_count = 0;
@@ -1174,6 +1774,11 @@ goodix_milan_profile9_build_broken_mask (
   state->profile9_class_counts.profile9_class1_count = (uint32_t) class1_count;
   state->profile9_class_counts.profile9_class2_count = (uint32_t) class2_count;
   state->profile9_class_counts.profile9_class3_count = (uint32_t) class3_count;
+  state->extraction_auxiliary.primary_histogram_state =
+    primary_histogram_state;
+  state->extraction_auxiliary.prior_selected_plane = prior_selected_plane;
+  state->extraction_auxiliary.promoted_secondary_histogram_state =
+    secondary_histogram_state;
   *mode = 0;
   *apply_mask = 0;
   if (class3_count * 100 > mask_count * 15)
@@ -1214,6 +1819,8 @@ out:
   free (direction);
   free (gradient);
   free (blurred);
+  free (history_qualified);
   free (valid);
+  free (prepared);
   return result;
 }

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -266,7 +266,7 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   GoodixMilanRuntimeOutput *output;
   GoodixMilanPrintTemplateInfo probe_info;
   gsize winner_position = G_MAXSIZE;
-  gint preprocess_status;
+  gint32 preprocess_status;
 
   g_return_val_if_fail (input != NULL, NULL);
   output = g_new0 (GoodixMilanRuntimeOutput, 1);
@@ -301,12 +301,25 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   output->preprocess_state = input->preprocess_state;
   output->profile_state = input->profile_state;
   processed = g_malloc (GOODIX_MILAN_SENSOR_PIXELS);
+#ifdef GOODIX53X5_DEBUG
+  output->preprocess_attempted = TRUE;
+#endif
   preprocess_status = goodix_milan_preprocess (
     &output->preprocess_state, &output->profile_state,
     input->setup_tx_on, input->live_raw,
     input->purpose, processed, &output->quality, &output->coverage);
+#ifdef GOODIX53X5_DEBUG
+  output->preprocess_status = preprocess_status;
+  output->preprocess_status_available = TRUE;
+#endif
+  if (preprocess_status != 0)
+    {
+      output->quality = 0;
+      output->coverage = 0;
+    }
   if (preprocess_status != 0 &&
-      preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY)
+      preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY &&
+      preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION)
     {
       output->status = GOODIX_MILAN_RUNTIME_RETRY;
       g_set_error_literal (&output->error, GOODIX_MILAN_PRINT_ERROR,
@@ -315,10 +328,13 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
       return output;
     }
 #ifdef GOODIX53X5_DEBUG
-  output->processed_image = g_bytes_new (processed, GOODIX_MILAN_SENSOR_PIXELS);
+  output->preprocess_completed = preprocess_status == 0;
+  if (output->preprocess_completed)
+    output->processed_image = g_bytes_new (processed, GOODIX_MILAN_SENSOR_PIXELS);
 #endif
   output->preprocess_state_valid = TRUE;
-  if (preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY)
+  if (preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY ||
+      preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION)
     {
       output->status = GOODIX_MILAN_RUNTIME_RETRY;
       g_set_error_literal (&output->error, GOODIX_MILAN_PRINT_ERROR,
@@ -331,6 +347,9 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
         G_MAXSIZE))
     return output;
 
+#ifdef GOODIX53X5_DEBUG
+  output->extraction_attempted = TRUE;
+#endif
   probe = goodix_match_extract_native (
     processed, &output->preprocess_state, input->live_raw, input->tcode,
     input->dac_high, input->dac_low, input->sensor_subtype);
@@ -345,6 +364,9 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
       goodix_match_free_info (probe);
       return output;
     }
+#ifdef GOODIX53X5_DEBUG
+  output->extraction_completed = TRUE;
+#endif
   output->probe_template = g_bytes_ref (probe_template);
   output->probe_record_count = probe_info.partition0_count +
                                probe_info.partition1_count;
@@ -369,6 +391,7 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
       const guint8 *feature;
       gsize feature_len;
       GoodixSigfmTemplateStatus status;
+      gboolean template_valid;
 
       result->gallery_position = position;
       result->gallery_index = gallery->gallery_index;
@@ -386,9 +409,13 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
           return output;
         }
 
-      if (!goodix_milan_print_validate_template (
-            gallery->template_bytes, &result->template_info,
-            &result->validation_error))
+      template_valid = goodix_milan_print_validate_template (
+        gallery->template_bytes, &result->template_info,
+        &result->validation_error);
+#ifdef GOODIX53X5_DEBUG
+      result->validation_observed = TRUE;
+#endif
+      if (!template_valid)
         {
           output->invalid_gallery_count++;
           goodix_study_queue_free (queue);
@@ -412,6 +439,7 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
           continue;
         }
 #ifdef GOODIX53X5_DEBUG
+      result->queue_before_match_observed = TRUE;
       result->queue_state_before_match = queue->enabled_state;
       result->queue_counter_before_match = queue->transaction_counter;
       result->queue_occupied_before_match = goodix_study_queue_occupied (queue);
@@ -422,12 +450,8 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
         queue);
       result->evaluated = TRUE;
 #ifdef GOODIX53X5_DEBUG
+      result->queue_after_match_observed = TRUE;
       result->queue_occupied_after_match = goodix_study_queue_occupied (queue);
-      result->after_match_template = after_match ? g_bytes_ref (after_match) : NULL;
-#endif
-#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
-      goodix_milan_runtime_hash_bytes (
-        after_match, result->after_match_sha256);
 #endif
       output->evaluated_gallery_count++;
       if (status != GOODIX_SIGFM_TEMPLATE_OK || !after_match)
@@ -442,6 +466,13 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
           goodix_study_queue_free (queue);
           continue;
         }
+#ifdef GOODIX53X5_DEBUG
+      result->after_match_template = g_bytes_ref (after_match);
+#endif
+#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
+      goodix_milan_runtime_hash_bytes (
+        after_match, result->after_match_sha256);
+#endif
       result->score = result->match_result.score;
       result->accepted = result->score > 0;
       output->score = result->score;
@@ -495,11 +526,26 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   const guint8 *after_match_data;
   gsize after_match_size;
   GoodixSigfmTemplateStatus study_status;
+#ifdef GOODIX53X5_DEBUG
+  GoodixMilanRuntimeGalleryResult *winner_result;
+#endif
 
   after_match_data = g_bytes_get_data (winner_after_match, &after_match_size);
+#ifdef GOODIX53X5_DEBUG
+  output->study_attempted = TRUE;
+#endif
   study_status = goodix_milan_runtime_study (
     input, probe, after_match_data, after_match_size, &output->match_result,
     winner_queue, &after_study, &output->study_action);
+#ifdef GOODIX53X5_DEBUG
+  winner_result = g_ptr_array_index (output->gallery_results, winner_position);
+
+  winner_result->queue_after_study_observed = TRUE;
+  winner_result->queue_state_after_study = winner_queue->enabled_state;
+  winner_result->queue_counter_after_study = winner_queue->transaction_counter;
+  winner_result->queue_occupied_after_study =
+    goodix_study_queue_occupied (winner_queue);
+#endif
   if (study_status != GOODIX_SIGFM_TEMPLATE_OK)
     {
       g_set_error_literal (&output->learning_error, GOODIX_MILAN_PRINT_ERROR,
@@ -509,6 +555,9 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
       goodix_match_free_info (probe);
       return output;
     }
+#ifdef GOODIX53X5_DEBUG
+  output->study_completed = TRUE;
+#endif
   if (goodix_milan_runtime_cancelled (
         input, output, GOODIX_MILAN_RUNTIME_CHECKPOINT_AFTER_STUDY,
         winner_position))

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -312,11 +312,6 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   output->preprocess_status = preprocess_status;
   output->preprocess_status_available = TRUE;
 #endif
-  if (preprocess_status != 0)
-    {
-      output->quality = 0;
-      output->coverage = 0;
-    }
   if (preprocess_status != 0 &&
       preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY &&
       preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION)

--- a/drivers/goodix53x5/milan/runtime.h
+++ b/drivers/goodix53x5/milan/runtime.h
@@ -70,10 +70,17 @@ typedef struct
   gchar                         after_match_sha256[65];
 #endif
 #ifdef GOODIX53X5_DEBUG
+  gboolean                      validation_observed;
+  gboolean                      queue_before_match_observed;
+  gboolean                      queue_after_match_observed;
+  gboolean                      queue_after_study_observed;
   guint32                       queue_state_before_match;
   guint32                       queue_counter_before_match;
   gsize                         queue_occupied_before_match;
   gsize                         queue_occupied_after_match;
+  guint32                       queue_state_after_study;
+  guint32                       queue_counter_after_study;
+  gsize                         queue_occupied_after_study;
 #endif
 } GoodixMilanRuntimeGalleryResult;
 
@@ -101,6 +108,14 @@ typedef struct _GoodixMilanRuntimeOutput
   gint                          quality;
   gint                          coverage;
 #ifdef GOODIX53X5_DEBUG
+  gboolean                      preprocess_attempted;
+  gboolean                      preprocess_completed;
+  gboolean                      preprocess_status_available;
+  gint32                        preprocess_status;
+  gboolean                      extraction_attempted;
+  gboolean                      extraction_completed;
+  gboolean                      study_attempted;
+  gboolean                      study_completed;
   GBytes                       *processed_image;
 #endif
   GBytes                       *probe_template;

--- a/meson-integration.patch
+++ b/meson-integration.patch
@@ -2,7 +2,7 @@ diff --git a/meson_options.txt b/meson_options.txt
 index 8f59b28..a9af6ec 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -34,3 +34,7 @@ option('installed-tests',
+@@ -34,3 +34,15 @@ option('installed-tests',
         description: 'Whether to install the installed tests',
         type: 'boolean',
         value: true)
@@ -10,6 +10,14 @@ index 8f59b28..a9af6ec 100644
 +       description: 'Build opt-in Goodix 53x5 image and timing diagnostics',
 +       type: 'boolean',
 +       value: false)
++option('goodix53x5_debug_build_id',
++       description: 'Unique build identity emitted by Goodix 53x5 diagnostics',
++       type: 'string',
++       value: '')
++option('goodix53x5_debug_source_id',
++       description: 'Deterministic source identity embedded in Goodix 53x5 debug builds',
++       type: 'string',
++       value: '')
 diff --git a/libfprint/meson.build b/libfprint/meson.build
 index ae0f6e2..bb4bc29 100644
 --- a/libfprint/meson.build

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -9,8 +9,32 @@ libfprint_dir="$work_dir/libfprint"
 libfprint_ref="${GOODIX_LIBFPRINT_REF:-v1.94.10}"
 build_dir="${GOODIX_MESON_BUILDDIR:-builddir}"
 debug_enabled=false
+debug_build_id=
+debug_source_id=
 if [[ "${GOODIX53X5_DEBUG:-0}" == 1 ]]; then
+  if [[ ${GOODIX53X5_INTERNAL_BUILD_ID+x} == x ]] &&
+     [[ ! ${GOODIX53X5_INTERNAL_BUILD_ID} =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'internal Goodix debug build ID must be exactly 64 lowercase hex characters\n' >&2
+    exit 1
+  fi
+  if [[ ${GOODIX53X5_INTERNAL_SOURCE_ID+x} == x ]] &&
+     [[ ! ${GOODIX53X5_INTERNAL_SOURCE_ID} =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'internal Goodix debug source ID must be exactly 64 lowercase hex characters\n' >&2
+    exit 1
+  fi
   debug_enabled=true
+  debug_build_id="${GOODIX53X5_INTERNAL_BUILD_ID:-$(od -An -N32 -tx1 /dev/urandom | tr -d '[:space:]')}"
+  debug_source_id="$($repo_dir/tools/milan-parity/build-identity "$repo_dir")"
+  if [[ ! $debug_build_id =~ ^[0-9a-f]{64}$ ||
+        ! $debug_source_id =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'failed to produce valid Goodix debug build provenance\n' >&2
+    exit 1
+  fi
+  if [[ -n ${GOODIX53X5_INTERNAL_SOURCE_ID:-} &&
+        ${GOODIX53X5_INTERNAL_SOURCE_ID} != "$debug_source_id" ]]; then
+    printf 'internal Goodix debug source ID differs from the deterministic source identity\n' >&2
+    exit 1
+  fi
 fi
 meson_options=(
   --prefix=/usr
@@ -21,6 +45,8 @@ meson_options=(
   -Dinstalled-tests=false
   -Ddoc=false
   -Dgoodix53x5_debug="$debug_enabled"
+  -Dgoodix53x5_debug_build_id="$debug_build_id"
+  -Dgoodix53x5_debug_source_id="$debug_source_id"
 )
 
 mkdir -p "$work_dir"
@@ -84,8 +110,9 @@ if ! grep -q "'goodix53x5'" "$libfprint_dir/libfprint/meson.build"; then
 fi
 
 if [ -d "$libfprint_dir/$build_dir" ]; then
-  # Register overlay-defined options before assigning them in an older builddir.
-  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure
+  # Register new overlay options without evaluating stale cached debug settings.
+  meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure \
+    -Dgoodix53x5_debug=false
   meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" --reconfigure "${meson_options[@]}"
 else
   meson setup "$libfprint_dir/$build_dir" "$libfprint_dir" "${meson_options[@]}"

--- a/scripts/build-milan-stack-local.sh
+++ b/scripts/build-milan-stack-local.sh
@@ -10,7 +10,7 @@ source "$script_dir/lib/milan-stack-common.sh"
 
 milan_validate_prefix
 milan_reject_ephemeral_root "GOODIX_MILAN_STACK_ROOT" "$MILAN_STACK_ROOT"
-for command in git flock timeout meson ninja sha256sum ldd install strings; do
+for command in git flock timeout meson ninja sha256sum ldd install strings od tr; do
   milan_require_command "$command"
 done
 milan_verify_repo_inputs "$repo_dir"
@@ -20,6 +20,16 @@ case "${GOODIX53X5_DEBUG:-0}" in
   1) debug_enabled=true; debug_manifest=1; build_kind=debug ;;
   *) milan_die "GOODIX53X5_DEBUG must be 0 or 1" ;;
 esac
+debug_build_id=
+debug_source_id=
+if [[ "$debug_manifest" == 1 ]]; then
+  debug_build_id="$(od -An -N32 -tx1 /dev/urandom | tr -d '[:space:]')"
+  debug_source_id="$($repo_dir/tools/milan-parity/build-identity "$repo_dir")"
+  if [[ ! $debug_build_id =~ ^[0-9a-f]{64}$ ||
+        ! $debug_source_id =~ ^[0-9a-f]{64}$ ]]; then
+    milan_die "failed to produce valid Goodix debug build provenance"
+  fi
+fi
 
 source_root="$MILAN_STACK_ROOT/sources"
 mkdir -p "$source_root"
@@ -73,6 +83,8 @@ milan_run_stage "apply repository libfprint and driver overlay" env \
   GOODIX_LIBFPRINT_OFFLINE=1 \
   GOODIX_MESON_BUILDDIR=builddir \
   GOODIX53X5_DEBUG="$debug_manifest" \
+  GOODIX53X5_INTERNAL_BUILD_ID="$debug_build_id" \
+  GOODIX53X5_INTERNAL_SOURCE_ID="$debug_source_id" \
   "$script_dir/build-local.sh"
 
 libfprint_source="$staging/libfprint-overlay/libfprint"
@@ -85,7 +97,9 @@ milan_run_stage "configure paired shadow libfprint" meson setup "$libfprint_buil
   "$libfprint_source" --reconfigure --prefix="$MILAN_PREFIX" --libdir=lib \
   -Ddrivers=goodix53x5 -Dudev_hwdb=disabled -Dudev_rules=disabled \
   -Dintrospection=false -Dinstalled-tests=false -Ddoc=false \
-  -Dgoodix53x5_debug="$debug_enabled"
+  -Dgoodix53x5_debug="$debug_enabled" \
+  -Dgoodix53x5_debug_build_id="$debug_build_id" \
+  -Dgoodix53x5_debug_source_id="$debug_source_id"
 milan_run_stage "build paired shadow libfprint" ninja -C "$libfprint_build"
 milan_run_stage "test libfprint update result" meson test -C "$libfprint_build" \
   --print-errorlogs fpi-device
@@ -124,6 +138,8 @@ cat > "$payload_prefix/manifest/build.env" <<EOF
 FORMAT=1
 PREFIX=$MILAN_PREFIX
 GOODIX53X5_DEBUG=$debug_manifest
+GOODIX53X5_DEBUG_BUILD_ID=$debug_build_id
+GOODIX53X5_DEBUG_SOURCE_ID=$debug_source_id
 LIBFPRINT_REVISION=$MILAN_LIBFPRINT_REVISION
 LIBFPRINT_SOURCE_TREE=$(git -C "$libfprint_pristine" rev-parse HEAD^{tree})
 FPRINTD_REVISION=$MILAN_FPRINTD_REVISION

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -31,9 +31,9 @@ static const char accepted_preprocess_sha256[] =
 static const char post_render_retry_sha256[] =
   "8b9629cb2aa7bf3d44a13c9ab087b961e02adf29644c237032597bf24401d943";
 static const char feature_extraction_sha256[] =
-  "ab009fd4dd0360b0998550a874364379b145b006c9b1b1c8a2cef57083372190";
+  "134e2432ad88c1cc4bfd9156fbf16557ea455d9de13a4f847241ebcc892ac600";
 static const char feature_template_sha256[] =
-  "2613b09571d11ce4ed7567535a220ddb5eb17d5059c7dff8bfc97e6e5af28cdd";
+  "2935dff248dbd6b10b045669a01ec6bf4b69d9cccb241daa5ea8f759a5bb0773";
 static const char feature_antifake_sha256[] =
   "2ec6a813e8a6b355693645aac1e60da4cc717bcdf57c3dbb5d12d7021b0e7572";
 
@@ -990,7 +990,7 @@ test_generated_production_replay (void)
                          &after_match, match_queue), ==,
                        GOODIX_SIGFM_TEMPLATE_OK);
       g_assert_nonnull (after_match);
-      g_assert_cmpint (result.score, ==, -4);
+      g_assert_cmpint (result.score, ==, 0);
       g_assert_cmpuint (result.matched_feature_index, ==, SIZE_MAX);
       for (size_t i = 0; i < G_N_ELEMENTS (result.match_transform); i++)
         g_assert_cmpint (result.match_transform[i],

--- a/tools/milan-parity/build-identity
+++ b/tools/milan-parity/build-identity
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import sys
+
+from milan_parity_common import HarnessError, source_identity
+
+
+try:
+    if len(sys.argv) != 2:
+        raise HarnessError(f"usage: {Path(sys.argv[0]).name} REPOSITORY")
+    print(source_identity(Path(sys.argv[1])))
+except HarnessError as error:
+    print(f"build-identity: {error}", file=sys.stderr)
+    raise SystemExit(2) from error

--- a/tools/milan-parity/milan_parity_common.py
+++ b/tools/milan-parity/milan_parity_common.py
@@ -1,0 +1,236 @@
+"""Shared strict I/O and contract helpers for Milan dump replay."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+from typing import Any, Iterator
+
+
+RUNTIME_SCHEMA = "goodix53x5-runtime-debug/v3"
+DRIVER_BUILD_SCHEMA = "milan-parity-driver-build/v2"
+CASE_SCHEMA = "milan-parity-case/v1"
+CORPUS_SCHEMA = "milan-parity-corpus/v1"
+RECORD_SCHEMA = "milan-parity-record/v1"
+REPORT_SCHEMA = "milan-parity-dump-report/v2"
+POLICY = {
+    "anti_fake_mode": 1,
+    "boundary_policy": "canonical-zero-v1",
+    "print_schema": 4,
+    "profile": 9,
+    "subtype": 12,
+}
+UINT32_MAX = (1 << 32) - 1
+UINT64_MAX = (1 << 64) - 1
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def canonical(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"),
+                       ensure_ascii=True) + "\n").encode("ascii")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as error:
+        raise HarnessError(f"cannot read {path}: {error.strerror or error}") from error
+    return digest.hexdigest()
+
+
+def load_json(path: Path, label: str = "JSON") -> Any:
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as error:
+        raise HarnessError(f"cannot read {label} {path}: {error}") from error
+    if raw != canonical(value):
+        raise HarnessError(f"{label} is not canonical JSON: {path}")
+    return value
+
+
+def write_atomic(path: Path, value: bytes, mode: int = 0o600) -> None:
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        partial = path.with_name(f".{path.name}.partial-{os.getpid()}")
+        fd = os.open(partial, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(value)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(partial, path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                partial.unlink()
+    except OSError as error:
+        raise HarnessError(f"cannot write {path}: {error.strerror or error}") from error
+
+
+def write_new_atomic(path: Path, value: bytes, mode: int = 0o600) -> None:
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        partial = path.with_name(f".{path.name}.partial-{os.getpid()}")
+        fd = os.open(partial, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(value)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.link(partial, path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                partial.unlink()
+    except FileExistsError as error:
+        raise HarnessError(f"refusing to overwrite existing file: {path}") from error
+    except OSError as error:
+        raise HarnessError(f"cannot write {path}: {error.strerror or error}") from error
+
+
+def ensure_private_directory(path: Path, create: bool = False) -> Path:
+    path = path.expanduser().resolve()
+    try:
+        if create:
+            path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        metadata = path.stat()
+    except OSError as error:
+        raise HarnessError(f"private directory is unavailable: {path}: {error.strerror or error}") from error
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise HarnessError(f"not a directory: {path}")
+    if metadata.st_mode & 0o077:
+        raise HarnessError(f"private directory must be owner-only (0700): {path}")
+    if metadata.st_uid != os.getuid():
+        raise HarnessError(f"private directory is not owned by the invoking user: {path}")
+    return path
+
+
+def contained(root: Path, relative: str, label: str) -> Path:
+    if not isinstance(relative, str):
+        raise HarnessError(f"{label} path must be a string")
+    member = Path(relative)
+    if member.is_absolute() or not member.parts or ".." in member.parts:
+        raise HarnessError(f"{label} path must be relative and contained")
+    current = root
+    for part in member.parts:
+        current = current / part
+        if current.is_symlink():
+            raise HarnessError(f"{label} must not traverse a symlink: {relative}")
+    resolved = (root / member).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise HarnessError(f"{label} escapes the dump: {relative}") from error
+    return resolved
+
+
+def require_exact_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HarnessError(f"{label} must be an object")
+    missing = sorted(keys - value.keys())
+    unexpected = sorted(value.keys() - keys)
+    if missing or unexpected:
+        detail = []
+        if missing:
+            detail.append("missing " + ", ".join(missing))
+        if unexpected:
+            detail.append("unexpected " + ", ".join(unexpected))
+        raise HarnessError(f"{label} fields differ: {'; '.join(detail)}")
+    return value
+
+
+def require_uint(value: Any, maximum: int, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= maximum:
+        raise HarnessError(f"{label} must be an unsigned integer no greater than {maximum}")
+    return value
+
+
+def require_int32(value: Any, label: str) -> int:
+    if (not isinstance(value, int) or isinstance(value, bool) or
+            not -(1 << 31) <= value < (1 << 31)):
+        raise HarnessError(f"{label} must be an int32")
+    return value
+
+
+def require_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise HarnessError(f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def run(command: tuple[str, ...] | list[str], label: str, **kwargs: Any) -> subprocess.CompletedProcess:
+    try:
+        process = subprocess.run(command, check=False, **kwargs)
+    except (OSError, subprocess.SubprocessError) as error:
+        raise HarnessError(f"{label} could not run: {error}") from error
+    if process.returncode:
+        stderr = getattr(process, "stderr", b"")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", "replace")
+        diagnostic = str(stderr).strip()
+        suffix = f": {diagnostic}" if diagnostic else ""
+        raise HarnessError(f"{label} failed with status {process.returncode}{suffix}")
+    return process
+
+
+def default_state_root() -> Path:
+    base = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return base / "milan-parity"
+
+
+@contextlib.contextmanager
+def locked_state(path_value: str | None) -> Iterator[Path]:
+    root = ensure_private_directory(Path(path_value) if path_value else default_state_root(),
+                                    create=True)
+    lock_path = root / "lock"
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError as error:
+        raise HarnessError(f"cannot open parity state lock: {error.strerror or error}") from error
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        work = root / "work"
+        if work.exists():
+            for child in work.iterdir():
+                if child.name.startswith(".partial-"):
+                    shutil.rmtree(child) if child.is_dir() else child.unlink()
+        yield root
+    except OSError as error:
+        raise HarnessError(f"parity state filesystem error: {error.strerror or error}") from error
+    finally:
+        os.close(fd)
+
+
+def source_identity(repo: Path) -> str:
+    repo = repo.expanduser().resolve()
+    roots = [repo / "drivers" / "goodix53x5"]
+    fixed = [repo / "meson-integration.patch", repo / "scripts" / "build-local.sh"]
+    paths = sorted(path for root in roots for path in root.rglob("*") if path.is_file())
+    paths.extend(fixed)
+    digest = hashlib.sha256()
+    try:
+        for path in paths:
+            if not path.is_file():
+                raise HarnessError(f"build identity input is missing: {path}")
+            digest.update(str(path.relative_to(repo)).encode("utf-8") + b"\0")
+            digest.update(path.read_bytes())
+    except OSError as error:
+        raise HarnessError(f"cannot calculate build identity: {error.strerror or error}") from error
+    return digest.hexdigest()


### PR DESCRIPTION
## Stack

PR 1 of 3 in an all-or-nothing stack completed by #39. This PR introduces the runtime-debug/v3 writer; #38 provides its sole supported reader. Do not merge this PR independently. Transitional support for older dump schemas is deliberately excluded.

## Summary

- Align profile 9/type 12 runtime behavior with the native implementation.
- Emit strict runtime-debug/v3 evidence with random build IDs and deterministic production source identities.
- Preserve exact retry, cancellation, gallery, queue, and study lifecycle state.

## Parity corrections

- Match native raw-admission retry behavior observed at identify 151.
- Preserve quality and coverage returned by stateful `0x7531` retries while early validation retries remain `0/0`.
- Reproduce packed classification and the independent matcher auxiliary class observed at identify 19.
- Use native flat-buffer anti-fake impulse adjacency observed at identify 59.
- Clamp over-range raw values before admission, matching recovered native control flow.

## Validation

- The controlled Linux and approved-DLL `0x7531` witness is exact at quality/coverage `0/18`.
- Targeted identify 19, 59, and 151 comparisons are exact.
- The corrected full stack passed 643/643 selected operations from the unchanged sealed campaign.
- Debug and release builds pass.
- Existing Milan synthetic, state, and runtime suites pass.