### PR TITLE
Restore Milan first-veto predicate grouping

### DIFF
--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -339,8 +339,9 @@ first_veto_type12 (const int32_t metrics[77],
                      (filtered > 17 || combined > 402 || geometry > 30) &&
                      (filtered > 13 || combined > 415 || geometry > 12))) &&
     (primary > 8 || filtered > 16 || combined > 402 || geometry > 18) &&
-    (primary > 10 || filtered > 16 || detail > 210 || geometry > 16 ||
-                     overlap > 229 || combined > 410 || coverage < 110) &&
+    (primary > 10 || filtered > 16 ||
+                     ((detail > 210 || geometry > 16) &&
+                      (overlap > 229 || combined > 410 || coverage < 110))) &&
     (primary > 12 || ((filtered > 17 || combined > 405 || geometry > 22) &&
                       (filtered > 22 || combined > 370 || geometry > 30 || overlap > 215))) &&
     (primary > 7 || filtered > 14 || detail > 208 || low_detail > 202 || geometry > 18) &&


### PR DESCRIPTION
## Stack

PR 4 of 4 in the existing all-or-nothing Milan parity stack, directly above #39. Merge the stack through this PR.

## Summary

- Restore the nested Boolean grouping used by the native profile-9/type-12 first-veto policy.
- Keep a mixed-strength feature aggregate-eligible without incorrectly promoting it to a direct positive.
- Preserve later-feature evaluation, selected-owner lifecycle, and downstream action-4 learning ownership.

## Root cause

Identify epoch 26 exposed a generic translation error. The DLL requires:

```text
(strong detail OR strong geometry) AND
(strong overlap OR strong combined evidence OR favorable coverage)
```

The clean-room implementation flattened those groups into one OR. A feature with useful aggregate evidence but weak direct geometry was therefore promoted to direct-positive, causing later features to be skipped. Authentication and action 4 still succeeded, but score, selected feature, after-match template, and final learned candidate diverged.

The correction changes only that Boolean grouping. It does not adjust thresholds, scores, selected features, study policy, relations, or hashes.

## Validation

- Focused failing selector: 1/1 exact at native score 25, selected feature 12, after-match hash, and final candidate hash.
- Discovering campaign: 248/248 selected operations passed.
- Enrollment follow-up campaign: 643/643 selected operations passed.
- Prior expanded campaign: 511/511 selected operations passed.
- Total exact-head parity coverage: 1,402/1,402 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Ghidra-backed predicate, routing, causal, semantic, and action-4 audit notes are available on `milan-dev`, including `re/milan/IDENTIFY-26-ACTION4-SEMANTIC-AUDIT-20260808.md`.