### PR TITLE
Bound Milan anti-fake mask packing

### DIFF
--- a/drivers/goodix53x5/milan/antifake/construction.c
+++ b/drivers/goodix53x5/milan/antifake/construction.c
@@ -166,8 +166,13 @@ milan_antifake_build_class (
 
   if (chip_type == 12)
     {
+      if (columns != 0 && rows > SIZE_MAX / columns)
+        goto out;
       size_t packed_pixels = rows * columns;
       uint8_t *packed_mask = goodix_milan_antifake_mask (antifake);
+
+      if (packed_pixels > GOODIX_MILAN_ANTIFAKE_MASK_SIZE * 8)
+        goto out;
 
       memset (packed_mask, 0, GOODIX_MILAN_ANTIFAKE_MASK_SIZE);
       for (size_t i = 0; i < packed_pixels; i++)


### PR DESCRIPTION
## Stack

PR 11 of 11 in the existing all-or-nothing Milan parity stack, directly above #48. Merge the stack through this PR.

## Summary

- Reject type-12 anti-fake dimensions whose packed mask exceeds the fixed 2,000-byte destination.
- Preserve byte-identical behavior for the physical 88x108 profile-9 geometry.

## Validation

- Oversized 1000x20 synthetic control returns failure with no ASan/UBSan report, heap overflow, or scalar corruption.
- Normal 88x108 control returns success and its complete 6,844-byte anti-fake blob is byte-identical before and after the guard.
- Release build passes.
- Existing Milan synthetic, state and runtime suites pass in 3.394 seconds with a 60-second cap.

Full campaign replay is intentionally omitted: physical profile-9/type-12 geometry is fixed at 88x108 (9,504 bits), far below the 16,000-bit guard, so retained hardware operations cannot execute the changed branch. Ghidra-backed capacity ownership is documented on `milan-dev` before this PR was opened.