### PR TITLE
Match Milan anti-fake dword arithmetic

### DIFF
--- a/drivers/goodix53x5/milan/antifake/morphology.c
+++ b/drivers/goodix53x5/milan/antifake/morphology.c
@@ -9,6 +9,7 @@
  */
 
 #include "milan/milan.h"
+#include "milan/transform-private.h"
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -281,11 +282,19 @@ goodix_milan_antifake_boundary_score (
       }
   uint32_t divisor = adjacent_count * maximum;
   uint32_t numerator = difference_sum * 1000;
+  int32_t signed_divisor = goodix_milan_transform_s32 (divisor);
 
-  *score = divisor == 0
-             ? (int32_t) numerator
-             : (int32_t) (((int64_t) (int32_t) numerator +
-                            (int32_t) divisor / 2) /
-                           (int32_t) divisor);
+  if (divisor == 0)
+    *score = goodix_milan_transform_s32 (numerator);
+  else
+    {
+      int32_t half_divisor = goodix_milan_transform_sar32 (divisor, 1);
+      int32_t rounded_numerator = goodix_milan_transform_s32 (
+        numerator + (uint32_t) half_divisor);
+
+      if (rounded_numerator == INT32_MIN && signed_divisor == -1)
+        return -1;
+      *score = rounded_numerator / signed_divisor;
+    }
   return 0;
 }

--- a/drivers/goodix53x5/milan/antifake/pair.c
+++ b/drivers/goodix53x5/milan/antifake/pair.c
@@ -9,6 +9,7 @@
  */
 
 #include "milan/milan.h"
+#include "milan/transform-private.h"
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -67,6 +68,22 @@ compare_int32 (const void *first,
   return (a > b) - (a < b);
 }
 
+static uint32_t
+antifake_coordinate_distance (int32_t prior_x,
+                              int32_t prior_y,
+                              int32_t transformed_x,
+                              int32_t transformed_y)
+{
+  uint32_t dx = (uint32_t) prior_x * UINT32_C (0x100) -
+                (uint32_t) transformed_x;
+  uint32_t dy = (uint32_t) prior_y * UINT32_C (0x100) -
+                (uint32_t) transformed_y;
+  uint32_t distance = (uint32_t) goodix_milan_transform_sar32 (dx * dx, 8);
+
+  distance += (uint32_t) goodix_milan_transform_sar32 (dy * dy, 8);
+  return distance;
+}
+
 int
 goodix_milan_antifake_pair_metrics (
   const GoodixMilanAntifakeBlob *prior,
@@ -90,7 +107,6 @@ goodix_milan_antifake_pair_metrics (
   int32_t distances[GOODIX_MILAN_ANTIFAKE_RECORD_CAPACITY];
   uint32_t prior_count;
   uint32_t current_count;
-  int64_t determinant;
   size_t distance_count = 0;
   int32_t current_valid_count = 0;
   int32_t prior_valid_count = 0;
@@ -107,32 +123,9 @@ goodix_milan_antifake_pair_metrics (
     return -1;
   memset (current_to_prior_index, 0xff, sizeof(current_to_prior_index));
   memset (prior_to_current_index, 0xff, sizeof(prior_to_current_index));
-
-  determinant = (int64_t) current_to_prior[0] * current_to_prior[4] -
-                (int64_t) current_to_prior[1] * current_to_prior[3];
-  if (determinant == 0)
-    memcpy (inverse, current_to_prior, sizeof(inverse));
-  else
-    {
-      inverse[0] = (int32_t) (((int64_t) current_to_prior[4] << 16) /
-                              determinant);
-      inverse[1] = (int32_t) ((int64_t) current_to_prior[1] * -65536 /
-                              determinant);
-      inverse[2] = (int32_t) ((((int64_t) current_to_prior[5] *
-                                current_to_prior[1] -
-                                (int64_t) current_to_prior[4] *
-                                current_to_prior[2]) * 256) /
-                              determinant);
-      inverse[3] = (int32_t) ((int64_t) current_to_prior[3] * -65536 /
-                              determinant);
-      inverse[4] = (int32_t) (((int64_t) current_to_prior[0] << 16) /
-                              determinant);
-      inverse[5] = (int32_t) ((((int64_t) current_to_prior[3] *
-                                current_to_prior[2] -
-                                (int64_t) current_to_prior[5] *
-                                current_to_prior[0]) * 256) /
-                              determinant);
-    }
+  if (goodix_milan_transform_invert_s32_checked (
+        current_to_prior, inverse) != 0)
+    return -1;
 
   for (int32_t y = 0; y < rows; y++)
     for (int32_t x = 0; x < columns; x++)
@@ -144,10 +137,16 @@ goodix_milan_antifake_pair_metrics (
         if ((goodix_milan_antifake_const_mask (prior)[pixel / 8] &
              (1U << (pixel & 7))) == 0)
           continue;
-        source_x = (int32_t) (((int64_t) inverse[0] * x +
-                              (int64_t) inverse[1] * y + inverse[2] + 0x80) >> 8);
-        source_y = (int32_t) (((int64_t) inverse[3] * x +
-                              (int64_t) inverse[4] * y + inverse[5] + 0x80) >> 8);
+        source_x = goodix_milan_transform_sar32 (
+          (uint32_t) goodix_milan_transform_affine_s32 (
+            inverse[0], (uint32_t) x, inverse[1], (uint32_t) y,
+            (uint32_t) inverse[2]) + UINT32_C (0x80),
+          8);
+        source_y = goodix_milan_transform_sar32 (
+          (uint32_t) goodix_milan_transform_affine_s32 (
+            inverse[3], (uint32_t) x, inverse[4], (uint32_t) y,
+            (uint32_t) inverse[5]) + UINT32_C (0x80),
+          8);
         if (source_x >= 0 && source_x < columns && source_y >= 0 &&
             source_y < rows)
           {
@@ -172,14 +171,16 @@ goodix_milan_antifake_pair_metrics (
       uint32_t best_distance = UINT32_MAX;
       int16_t best_index = -1;
 
-      transformed_x[current_index] =
-        (int32_t) ((int64_t) current_to_prior[0] * x +
-                   (int64_t) current_to_prior[1] * y + current_to_prior[2]);
-      transformed_y[current_index] =
-        (int32_t) ((int64_t) current_to_prior[3] * x +
-                   (int64_t) current_to_prior[4] * y + current_to_prior[5]);
-      rounded_x = (transformed_x[current_index] + 0x80) >> 8;
-      rounded_y = (transformed_y[current_index] + 0x80) >> 8;
+      transformed_x[current_index] = goodix_milan_transform_affine_s32 (
+        current_to_prior[0], (uint32_t) x, current_to_prior[1],
+        (uint32_t) y, (uint32_t) current_to_prior[2]);
+      transformed_y[current_index] = goodix_milan_transform_affine_s32 (
+        current_to_prior[3], (uint32_t) x, current_to_prior[4],
+        (uint32_t) y, (uint32_t) current_to_prior[5]);
+      rounded_x = goodix_milan_transform_sar32 (
+        (uint32_t) transformed_x[current_index] + UINT32_C (0x80), 8);
+      rounded_y = goodix_milan_transform_sar32 (
+        (uint32_t) transformed_y[current_index] + UINT32_C (0x80), 8);
       if (rounded_x < 0 || rounded_x >= columns || rounded_y < 0 ||
           rounded_y >= rows || !overlap[rounded_y * columns + rounded_x])
         continue;
@@ -191,10 +192,9 @@ goodix_milan_antifake_pair_metrics (
             prior, prior_index);
           int32_t prior_x = goodix_milan_antifake_record_x (prior_record);
           int32_t prior_y = goodix_milan_antifake_record_y (prior_record);
-          int32_t dx = prior_x * 256 - transformed_x[current_index];
-          int32_t dy = prior_y * 256 - transformed_y[current_index];
-          uint32_t candidate = (uint32_t) (((int64_t) dx * dx >> 8) +
-                                           ((int64_t) dy * dy >> 8));
+          uint32_t candidate = antifake_coordinate_distance (
+            prior_x, prior_y, transformed_x[current_index],
+            transformed_y[current_index]);
 
           if (candidate < best_distance)
             {
@@ -222,16 +222,13 @@ goodix_milan_antifake_pair_metrics (
       for (uint32_t current_index = 0; current_index < current_count;
            current_index++)
         {
-          int32_t dx;
-          int32_t dy;
           uint32_t candidate;
 
           if (!current_valid[current_index])
             continue;
-          dx = prior_x * 256 - transformed_x[current_index];
-          dy = prior_y * 256 - transformed_y[current_index];
-          candidate = (uint32_t) (((int64_t) dx * dx >> 8) +
-                                  ((int64_t) dy * dy >> 8));
+          candidate = antifake_coordinate_distance (
+            prior_x, prior_y, transformed_x[current_index],
+            transformed_y[current_index]);
           if (candidate < best_distance)
             {
               best_distance = candidate;

--- a/drivers/goodix53x5/milan/antifake/signal.c
+++ b/drivers/goodix53x5/milan/antifake/signal.c
@@ -9,6 +9,7 @@
  */
 
 #include "milan/milan.h"
+#include "milan/transform-private.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -345,10 +346,11 @@ goodix_milan_antifake_block_variation (
   int32_t mean_square = 0;
   if (valid_count != 0)
     {
+      uint32_t rounded_square_sum = square_sum + valid_count / 2;
+
       mean = (sum + valid_count / 2) / valid_count;
-      mean_square = (int32_t) (((int64_t) (int32_t) square_sum +
-                                valid_count / 2) /
-                               valid_count);
+      mean_square = goodix_milan_transform_s32 (rounded_square_sum) /
+                    (int32_t) valid_count;
     }
   uint32_t variance = (uint32_t) mean_square - mean * mean;
   if ((int32_t) variance < 0)

--- a/drivers/goodix53x5/milan/enrollment/template.c
+++ b/drivers/goodix53x5/milan/enrollment/template.c
@@ -16,6 +16,7 @@
 #include "milan/match/info-private.h"
 #include "milan/milan.h"
 #include "milan/relations.h"
+#include "milan/transform-private.h"
 
 #include <string.h>
 
@@ -47,7 +48,14 @@ goodix_match_update_antifake_score (GoodixMilanAntifakeBlob *antifake,
 {
   gint32 current = goodix_milan_antifake_pair_score (antifake);
 
-  current = current == -1 ? score : (current + score) / 2;
+  if (current == -1)
+    current = score;
+  else
+    {
+      uint32_t sum = (uint32_t) current + (uint32_t) score;
+
+      current = goodix_milan_transform_s32 (sum) / 2;
+    }
   goodix_milan_antifake_set_pair_score (antifake, current);
 }
 

--- a/drivers/goodix53x5/milan/match/correspondence.c
+++ b/drivers/goodix53x5/milan/match/correspondence.c
@@ -461,46 +461,6 @@ goodix_milan_match_relaxed_correspondences (
   return match_count;
 }
 
-static int
-milan_match_inverse_affine_s32 (const int32_t transform[6],
-                                int32_t       inverse[6])
-{
-  uint64_t numerator[6];
-  int32_t determinant = goodix_milan_transform_s32 (
-    (uint32_t) transform[0] * (uint32_t) transform[4] -
-    (uint32_t) transform[1] * (uint32_t) transform[3]);
-
-  if (determinant == 0)
-    {
-      memcpy (inverse, transform, 6 * sizeof(*inverse));
-      return 0;
-    }
-  numerator[0] = (uint64_t) (int64_t) transform[4] << 16;
-  numerator[1] = (UINT64_C (0) -
-                  (uint64_t) (int64_t) transform[1]) << 16;
-  numerator[2] =
-    ((uint64_t) (int64_t) transform[5] *
-       (uint64_t) (int64_t) transform[1] -
-     (uint64_t) (int64_t) transform[4] *
-       (uint64_t) (int64_t) transform[2]) << 8;
-  numerator[3] = (UINT64_C (0) -
-                  (uint64_t) (int64_t) transform[3]) << 16;
-  numerator[4] = (uint64_t) (int64_t) transform[0] << 16;
-  numerator[5] =
-    ((uint64_t) (int64_t) transform[3] *
-       (uint64_t) (int64_t) transform[2] -
-     (uint64_t) (int64_t) transform[5] *
-       (uint64_t) (int64_t) transform[0]) << 8;
-  for (size_t i = 0; i < 6; i++)
-    {
-      if (determinant == -1 && numerator[i] == (UINT64_C (1) << 63))
-        return -1;
-      inverse[i] = goodix_milan_transform_divide (
-        numerator[i], determinant);
-    }
-  return 0;
-}
-
 static int32_t
 milan_match_scan_raw_s32 (int32_t first,
                           uint32_t first_coordinate,
@@ -508,11 +468,9 @@ milan_match_scan_raw_s32 (int32_t first,
                           uint32_t second_coordinate,
                           int32_t translation)
 {
-  uint32_t value = (uint32_t) first * first_coordinate;
-
-  value += (uint32_t) second * second_coordinate;
-  value += (uint32_t) translation << 8;
-  return goodix_milan_transform_s32 (value);
+  return goodix_milan_transform_affine_s32 (
+    first, first_coordinate, second, second_coordinate,
+    (uint32_t) translation << 8);
 }
 
 static int32_t
@@ -559,7 +517,8 @@ goodix_milan_match_alternate_correspondences_internal (
       !pair_count || enrolled_partition > enrolled_record_count ||
       probe_partition > probe_record_count || pair_capacity == 0 ||
       pair_capacity > MILAN_MATCH_MAX_PAIRS ||
-      milan_match_inverse_affine_s32 (primary_transform, inverse) != 0)
+      goodix_milan_transform_invert_s32_checked (
+        primary_transform, inverse) != 0)
     return -1;
   for (size_t partition = 0; partition < 2; partition++)
     {
@@ -918,7 +877,8 @@ goodix_milan_match_cross_class_alternate_correspondences (
       pairs[i * 2] = -1;
       pairs[i * 2 + 1] = -1;
     }
-  if (milan_match_inverse_affine_s32 (primary_transform, inverse) != 0)
+  if (goodix_milan_transform_invert_s32_checked (
+        primary_transform, inverse) != 0)
     return 0;
 
   for (size_t enrolled_index = 0;

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -21,6 +21,7 @@
 #include "milan/match/rescue.h"
 #include "milan/match/selection.h"
 #include "milan/relations.h"
+#include "milan/transform-private.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -1206,15 +1207,19 @@ milan_match_prepared_probe (
                     probe_antifake, GOODIX_MILAN_ANTIFAKE_SIZE, transform,
                     comparison_metrics) != 0)
                 goto out;
+              int32_t texture_delta = goodix_milan_transform_s32 (
+                (uint32_t) goodix_milan_antifake_texture (feature.antifake) -
+                (uint32_t) goodix_milan_antifake_texture (probe_antifake));
+              int32_t mean_delta = goodix_milan_transform_s32 (
+                (uint32_t) goodix_milan_antifake_mean (feature.antifake) -
+                (uint32_t) goodix_milan_antifake_mean (probe_antifake));
+              int32_t threshold_delta = goodix_milan_transform_s32 (
+                (uint32_t) goodix_milan_antifake_threshold (feature.antifake) -
+                (uint32_t) goodix_milan_antifake_threshold (probe_antifake));
+
               blocked = goodix_milan_match_selection_block_candidate (
                 &match_selection, enrolled->metadata.sensor_type,
-                comparison_metrics,
-                goodix_milan_antifake_texture (feature.antifake) -
-                  goodix_milan_antifake_texture (probe_antifake),
-                goodix_milan_antifake_mean (feature.antifake) -
-                  goodix_milan_antifake_mean (probe_antifake),
-                goodix_milan_antifake_threshold (feature.antifake) -
-                  goodix_milan_antifake_threshold (probe_antifake),
+                comparison_metrics, texture_delta, mean_delta, threshold_delta,
                 goodix_milan_antifake_pair_score (feature.antifake),
                 direct_metrics[9], &contribution_event);
               if (blocked < 0)

--- a/drivers/goodix53x5/milan/transform-private.h
+++ b/drivers/goodix53x5/milan/transform-private.h
@@ -33,6 +33,20 @@ goodix_milan_transform_sar32 (uint32_t value, unsigned int shift)
 }
 
 static inline int32_t
+goodix_milan_transform_affine_s32 (int32_t  first,
+                                   uint32_t first_coordinate,
+                                   int32_t  second,
+                                   uint32_t second_coordinate,
+                                   uint32_t translation)
+{
+  uint32_t value = (uint32_t) first * first_coordinate;
+
+  value += (uint32_t) second * second_coordinate;
+  value += translation;
+  return goodix_milan_transform_s32 (value);
+}
+
+static inline int32_t
 goodix_milan_transform_divide (uint64_t numerator, int32_t denominator)
 {
   uint64_t magnitude;
@@ -48,4 +62,44 @@ goodix_milan_transform_divide (uint64_t numerator, int32_t denominator)
   if (negative != (denominator < 0))
     quotient = ~quotient + 1;
   return goodix_milan_transform_s32 ((uint32_t) quotient);
+}
+
+static inline int
+goodix_milan_transform_invert_s32_checked (const int32_t transform[6],
+                                           int32_t       inverse[6])
+{
+  uint64_t numerator[6];
+  int32_t determinant = goodix_milan_transform_s32 (
+    (uint32_t) transform[0] * (uint32_t) transform[4] -
+    (uint32_t) transform[1] * (uint32_t) transform[3]);
+
+  if (determinant == 0)
+    {
+      memcpy (inverse, transform, 6 * sizeof(*inverse));
+      return 0;
+    }
+  numerator[0] = (uint64_t) (int64_t) transform[4] << 16;
+  numerator[1] = (UINT64_C (0) -
+                  (uint64_t) (int64_t) transform[1]) << 16;
+  numerator[2] =
+    ((uint64_t) (int64_t) transform[5] *
+       (uint64_t) (int64_t) transform[1] -
+     (uint64_t) (int64_t) transform[4] *
+       (uint64_t) (int64_t) transform[2]) << 8;
+  numerator[3] = (UINT64_C (0) -
+                  (uint64_t) (int64_t) transform[3]) << 16;
+  numerator[4] = (uint64_t) (int64_t) transform[0] << 16;
+  numerator[5] =
+    ((uint64_t) (int64_t) transform[3] *
+       (uint64_t) (int64_t) transform[2] -
+     (uint64_t) (int64_t) transform[5] *
+       (uint64_t) (int64_t) transform[0]) << 8;
+  for (unsigned int i = 0; i < 6; i++)
+    {
+      if (determinant == -1 && numerator[i] == (UINT64_C (1) << 63))
+        return -1;
+      inverse[i] = goodix_milan_transform_divide (
+        numerator[i], determinant);
+    }
+  return 0;
 }


### PR DESCRIPTION
## Summary

- share the recovered wrapped-dword affine inverse across correspondence and anti-fake pair comparison
- reproduce native dword mapping, distance, variation, and boundary-score rounding semantics
- make persisted anti-fake subtraction and enrollment averaging wrap explicitly instead of relying on signed C overflow
- retain safe failure for native-hostile signed division overflow

The four corrections are separate commits for review and regression isolation. No tests were added or expanded. Detailed native contracts are recorded in the corresponding `re/milan/functions/` notes on `milan-dev`.

## Native contracts

- `FUN_1800689a0` and `FUN_18003c520`: the affine determinant is `wrap32(a*d-b*c)`; wrapped zero copies the input transform, and pair mapping/distance arithmetic remains dword-width.
- `FUN_18003ceb0`: the rounded square-sum numerator wraps before signed division.
- `FUN_18003ad10`: numerator/divisor products and rounding addition wrap, divisor halving uses arithmetic `SAR`, and final division is signed.
- `FUN_180055a40` and `FUN_180041ac0`: anti-fake deltas and pair-score averaging use wrapping dword subtraction/addition.

## Focused validation

- determinant-wrap pair control: pair count `0`, matching the DLL instead of the former `1`
- 48-block `INT32_MAX` square-sum control: variation `0`, matching the DLL instead of the former `27884`
- extreme scalar control: wrapped delta `501`; wrapped enrollment average `-1073741824`
- ordinary sequence-2 boundary score remains `13`

All focused controls were transient; the committed synthetic suite was not expanded.

## Validation

- clean `GOODIX53X5_DEBUG=0` release build: passed
- existing Milan synthetic, state, and runtime suites: 3/3 passed
- current campaign: 450/450 operations passed with zero differences
- independent enrollment follow-up campaign: 643/643 operations passed with zero differences
- total standing parity: 1,093/1,093 operations