### PR TITLE
Use Milan full-domain action 2 fallback

### DIFF
--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -118,7 +118,7 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
   else if (input->retained_flag == 0)
     {
       if ((int64_t) input->primary_transform_area * 100 <=
-          (int64_t) GOODIX_MILAN_STUDY_MASK_SIZE * 80)
+          (int64_t) (104 * 88) * 80)
         return 0;
       selected = matched;
       selected_index = input->matched_feature_index;
@@ -207,6 +207,25 @@ goodix_milan_study_policy_footprint_area (const int32_t transform[6])
 
   memset (mask, 1, sizeof(mask));
   return goodix_milan_study_policy_remove_footprint (mask, transform);
+}
+
+int32_t
+goodix_milan_study_policy_full_footprint_area (const int32_t transform[6])
+{
+  int32_t area = 0;
+
+  for (int32_t y = 0; y < 88; y++)
+    for (int32_t x = 0; x < 104; x++)
+      {
+        int64_t mapped_x = (int64_t) transform[0] * x +
+                           (int64_t) transform[1] * y + transform[2];
+        int64_t mapped_y = (int64_t) transform[3] * x +
+                           (int64_t) transform[4] * y + transform[5];
+
+        area += mapped_x >= 0 && mapped_x <= 103 * 0x100 &&
+                mapped_y >= 0 && mapped_y <= 87 * 0x100;
+      }
+  return area;
 }
 
 int32_t

--- a/drivers/goodix53x5/milan/study/policy.h
+++ b/drivers/goodix53x5/milan/study/policy.h
@@ -80,4 +80,7 @@ int32_t
 goodix_milan_study_policy_footprint_area (const int32_t transform[6]);
 
 int32_t
+goodix_milan_study_policy_full_footprint_area (const int32_t transform[6]);
+
+int32_t
 goodix_milan_study_policy_footprint_percent (const int32_t transform[6]);

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -626,12 +626,8 @@ milan_study_policy_derive (
   input->template_counter = (int32_t) goodix_milan_template_read_u32 (
     current->tail_state + 0x510);
 
-  int32_t adjusted_primary[6];
-  memcpy (adjusted_primary, primary_transform, sizeof(adjusted_primary));
-  adjusted_primary[2] >>= 1;
-  adjusted_primary[5] >>= 1;
   input->primary_transform_area =
-    goodix_milan_study_policy_footprint_area (adjusted_primary);
+    goodix_milan_study_policy_full_footprint_area (primary_transform);
 
   for (size_t i = 0; i < current->feature_count; i++)
     {


### PR DESCRIPTION
## Stack

PR 7 of 7 in the existing all-or-nothing Milan parity stack, directly above #44. Merge the stack through this PR.

## Summary

- Evaluate the action-2 flag-zero fallback over the native 104x88 domain.
- Preserve the original transform translations instead of halving them for a 52x44 approximation.
- Keep the native strict greater-than-80-percent boundary.

## Native contract

The DLL measures the primary transform over all 9,152 full-domain pixels. Linux previously measured a half-resolution approximation, which can disagree at odd and subpixel boundaries and change action 0 into action 2 or vice versa.

The controlled transform `[240,-24,-3472,24,240,0]` covers 7,329/9,152 pixels in the DLL and passes the strict 80-percent gate. The former half-domain result was 1,813/2,288 and incorrectly failed.

## Validation

- Focused control: current/DLL full-domain area 7,329/9,152 and action 2.
- Current independent campaign: 450/450 selected operations passed.
- Prior independent campaign: 643/643 selected operations passed.
- Total unique exact-head parity coverage: 1,093/1,093 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Ghidra-backed action-2 selector and fallback contracts are documented on `milan-dev` before this PR was opened.