### PR TITLE
Complete Milan action 1 append contracts

### DIFF
--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -147,15 +147,13 @@ goodix_match_study_feature_internal (
 
   probe_milan = probe_feature;
   probe_milan_len = probe_feature_len;
-  if (probe_milan_len > GOODIX_MILAN_TEMPLATE_MAX_SIZE - 45 ||
-      enrolled_milan_len > GOODIX_MILAN_TEMPLATE_MAX_SIZE - probe_milan_len -
-                              45)
+  if (probe_milan_len > GOODIX_MILAN_TEMPLATE_MAX_SIZE)
     return GOODIX_SIGFM_TEMPLATE_INVALID;
 
   enrolled = g_malloc (sizeof(*enrolled));
   probe = g_malloc (sizeof(*probe));
   updated = g_malloc (sizeof(*updated));
-  packed_capacity = enrolled_milan_len + probe_milan_len + 45;
+  packed_capacity = GOODIX_MILAN_TEMPLATE_MAX_SIZE;
   packed = g_malloc (packed_capacity);
   if (goodix_milan_template_unpack (
         enrolled_milan, enrolled_milan_len, enrolled) != 0 ||

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -488,6 +488,7 @@ goodix_milan_study_append (
     { 0xba, 1 },
     { 0xbb, 0 },
     { 0xbc, (int32_t) current->feature_count },
+    { 0xbd, 0 },
     { 0xbe, matched_study_count },
   };
   for (size_t i = 0; i < sizeof(scalar_patches) / sizeof(scalar_patches[0]);


### PR DESCRIPTION
## Stack

PR 6 of 6 in the existing all-or-nothing Milan parity stack, directly above #43. Merge the stack through this PR.

## Summary

- Size the private study output for maximum valid relation growth during append.
- Initialize appended lifecycle field `bd` to the native literal zero.
- Keep both corrections isolated as separate commits.

## Native contract

A capacity-reaching append can materialize retained reference relations before adding the new feature. The previous `enrolled + probe + 45` estimate could reject a valid result even though it remained below the existing 1 MiB profile limit. The DLL mutates preallocated live storage and has no equivalent underestimate.

The DLL append helper also writes `bd=0` unconditionally. Linux previously retained a synthetic probe value; natural extraction currently emits zero, but valid external inputs could diverge.

## Validation

- Current independent campaign: 450/450 selected operations passed.
- Prior independent campaign: 643/643 selected operations passed.
- Total unique exact-head parity coverage: 1,093/1,093 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Ghidra-backed append and maximum-capacity contracts are documented on `milan-dev` before this PR was opened.