### PR TITLE
Validate Milan persisted feature order

### DIFF
--- a/drivers/goodix53x5/milan/print.c
+++ b/drivers/goodix53x5/milan/print.c
@@ -10,6 +10,7 @@
 
 #include "milan/print.h"
 #include "milan/relations.h"
+#include "milan/template/codec-private.h"
 
 #include <string.h>
 
@@ -39,6 +40,7 @@ goodix_milan_print_validate_template (GBytes                       *template_byt
   guint32 partition0 = 0;
   guint32 partition1 = 0;
   gint32 row_bases[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  gboolean order_seen[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { FALSE };
   GoodixMilanRelationMatrix relation_matrix;
 
   if (info)
@@ -70,6 +72,18 @@ goodix_milan_print_validate_template (GBytes                       *template_byt
     return goodix_milan_print_fail (
       error, GOODIX_MILAN_PRINT_ERROR_INVALID,
       "Milan template profile-9 counts are invalid");
+
+  for (gsize i = 0; i < unpacked->feature_count; i++)
+    {
+      guint32 feature_index = goodix_milan_template_read_u32 (
+        unpacked->tail_state + i * 4);
+
+      if (feature_index >= unpacked->feature_count || order_seen[feature_index])
+        return goodix_milan_print_fail (
+          error, GOODIX_MILAN_PRINT_ERROR_INVALID,
+          "Milan template order is invalid");
+      order_seen[feature_index] = TRUE;
+    }
 
   for (gsize i = 0; i < unpacked->feature_count; i++)
     {


### PR DESCRIPTION
## Summary

- validate the defined persisted feature-order prefix before matcher or study traversal
- reject duplicate and out-of-range indices instead of admitting ambiguous state or reaching the native crash surface
- preserve the reserved order suffix and all canonical profile-9 templates unchanged

## Native contract

For a profile-9 template with `N` features, the first `N` dwords at live template `+0x87e8` must be a permutation of `[0,N)`. `FUN_180055a40` consumes those values as feature-owner indices without validating them. The implementation therefore enforces the invariant at persisted-print admission rather than sorting or repairing malformed state.

Detailed evidence is recorded in `re/milan/PERSISTED-ORDER-ADMISSION-AUDIT-20260809.md` on `milan-dev`.

## Validation

- release build: passed
- existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, and `goodix53x5-milan-runtime` suites: passed in 3.154s
- canonical 40-feature control: remains admitted with score 25 and study action 4
- duplicate-order control: rejected during persisted-print validation
- out-of-range-order control: rejected during persisted-print validation

Full campaign replay was omitted because this is a synthetic-only admission guard: all natural captured templates already satisfy the permutation invariant, and valid state does not execute a changed outcome.