### PR TITLE
Preserve Milan replacement c0 ownership

### DIFF
--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -829,6 +829,7 @@ goodix_milan_study_replace (
   int32_t target_bd;
   int32_t target_be;
   int32_t target_c0;
+  int32_t probe_c0;
   int32_t matched_be;
   GoodixMilanFeatureView target_feature;
   GoodixMilanFeatureView probe_feature;
@@ -858,6 +859,8 @@ goodix_milan_study_replace (
         current->feature_elements[replacement_index],
         current->feature_element_sizes[replacement_index], 0xc0,
         &target_c0) != 0 || goodix_milan_template_read_feature_scalar (
+        probe->feature_elements[0], probe->feature_element_sizes[0], 0xc0,
+        &probe_c0) != 0 || goodix_milan_template_read_feature_scalar (
         current->feature_elements[matched_feature_index],
         current->feature_element_sizes[matched_feature_index], 0xbe,
         &matched_be) != 0 || goodix_milan_template_parse_feature_element (
@@ -947,7 +950,7 @@ goodix_milan_study_replace (
     { 0xbe, policy_result.action ==
                 GOODIX_MILAN_STUDY_ACTION_REPLACE_NO_RELATION
               ? target_be : matched_be },
-    { 0xc0, target_c0 },
+    { 0xc0, probe_c0 != 0 && (probe_c0 & 1) != 0 ? probe_c0 : target_c0 },
   };
   for (size_t i = 0; i < sizeof(scalar_patches) / sizeof(scalar_patches[0]);
        i++)


### PR DESCRIPTION
## Stack

PR 5 of 5 in the existing all-or-nothing Milan parity stack, directly above #42. Merge the stack through this PR.

## Summary

- Match native conditional ownership of replacement field `c0`.
- Import probe `c0` only when it is nonzero and odd.
- Preserve target `c0` for zero and even probe values.

## Native contract

The approved DLL branch at `FUN_1800458c0:0x18004594e..0x180045961` does not assign `c0` entirely to either the probe or replacement target. It conditionally imports an odd nonzero probe value; all other values retain the target field.

Linux previously rebuilt the replacement from the probe and then always restored target `c0`, losing valid odd probe values. The correction applies the complete native condition without action, feature, row, or hash special cases.

## Validation

- Controlled target `c0=42`, probe `c0=0`: current/DLL output 42.
- Controlled target `c0=42`, probe `c0=2`: current/DLL output 42.
- Controlled target `c0=42`, probe `c0=3`: current/DLL output 3.
- Current independent campaign: 450/450 selected operations passed.
- Prior independent campaign: 643/643 selected operations passed.
- Total unique exact-head parity coverage: 1,093/1,093 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Natural retained probes currently use `c0=0`; this closes the generic valid-input contract for externally supplied or future odd values. Ghidra-backed replacement, target-selection, and fallback audit notes are available on `milan-dev`.