### PR TITLE
Defer Milan print updates until auth completion

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -78,7 +78,8 @@ goodix_clear_pending_result_report (FpiDeviceGoodix53x5 *self)
   self->pending_result_action = 0;
   self->pending_verify_result = 0;
   g_clear_object (&self->pending_identify_match);
-  self->pending_updated = FALSE;
+  g_clear_object (&self->pending_update_target);
+  g_clear_pointer (&self->pending_update_data, g_variant_unref);
   g_clear_error (&self->pending_result_error);
   g_clear_error (&self->pending_learning_error);
 }
@@ -86,21 +87,18 @@ goodix_clear_pending_result_report (FpiDeviceGoodix53x5 *self)
 static void
 goodix_queue_verify_report (FpiDeviceGoodix53x5 *self,
                              FpiMatchResult       result,
-                             gboolean             updated,
                              GError              *error)
 {
   goodix_clear_pending_result_report (self);
   self->pending_result_report = TRUE;
   self->pending_result_action = FPI_DEVICE_ACTION_VERIFY;
   self->pending_verify_result = result;
-  self->pending_updated = updated;
   self->pending_result_error = error;
 }
 
 static void
 goodix_queue_identify_report (FpiDeviceGoodix53x5 *self,
                                FpPrint             *match,
-                               gboolean             updated,
                                GError              *error)
 {
   goodix_clear_pending_result_report (self);
@@ -108,7 +106,6 @@ goodix_queue_identify_report (FpiDeviceGoodix53x5 *self,
   self->pending_result_action = FPI_DEVICE_ACTION_IDENTIFY;
   if (match)
     self->pending_identify_match = g_object_ref (match);
-  self->pending_updated = updated;
   self->pending_result_error = error;
 }
 
@@ -137,6 +134,8 @@ goodix_flush_pending_result_report (FpDevice *dev)
   self->pending_result_action = 0;
   self->pending_verify_result = 0;
   g_clear_object (&self->pending_identify_match);
+  g_clear_object (&self->pending_update_target);
+  g_clear_pointer (&self->pending_update_data, g_variant_unref);
   g_clear_error (&self->pending_learning_error);
 }
 
@@ -185,24 +184,22 @@ goodix_auth_worker (GTask        *task,
                          (GDestroyNotify) goodix_milan_runtime_output_free);
 }
 
-static gboolean
-goodix_auth_build_update (FpPrint                 *original,
-                           GoodixMilanRuntimeOutput *output)
+static GVariant *
+goodix_auth_build_update (GoodixMilanRuntimeOutput *output)
 {
   g_autoptr(GError) error = NULL;
   g_autoptr(GVariant) data = NULL;
 
   if (!output->final_candidate)
-    return FALSE;
+    return NULL;
   data = goodix_milan_print_build_data (output->final_candidate, &error);
   if (!data)
     {
       if (!output->learning_error)
         output->learning_error = g_steal_pointer (&error);
-      return FALSE;
+      return NULL;
     }
-  fpi_print_set_raw_data (original, data);
-  return TRUE;
+  return g_steal_pointer (&data);
 }
 
 #ifdef GOODIX53X5_DEBUG
@@ -314,7 +311,7 @@ goodix_auth_task_done (GObject      *source_object,
                               ? g_ptr_array_index (data->originals,
                                                    output->winner_index)
                               : NULL;
-        gboolean updated = FALSE;
+        g_autoptr(GVariant) update_data = NULL;
 
         if (!original)
           {
@@ -323,20 +320,25 @@ goodix_auth_task_done (GObject      *source_object,
               fpi_device_error_new (FP_DEVICE_ERROR_DATA_INVALID));
             goto out;
           }
-        updated = goodix_auth_build_update (original, output);
+        update_data = goodix_auth_build_update (output);
         if (data->action == FPI_DEVICE_ACTION_IDENTIFY)
           {
             goodix_debug_dump_probe (data->action, "match",
                                      self->captured_raw_image,
                                      self->captured_image);
-            goodix_queue_identify_report (self, original, updated, NULL);
+            goodix_queue_identify_report (self, original, NULL);
           }
         else
           {
             goodix_debug_dump_probe (data->action, "pass",
                                      self->captured_raw_image,
                                      self->captured_image);
-            goodix_queue_verify_report (self, FPI_MATCH_SUCCESS, updated, NULL);
+            goodix_queue_verify_report (self, FPI_MATCH_SUCCESS, NULL);
+          }
+        if (update_data)
+          {
+            self->pending_update_target = g_object_ref (original);
+            self->pending_update_data = g_steal_pointer (&update_data);
           }
         if (output->learning_error)
           self->pending_learning_error = g_error_copy (output->learning_error);
@@ -351,14 +353,14 @@ goodix_auth_task_done (GObject      *source_object,
           goodix_debug_dump_probe (data->action, "miss",
                                    self->captured_raw_image,
                                    self->captured_image);
-          goodix_queue_identify_report (self, NULL, FALSE, NULL);
+          goodix_queue_identify_report (self, NULL, NULL);
         }
       else
         {
           goodix_debug_dump_probe (data->action, "fail",
                                    self->captured_raw_image,
                                    self->captured_image);
-          goodix_queue_verify_report (self, FPI_MATCH_FAIL, FALSE, NULL);
+          goodix_queue_verify_report (self, FPI_MATCH_FAIL, NULL);
         }
       goodix_scan_set_disposition (
         dev, GOODIX_SCAN_DISPOSITION_AUTH_RETRY_AFTER_UP, NULL);
@@ -370,11 +372,11 @@ goodix_auth_task_done (GObject      *source_object,
                                self->captured_image);
       if (data->action == FPI_DEVICE_ACTION_IDENTIFY)
         goodix_queue_identify_report (
-          self, NULL, FALSE,
+          self, NULL,
           fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
       else
         goodix_queue_verify_report (
-          self, FPI_MATCH_ERROR, FALSE,
+          self, FPI_MATCH_ERROR,
           fpi_device_retry_new (FP_DEVICE_RETRY_REMOVE_FINGER));
       goodix_scan_set_disposition (
         dev, GOODIX_SCAN_DISPOSITION_AUTH_RETRY_AFTER_UP, NULL);
@@ -575,14 +577,17 @@ goodix_verify_ssm_done (FpiSsm   *ssm,
           "Native Milan auth completed without a result");
       else
         {
-          updated = self->pending_updated;
+          if (self->pending_update_target && self->pending_update_data)
+            {
+              fpi_print_set_raw_data (self->pending_update_target,
+                                      self->pending_update_data);
+              updated = TRUE;
+            }
           goodix_flush_pending_result_report (dev);
         }
     }
   if (error)
     goodix_clear_pending_result_report (self);
-
-  self->pending_updated = FALSE;
 
   if (error && goodix_error_indicates_stale_device (error))
     self->needs_reinit = TRUE;

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -139,8 +139,9 @@ struct _FpiDeviceGoodix53x5
   FpiDeviceAction pending_result_action;
   FpiMatchResult  pending_verify_result;
   FpPrint        *pending_identify_match;
+  FpPrint        *pending_update_target;
+  GVariant       *pending_update_data;
   GError         *pending_result_error;
-  gboolean        pending_updated;
   GError         *pending_learning_error;
 
   /* Native CPU work is isolated in one cancellable task. Only its callback on

--- a/tests/test-goodix53x5-milan-runtime.c
+++ b/tests/test-goodix53x5-milan-runtime.c
@@ -386,6 +386,11 @@ milan_runtime_harness_scan_set_disposition (
     }
   if (disposition == GOODIX_SCAN_DISPOSITION_AUTH_SUCCESS)
     {
+      if (pause_cycle_settled)
+        {
+          paused_ssm = ssm;
+          return;
+        }
       fpi_ssm_mark_completed (ssm);
       return;
     }
@@ -1001,6 +1006,33 @@ test_cancellation_no_publication (void)
   g_assert_cmpuint (plan.study_calls, ==, 1);
   g_assert_cmpuint (self->milan_generation->state.sample_count, ==,
                     sample_count);
+  clear_result (&result);
+
+  reset_plan (positive, templates, G_N_ELEMENTS (positive), update);
+  pause_cycle_settled = TRUE;
+  cancel = g_cancellable_new ();
+  fp_device_verify (device, print, cancel, match_report, &result, NULL,
+                    verify_done, &result);
+  wait_paused ();
+  g_assert_true (self->pending_result_report);
+  g_assert_true (self->pending_update_target == print);
+  g_assert_nonnull (self->pending_update_data);
+  g_autoptr(GBytes) pending = get_print_template (print);
+  g_assert_true (g_bytes_equal (pending, stored));
+  g_cancellable_cancel (cancel);
+  wait_cancelled ();
+  fpi_ssm_mark_failed (paused_ssm, g_error_new_literal (
+    G_IO_ERROR, G_IO_ERROR_CANCELLED, "late cancellation"));
+  paused_ssm = NULL;
+  pause_cycle_settled = FALSE;
+  wait_done (&result);
+  g_assert_cmpuint (result.reports, ==, 0);
+  g_assert_false (result.updated);
+  g_autoptr(GBytes) unchanged = get_print_template (print);
+  g_assert_true (g_bytes_equal (unchanged, stored));
+  g_assert_false (self->pending_result_report);
+  g_assert_null (self->pending_update_target);
+  g_assert_null (self->pending_update_data);
   clear_result (&result);
   close_device (device);
 }


### PR DESCRIPTION
## Stack

PR 12 of 12 in the existing all-or-nothing Milan parity stack, directly above #49. Merge the stack through this PR.

## Summary

- Retain learned candidate data without mutating the caller print during the worker callback.
- Apply the update only in the existing successful final SSM path immediately before report flush.
- Discard pending update ownership on cancellation, cleanup failure, stale action, close or restart.

This does not add a finger-up wait or slow authentication. Successful reporting already occurs after scan cleanup; only mutation ownership moves to that existing boundary.

## Validation

- Focused late-cancellation control proves the original print remains byte-identical when cleanup is cancelled after success was queued.
- Successful update behavior and reported `updated` status remain unchanged.
- Focused cancellation runtime test passes in 0.16 seconds.
- Existing Milan synthetic, state and runtime suites pass under a 60-second cap.
- Release build passes.

Full parity replay is not relevant because matcher/runtime candidate bytes are unchanged; this fixes device-level publication ownership after those outputs already exist. The lifecycle audit and closure are documented on `milan-dev` before this PR was opened.