### PR TITLE
Rank Milan action 3 by raw overlap area

### DIFF
--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -125,16 +125,17 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
     }
   else
     {
-      int32_t best_percent = INT32_MIN;
+      int32_t best_area = INT32_MIN;
 
       for (size_t i = 0; i < input->feature_count; i++)
         if (input->features[i].active != 0 && input->features[i].state != 5 &&
-            input->features[i].geometric_overlap_percent > best_percent)
+            input->features[i].geometric_overlap_area > best_area)
           {
             selected = &input->features[i];
             selected_index = i;
-            best_percent = selected->geometric_overlap_percent;
+            best_area = selected->geometric_overlap_area;
           }
+      int32_t best_percent = selected ? selected->geometric_overlap_percent : 0;
       if (!selected ||
           (best_percent < 80 &&
            (best_percent < 60 || input->template_counter <= 1000)))

--- a/drivers/goodix53x5/milan/study/policy.h
+++ b/drivers/goodix53x5/milan/study/policy.h
@@ -35,6 +35,7 @@ typedef struct
   int32_t residual;
   int32_t overlap_count;
   int32_t uncovered_probe_residual;
+  int32_t geometric_overlap_area;
   int32_t geometric_overlap_percent;
 } GoodixMilanStudyPolicyFeature;
 

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -718,8 +718,10 @@ milan_study_policy_derive (
         reference_to_features[i], relation_transform, candidate_transform);
       candidate_transform[2] >>= 1;
       candidate_transform[5] >>= 1;
-      feature->geometric_overlap_percent =
-        goodix_milan_study_policy_footprint_percent (candidate_transform);
+      feature->geometric_overlap_area =
+        goodix_milan_study_policy_footprint_area (candidate_transform);
+      feature->geometric_overlap_percent = feature->geometric_overlap_area * 100 /
+                                           GOODIX_MILAN_STUDY_MASK_SIZE;
 
     }
   return 0;

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -521,8 +521,11 @@ test_study_policy_actions (void)
           input.features[feature].coverage = 80;
           input.features[feature].residual = 20;
           input.features[feature].uncovered_probe_residual = 0;
+          input.features[feature].geometric_overlap_area =
+            feature == 2 ? 1945 : 1602;
           input.features[feature].geometric_overlap_percent =
-            feature == 2 ? 85 : 70;
+            input.features[feature].geometric_overlap_area * 100 /
+            GOODIX_MILAN_STUDY_MASK_SIZE;
         }
       input.features[input.matched_feature_index].residual =
         cases[i].matched_residual;


### PR DESCRIPTION
## Stack

PR 8 of 8 in the existing all-or-nothing Milan parity stack, directly above #45. Merge the stack through this PR.

## Summary

- Rank geometric action-3 targets by native raw overlap area.
- Convert only the selected winner to an integer percentage for the 80/60 policy gate.
- Preserve earlier-index ownership only for an exact raw-area tie.

## Native contract

The DLL compares raw overlap areas before percentage conversion. Linux previously ranked already-truncated percentages, so two unequal areas that both became 80 percent incorrectly kept the earlier feature.

A controlled pair with areas 1,848 and 1,849 both truncates to 80 percent. The DLL selects the later 1,849-area feature; this change does the same.

## Validation

- Controlled raw-area witness selects the DLL target.
- Current independent campaign: 450/450 selected operations passed.
- Prior independent campaign: 643/643 selected operations passed.
- Total unique exact-head parity coverage: 1,093/1,093 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Ghidra-backed geometric fallback and ranking contracts are documented on `milan-dev` before this PR was opened.