### PR TITLE
Match Milan action 4 native contracts

### DIFF
--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -145,12 +145,15 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
           (best_percent < 80 &&
            (best_percent < 60 || input->template_counter <= 1000)))
         return 0;
-      result->action = GOODIX_MILAN_STUDY_ACTION_GEOMETRIC;
-      result->selected_feature_index = selected_index;
-      return 0;
+      if (input->retained_flag == 1)
+        {
+          result->action = GOODIX_MILAN_STUDY_ACTION_GEOMETRIC;
+          result->selected_feature_index = selected_index;
+          return 0;
+        }
     }
 
-  if (input->retained_flag == 0)
+  if (input->retained_flag != 1)
     {
       if (input->probe_coverage < matched->coverage - 10)
         return 0;

--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -16,17 +16,15 @@
 static inline int
 goodix_milan_study_policy_feature_better (
   const GoodixMilanStudyPolicyFeature *candidate,
-  size_t                               candidate_index,
-  const GoodixMilanStudyPolicyFeature *selected,
-  size_t                               selected_index)
+  int32_t                               best_residual,
+  int32_t                               best_coverage,
+  int32_t                               best_overlap_count)
 {
-  return !selected || candidate->residual < selected->residual ||
-         (candidate->residual == selected->residual &&
-          (candidate->coverage < selected->coverage ||
-           (candidate->coverage == selected->coverage &&
-            (candidate->overlap_count > selected->overlap_count ||
-             (candidate->overlap_count == selected->overlap_count &&
-              candidate_index < selected_index)))));
+  return candidate->residual < best_residual ||
+         (candidate->residual == best_residual &&
+          (candidate->coverage < best_coverage ||
+           (candidate->coverage == best_coverage &&
+            candidate->overlap_count > best_overlap_count)));
 }
 
 int
@@ -36,6 +34,9 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
   const GoodixMilanStudyPolicyFeature *matched;
   const GoodixMilanStudyPolicyFeature *selected = NULL;
   size_t selected_index = SIZE_MAX;
+  int32_t best_residual = 0xfffff;
+  int32_t best_coverage = 0xfffff;
+  int32_t best_overlap_count = 0;
 
   if (!input || !result || input->feature_count == 0 ||
       input->feature_count > GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY ||
@@ -80,10 +81,14 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
           if (candidate->active == 0 || i == input->reference_feature_index)
             continue;
           if (goodix_milan_study_policy_feature_better (
-                candidate, i, selected, selected_index))
+                candidate, best_residual, best_coverage,
+                best_overlap_count))
             {
               selected = candidate;
               selected_index = i;
+              best_residual = candidate->residual;
+              best_coverage = candidate->coverage;
+              best_overlap_count = candidate->overlap_count;
             }
         }
       if (selected && input->retained_flag != 0)

--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -13,6 +13,70 @@
 #include <limits.h>
 #include <string.h>
 
+static inline int32_t
+study_policy_u32_as_s32 (uint32_t value)
+{
+  if (value <= INT32_MAX)
+    return (int32_t) value;
+  return -1 - (int32_t) (UINT32_MAX - value);
+}
+
+static inline int32_t
+study_policy_wrap_add (int32_t left,
+                       int32_t right)
+{
+  return study_policy_u32_as_s32 ((uint32_t) left + (uint32_t) right);
+}
+
+static inline int32_t
+study_policy_wrap_subtract (int32_t left,
+                            int32_t right)
+{
+  return study_policy_u32_as_s32 ((uint32_t) left - (uint32_t) right);
+}
+
+static inline int32_t
+study_policy_wrap_multiply (int32_t left,
+                            int32_t right)
+{
+  return study_policy_u32_as_s32 ((uint32_t) left * (uint32_t) right);
+}
+
+static inline int32_t
+study_policy_wrap_shift_left (int32_t value,
+                              unsigned int shift)
+{
+  return study_policy_u32_as_s32 ((uint32_t) value << shift);
+}
+
+static inline int32_t
+study_policy_footprint_bound (int32_t dimension)
+{
+  return study_policy_wrap_subtract (
+    study_policy_wrap_shift_left (dimension, 8), 0x100);
+}
+
+static inline int32_t
+study_policy_transform_coordinate (int32_t first_coefficient,
+                                   int32_t first_coordinate,
+                                   int32_t second_coefficient,
+                                   int32_t second_coordinate,
+                                   int32_t offset)
+{
+  return study_policy_wrap_add (
+    study_policy_wrap_add (
+      study_policy_wrap_multiply (first_coefficient, first_coordinate),
+      study_policy_wrap_multiply (second_coefficient, second_coordinate)),
+    offset);
+}
+
+static inline int32_t
+study_policy_percent_from_area (int32_t area)
+{
+  return study_policy_wrap_multiply (area, 100) /
+         GOODIX_MILAN_STUDY_MASK_SIZE;
+}
+
 static inline int
 goodix_milan_study_policy_feature_better (
   const GoodixMilanStudyPolicyFeature *candidate,
@@ -64,7 +128,8 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
 
   matched = &input->features[input->matched_feature_index];
   if (matched->quality >= 60 &&
-      (int64_t) input->probe_quality * 10 <= (int64_t) matched->quality * 6)
+      study_policy_wrap_multiply (input->probe_quality, 10) <=
+        study_policy_wrap_multiply (matched->quality, 6))
     return 0;
 
   if (matched->residual == 0)
@@ -96,7 +161,7 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
           int32_t adjusted = selected->uncovered_probe_residual;
 
           if (input->template_counter > 700)
-            adjusted += 20;
+            adjusted = study_policy_wrap_add (adjusted, 20);
           if (adjusted < selected->residual)
             {
               selected = NULL;
@@ -122,8 +187,12 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
     result->primary_candidate = 1;
   else if (input->retained_flag == 0)
     {
-      if ((int64_t) input->primary_transform_area * 100 <=
-          (int64_t) (104 * 88) * 80)
+      int32_t scaled_area = study_policy_wrap_multiply (
+        input->primary_transform_area, 100);
+      int32_t threshold = study_policy_wrap_multiply (
+        study_policy_wrap_multiply (104, 88), 80);
+
+      if (scaled_area <= threshold)
         return 0;
       selected = matched;
       selected_index = input->matched_feature_index;
@@ -140,7 +209,10 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
             selected_index = i;
             best_area = selected->geometric_overlap_area;
           }
-      int32_t best_percent = selected ? selected->geometric_overlap_percent : 0;
+      int32_t best_percent = selected
+                               ? study_policy_percent_from_area (
+                                   selected->geometric_overlap_area)
+                               : 0;
       if (!selected ||
           (best_percent < 80 &&
            (best_percent < 60 || input->template_counter <= 1000)))
@@ -155,7 +227,8 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
 
   if (input->retained_flag != 1)
     {
-      if (input->probe_coverage < matched->coverage - 10)
+      if (input->probe_coverage <
+          study_policy_wrap_subtract (matched->coverage, 10))
         return 0;
       result->action = GOODIX_MILAN_STUDY_ACTION_REPLACE_NO_RELATION;
     }
@@ -189,21 +262,23 @@ goodix_milan_study_policy_remove_footprint (
   const int32_t transform[6])
 {
   int32_t removed = 0;
+  const int32_t max_x = study_policy_footprint_bound (52);
+  const int32_t max_y = study_policy_footprint_bound (44);
 
   for (int32_t y = 0; y < 44; y++)
     for (int32_t x = 0; x < 52; x++)
       {
         size_t index = (size_t) y * 52 + (size_t) x;
-        int64_t mapped_x = (int64_t) transform[0] * x +
-                           (int64_t) transform[1] * y + transform[2];
-        int64_t mapped_y = (int64_t) transform[3] * x +
-                           (int64_t) transform[4] * y + transform[5];
+        int32_t mapped_x = study_policy_transform_coordinate (
+          transform[0], x, transform[1], y, transform[2]);
+        int32_t mapped_y = study_policy_transform_coordinate (
+          transform[3], x, transform[4], y, transform[5]);
 
-        if (mask[index] != 0 && mapped_x >= 0 && mapped_x <= 51 * 0x100 &&
-            mapped_y >= 0 && mapped_y <= 43 * 0x100)
+        if (mask[index] != 0 && mapped_x >= 0 && mapped_x <= max_x &&
+            mapped_y >= 0 && mapped_y <= max_y)
           {
             mask[index] = 0;
-            removed++;
+            removed = study_policy_wrap_add (removed, 1);
           }
       }
   return removed;
@@ -222,17 +297,20 @@ int32_t
 goodix_milan_study_policy_full_footprint_area (const int32_t transform[6])
 {
   int32_t area = 0;
+  const int32_t max_x = study_policy_footprint_bound (104);
+  const int32_t max_y = study_policy_footprint_bound (88);
 
   for (int32_t y = 0; y < 88; y++)
     for (int32_t x = 0; x < 104; x++)
       {
-        int64_t mapped_x = (int64_t) transform[0] * x +
-                           (int64_t) transform[1] * y + transform[2];
-        int64_t mapped_y = (int64_t) transform[3] * x +
-                           (int64_t) transform[4] * y + transform[5];
+        int32_t mapped_x = study_policy_transform_coordinate (
+          transform[0], x, transform[1], y, transform[2]);
+        int32_t mapped_y = study_policy_transform_coordinate (
+          transform[3], x, transform[4], y, transform[5]);
 
-        area += mapped_x >= 0 && mapped_x <= 103 * 0x100 &&
-                mapped_y >= 0 && mapped_y <= 87 * 0x100;
+        area = study_policy_wrap_add (
+          area, mapped_x >= 0 && mapped_x <= max_x &&
+                  mapped_y >= 0 && mapped_y <= max_y);
       }
   return area;
 }
@@ -240,6 +318,6 @@ goodix_milan_study_policy_full_footprint_area (const int32_t transform[6])
 int32_t
 goodix_milan_study_policy_footprint_percent (const int32_t transform[6])
 {
-  return goodix_milan_study_policy_footprint_area (transform) * 100 /
-         GOODIX_MILAN_STUDY_MASK_SIZE;
+  return study_policy_percent_from_area (
+    goodix_milan_study_policy_footprint_area (transform));
 }

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -21,6 +21,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+static inline int32_t
+milan_study_u32_as_s32 (uint32_t value)
+{
+  if (value <= INT32_MAX)
+    return (int32_t) value;
+  return -1 - (int32_t) (UINT32_MAX - value);
+}
+
+static inline int32_t
+milan_study_wrap_increment (int32_t value)
+{
+  return milan_study_u32_as_s32 ((uint32_t) value + 1U);
+}
+
+static inline int32_t
+milan_study_wrap_decrement (int32_t value)
+{
+  return milan_study_u32_as_s32 ((uint32_t) value - 1U);
+}
+
 int
 goodix_milan_study_order_key_greater (const GoodixMilanStudyOrderKey *left,
                                       const GoodixMilanStudyOrderKey *right)
@@ -836,8 +856,7 @@ goodix_milan_study_replace (
         current->feature_element_sizes[replacement_index], &target_feature) != 0 ||
       goodix_milan_template_parse_feature_element (
         probe->feature_elements[0], probe->feature_element_sizes[0],
-        &probe_feature) != 0 || target_bd == INT32_MAX || target_bc < 0 ||
-      (size_t) target_bc >= current->feature_count)
+        &probe_feature) != 0)
     goto out;
 
   const uint8_t *matched_source =
@@ -914,7 +933,7 @@ goodix_milan_study_replace (
                 GOODIX_MILAN_STUDY_ACTION_REPLACE_NO_RELATION
               ? target_bb : 0 },
     { 0xbc, (int32_t) current->feature_count - 1 },
-    { 0xbd, target_bd + 1 },
+    { 0xbd, milan_study_wrap_increment (target_bd) },
     { 0xbe, policy_result.action ==
                 GOODIX_MILAN_STUDY_ACTION_REPLACE_NO_RELATION
               ? target_be : matched_be },
@@ -937,7 +956,8 @@ goodix_milan_study_replace (
           goto out;
         if (ordinal > target_bc && goodix_milan_template_patch_feature_scalar (
               (uint8_t *) current->feature_elements[i],
-              current->feature_element_sizes[i], 0xbc, ordinal - 1) != 0)
+              current->feature_element_sizes[i], 0xbc,
+              milan_study_wrap_decrement (ordinal)) != 0)
           goto out;
       }
 


### PR DESCRIPTION
## Summary

- seed action-4 candidate ranking with the native signed sentinel tuple instead of treating the first eligible feature as an automatic winner
- preserve nonzero retained-state validation while reserving action 3/4 selection for `retained_flag == 1`
- reproduce the DLL's wrapped signed-dword policy arithmetic across quality, residual, area, coverage, transform, and percentage calculations
- accept arbitrary signed old replacement ordinals, wrap replacement counters, and rewrite the selected ordinal after mutation

The four corrections are separate commits for review and regression isolation. No tests were added or expanded. Detailed native contracts are pushed on `milan-dev` at commit `62b2c44b`.

## Native evidence

Fresh `GoodixEngineAdapter.dll` disassembly identifies `FUN_1800469f0` as the authoritative profile-9/type-12 selector, with `FUN_180045530` owning candidate ranking and `FUN_1800458c0`/`FUN_1800452e0` owning replacement mutation.

- candidate comparison starts from signed `(residual=0xfffff, coverage=0xfffff, overlap=0, index=-1)` and updates only on strict lexicographic improvement
- primary validation treats retained state as nonzero, but the final action-family split compares it exactly with `1`
- policy multiply/add/subtract/shift intermediates remain dword-width and feed signed comparisons or signed truncating division
- replacement increments `bd` with dword wrap, compares against the captured arbitrary signed old `bc`, decrements greater ordinals with dword wrap, and rewrites the target to `feature_count - 1`

## Focused validation

Transient controls produce the DLL outcomes:

- sentinel tuple: action 0, selected index unset
- wrapped quality ratio: action 4, selected index 1
- retained flag 2: action 2, selected index 1
- target `bd=INT32_MAX`: replacement succeeds with `bd=INT32_MIN`
- target `bc=-1`: replacement succeeds and rewrites target `bc=39`

## Validation

- clean `GOODIX53X5_DEBUG=0` release build: passed
- existing Milan synthetic, state, and runtime suites: 3/3 passed
- current campaign: 450/450 operations passed with zero differences
- independent enrollment follow-up campaign: 643/643 operations passed with zero differences
- total standing parity: 1,093/1,093 operations