### PR TITLE
Preserve Milan queued overlap state

### DIFF
--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -26,6 +26,7 @@
 #include "milan/match/lifecycle-private.h"
 #include "milan/match/rescue.h"
 #include "milan/milan.h"
+#include "milan/private.h"
 #include "milan/study/queue.h"
 
 #include <string.h>
@@ -106,6 +107,7 @@ goodix_match_study_feature_internal (
   gsize                        *selected_feature_index,
   gboolean                      apply_dispatcher_prepass,
   gboolean                      finalize_study,
+  int32_t                       live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   GoodixMilanStudyTransientState *transient_state)
 {
   const guint8 *enrolled_milan;
@@ -133,7 +135,7 @@ goodix_match_study_feature_internal (
   if (!transient_state)
     transient_state = &transient_storage;
   memset (transient_state, 0, sizeof(*transient_state));
-  if (!probe_feature || !feature || !match_result ||
+  if (!probe_feature || !feature || !match_result || !live_overlap_counts ||
       !updated_feature || !action)
     return GOODIX_SIGFM_TEMPLATE_INVALID;
   enrolled_milan = feature;
@@ -233,6 +235,7 @@ goodix_match_study_feature_internal (
         apply_dispatcher_prepass,
         finalize_study,
         finalize_current_study,
+        live_overlap_counts,
         packed, packed_capacity, &packed_size);
       *action = GOODIX_MILAN_STUDY_APPEND;
       if (selected_feature_index)
@@ -253,6 +256,7 @@ goodix_match_study_feature_internal (
         match_result->match_transform,
         finalize_study,
         finalize_current_study,
+        live_overlap_counts,
         packed, packed_capacity, &packed_size, &action_code,
         selected_feature_index, transient_state);
       *action = (GoodixMilanStudyAction) action_code;
@@ -298,7 +302,36 @@ typedef struct
 {
   GBytes *current;
   GoodixMatchInfo *live_features[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
+  int32_t live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
 } GoodixStudyFollowupContext;
+
+static gboolean
+goodix_match_initialize_study_overlap_counts (
+  const guint8 *feature,
+  gsize         feature_len,
+  int32_t       overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY])
+{
+  GoodixMilanUnpackedTemplate *unpacked;
+  uint8_t *feature_copies[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  gboolean result = FALSE;
+
+  if (!feature || !overlap_counts ||
+      feature_len > GOODIX_MILAN_TEMPLATE_MAX_SIZE)
+    return FALSE;
+  memset (overlap_counts, 0,
+          GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY * sizeof(*overlap_counts));
+  unpacked = g_malloc (sizeof(*unpacked));
+  if (goodix_milan_template_unpack (feature, feature_len, unpacked) == 0 &&
+      unpacked->metadata.sensor_type == 12 &&
+      goodix_milan_template_normalize_unpacked (
+        unpacked, feature_copies, overlap_counts) == 0)
+    result = TRUE;
+
+  for (size_t i = 0; i < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY; i++)
+    g_free (feature_copies[i]);
+  g_free (unpacked);
+  return result;
+}
 
 static gboolean
 goodix_match_set_live_feature (GoodixStudyFollowupContext *context,
@@ -433,7 +466,8 @@ goodix_match_study_followup (GoodixMatchInfo *queued,
     probe_data, probe_size,
     g_bytes_get_data (context->current, NULL),
     g_bytes_get_size (context->current), &match_result, TRUE,
-    &after_study, &action, selected_index, FALSE, FALSE, NULL);
+    &after_study, &action, selected_index, FALSE, FALSE,
+    context->live_overlap_counts, NULL);
   if (status != GOODIX_SIGFM_TEMPLATE_OK)
     goto invalid;
   if (action != GOODIX_MILAN_STUDY_NONE)
@@ -554,6 +588,9 @@ goodix_match_study_feature_queued (
       !goodix_study_queue_validate (queue) ||
       !goodix_match_queue_matches_template (queue, feature, feature_len))
     return GOODIX_SIGFM_TEMPLATE_INVALID;
+  if (!goodix_match_initialize_study_overlap_counts (
+        feature, feature_len, context.live_overlap_counts))
+    return GOODIX_SIGFM_TEMPLATE_INVALID;
   probe_feature = goodix_match_serialize_template (probe_info);
   if (!probe_feature)
     return GOODIX_SIGFM_TEMPLATE_INVALID;
@@ -561,7 +598,7 @@ goodix_match_study_feature_queued (
   status = goodix_match_study_feature_internal (
     probe_data, probe_size, feature, feature_len, match_result, study_eligible,
     &primary_update, &primary_action, &selected_index, TRUE, FALSE,
-    &transient);
+    context.live_overlap_counts, &transient);
   if (status != GOODIX_SIGFM_TEMPLATE_OK)
     goto out;
   if (primary_action == GOODIX_MILAN_STUDY_NONE)

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -1126,6 +1126,7 @@ int goodix_milan_study_append (
   int             apply_dispatcher_prepass,
   int             complete_dispatcher_transaction,
   int             finalize_study,
+  int32_t         live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   uint8_t        *packed,
   size_t          packed_capacity,
   size_t         *packed_size);
@@ -1147,6 +1148,7 @@ int goodix_milan_study_replace (
   const int32_t   primary_transform[6],
   int             complete_dispatcher_transaction,
   int             finalize_study,
+  int32_t         live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   uint8_t        *packed,
   size_t          packed_capacity,
   size_t         *packed_size,

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -405,6 +405,7 @@ goodix_milan_study_append (
   int            apply_dispatcher_prepass,
   int            complete_dispatcher_transaction,
   int            finalize_study,
+  int32_t        live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   uint8_t       *packed,
   size_t         packed_capacity,
   size_t        *packed_size)
@@ -420,8 +421,8 @@ goodix_milan_study_append (
   int graph_was_established;
   int result = -1;
 
-  if (!current_template || !probe_template || !relation_values || !packed ||
-      !packed_size)
+  if (!current_template || !probe_template || !relation_values ||
+      !live_overlap_counts || !packed || !packed_size)
     return -1;
   current = malloc (sizeof(*current));
   probe = malloc (sizeof(*probe));
@@ -505,6 +506,7 @@ goodix_milan_study_append (
   current->feature_elements[current->feature_count] = new_feature;
   current->feature_element_sizes[current->feature_count] = new_feature_size;
   current->feature_count++;
+  live_overlap_counts[old_feature_count] = 0;
   current->metadata.registration_count += (uint32_t) old_feature_count;
 
   if (!graph_was_established)
@@ -552,8 +554,7 @@ goodix_milan_study_append (
       (current->metadata.sensor_type == 12 &&
        current->feature_count == current->metadata.maximum_features &&
        goodix_milan_template_normalize_unpacked (
-         current, normalization_copies,
-         current->normalization_overlap_counts) != 0))
+          current, normalization_copies, live_overlap_counts) != 0))
     goto out;
 
   uint32_t append_count = goodix_milan_template_read_u32 (current->tail_state + 0x50c);
@@ -591,14 +592,14 @@ milan_study_policy_derive (
   int32_t                      probe_coverage,
   const int32_t                primary_transform[6],
   const int32_t                relation_transform[6],
+  const int32_t                live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   GoodixMilanStudyPolicyInput *input)
 {
-  GoodixMilanFeatureView views[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
   GoodixMilanFeatureView probe_view;
   int32_t reference_to_features[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY][6];
 
   if (!current || !probe || !primary_transform || !relation_transform ||
-      !input || current->feature_count == 0 ||
+      !live_overlap_counts || !input || current->feature_count == 0 ||
       current->feature_count > GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY ||
       probe->feature_count != 1 ||
       current->metadata.graph_established != 1 ||
@@ -633,10 +634,7 @@ milan_study_policy_derive (
     {
       GoodixMilanStudyPolicyFeature *feature = &input->features[i];
 
-      if (goodix_milan_template_parse_feature_element (
-            current->feature_elements[i], current->feature_element_sizes[i],
-            &views[i]) != 0 ||
-          goodix_milan_template_read_feature_scalar (
+      if (goodix_milan_template_read_feature_scalar (
             current->feature_elements[i], current->feature_element_sizes[i],
             0xb5, &feature->active) != 0 ||
           goodix_milan_template_read_feature_scalar (
@@ -654,42 +652,12 @@ milan_study_policy_derive (
           goodix_milan_template_reference_transform (
             current, i, 1, reference_to_features[i]) != 0)
         return -1;
+      feature->overlap_count = live_overlap_counts[i];
     }
 
   for (size_t i = 0; i < current->feature_count; i++)
     {
       GoodixMilanStudyPolicyFeature *feature = &input->features[i];
-      uint8_t residual[GOODIX_MILAN_STUDY_MASK_SIZE];
-      int32_t current_to_reference[6];
-
-      if (feature->active != 0)
-        {
-          goodix_milan_study_policy_expand_mask (
-            views[i].inline_mask, residual);
-          if (goodix_milan_template_reference_transform (
-                current, i, 0, current_to_reference) != 0)
-            return -1;
-          for (size_t other = 0; other < current->feature_count; other++)
-            {
-              int32_t footprint[6];
-
-              if (other == i || input->features[other].active == 0)
-                continue;
-              milan_compose_transform (
-                reference_to_features[other], current_to_reference, footprint);
-              footprint[2] = goodix_milan_template_normalization_sar1 (footprint[2]);
-              footprint[5] = goodix_milan_template_normalization_sar1 (footprint[5]);
-              int32_t area = goodix_milan_template_normalization_remove_footprint (
-                residual, 44, 52, 44, 52, footprint);
-
-              if (goodix_milan_template_normalization_overlap_qualifies (
-                    area, 88, 104, 1))
-                feature->overlap_count = goodix_milan_template_normalization_add (
-                  feature->overlap_count, 1);
-            }
-          current->normalization_overlap_counts[i] = feature->overlap_count;
-        }
-
       uint8_t probe_residual[GOODIX_MILAN_STUDY_MASK_SIZE];
       int32_t candidate_transform[6];
 
@@ -745,6 +713,7 @@ goodix_milan_study_replace (
   const int32_t  primary_transform[6],
   int            complete_dispatcher_transaction,
   int            finalize_study,
+  int32_t        live_overlap_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
   uint8_t       *packed,
   size_t         packed_capacity,
   size_t        *packed_size,
@@ -764,8 +733,9 @@ goodix_milan_study_replace (
   size_t replacement_index = SIZE_MAX;
   int result = -1;
 
-  if (!current_template || !probe_template || !relation_values || !packed ||
-      !packed_size || !action_code || !primary_transform)
+  if (!current_template || !probe_template || !relation_values ||
+      !live_overlap_counts || !packed || !packed_size || !action_code ||
+      !primary_transform)
     return -1;
   *packed_size = 0;
   *action_code = GOODIX_MILAN_STUDY_ACTION_NONE;
@@ -792,14 +762,13 @@ goodix_milan_study_replace (
          relation_values + 1, feature_copies) != 0 ||
        milan_study_project_relations (current, relation_matrix) != 0 ||
        (current->feature_count == current->metadata.maximum_features &&
-        goodix_milan_template_normalize_unpacked (
-          current, pre_normalization_copies,
-          current->normalization_overlap_counts) != 0)))
+         goodix_milan_template_normalize_unpacked (
+           current, pre_normalization_copies, live_overlap_counts) != 0)))
     goto out;
   if (milan_study_policy_derive (
         current, probe, matched_feature_index, retained_flag, probe_quality,
         probe_coverage, primary_transform, relation_values + 1,
-        &policy_input) != 0 ||
+        live_overlap_counts, &policy_input) != 0 ||
       goodix_milan_study_policy_select (&policy_input, &policy_result) != 0)
     goto out;
   *action_code = policy_result.action;
@@ -986,9 +955,8 @@ goodix_milan_study_replace (
   if ((policy_result.action == GOODIX_MILAN_STUDY_ACTION_GEOMETRIC ||
        policy_result.action == GOODIX_MILAN_STUDY_ACTION_REPLACE) &&
        (milan_study_project_relations (current, relation_matrix) != 0 ||
-        goodix_milan_template_normalize_unpacked (
-          current, post_normalization_copies,
-          current->normalization_overlap_counts) != 0))
+         goodix_milan_template_normalize_unpacked (
+           current, post_normalization_copies, live_overlap_counts) != 0))
     goto out;
 
   if (finalize_study)


### PR DESCRIPTION
## Stack

PR 9 of 9 in the existing all-or-nothing Milan parity stack, directly above #46. Merge the stack through this PR.

## Summary

- Preserve native live per-feature overlap state across primary and queued study.
- Keep action-2 target overlap unchanged for queued action-5 selection.
- Refresh overlap state only at native normalization boundaries and never serialize it.

## Native contract

The DLL stores overlap at live feature `+0x148`. Action 2 replaces a feature without normalizing and intentionally preserves that slot value. A queued selector reads the preserved vector. Linux previously recomputed overlaps from packed masks on every selector call, losing transaction state and potentially choosing a different queued target.

The transaction now owns a physical-slot overlap vector. Append initializes its new slot; capacity-reaching append and actions 3/4 refresh it; action 2 leaves it untouched.

## Validation

- Current independent campaign: 450/450 selected operations passed.
- Prior independent campaign: 643/643 selected operations passed.
- Total unique exact-head parity coverage: 1,093/1,093 selected operations, zero differences.
- Release build passes.
- Existing Milan synthetic, state, and runtime suites pass.

Ghidra-backed queue and normalization ownership contracts are documented on `milan-dev` before this PR was opened.