### PR TITLE
Reject odd GEA payload lengths

### DIFF
--- a/drivers/goodix53x5/device/crypto.c
+++ b/drivers/goodix53x5/device/crypto.c
@@ -238,7 +238,7 @@ goodix_crypto_gea_decrypt (const guint8 *key4,
   guint32 adjacent_key_xor, keystream_bits;
   guint16 key_low_word, ciphertext_word, keystream_word;
 
-  for (gsize i = 0; i < in_len; i += 2)
+  for (gsize i = 0; i + 1 < in_len; i += 2)
     {
       adjacent_key_xor = (key >> 1 ^ key) & 0xFFFFFFFF;
       keystream_bits = (((((((
@@ -274,6 +274,9 @@ goodix_crypto_gea_decrypt (const guint8 *key4,
       out[i] = plaintext_word & 0xFF;
       out[i + 1] = (plaintext_word >> 8) & 0xFF;
     }
+
+  if (in_len % 2 != 0)
+    out[in_len - 1] = in[in_len - 1];
 }
 
 /**
@@ -492,6 +495,13 @@ goodix_crypto_gtls_decrypt_sensor_data (GoodixGtlsCtx *ctx,
   /* Extract and verify CRC */
   msg_gea_crc = goodix_crypto_decode_u32 (gea_data + gea_data_len - 4);
   gea_data_len -= 4;
+
+  if (gea_data_len % 2 != 0)
+    {
+      fp_warn ("GEA data length is odd: %zu", gea_data_len);
+      g_free (gea_encrypted);
+      return NULL;
+    }
 
   computed_crc = goodix_crypto_crc32_mpeg2 (gea_data, gea_data_len);
   if (computed_crc != msg_gea_crc)


### PR DESCRIPTION
## Summary

- reject odd GEA image payload lengths before decryption
- bound the low-level GEA primitive to complete 16-bit words
- preserve valid even-length capture output unchanged

## Scope and threat model

This is narrow defense-in-depth, not a fix for behavior expected from genuine hardware.

Profile-9 sensors produce a fixed 14,256-byte raw12 frame, so normal firmware cannot reach the odd-length case. Inspection of the Windows 2.0.310.900 native path also shows that it relies on this fixed-size contract rather than rejecting odd lengths at the GTLS boundary. Its GEA primitive processes only complete 16-bit words and leaves any trailing byte untouched, so it does not have the same out-of-bounds access.

Reaching this in practice would require malformed authenticated input, such as compromised sensor firmware, a spoofed USB endpoint able to derive the session keys, or severe device malfunction. The default all-zero PSK makes spoofing more plausible; installations using an imported per-device Windows PSK substantially narrow that route.

Although the scenario is unusual, the current Linux primitive unconditionally reads and writes the second byte of every word. An odd device-controlled length therefore causes a one-byte heap overflow in `fprintd`. This change rejects that malformed frame and independently keeps the primitive memory-safe if another caller supplies an odd length.

## Native comparison

The primitive behavior deliberately follows the safe part of native handling: process complete 16-bit words only and preserve a trailing byte. The GTLS caller is stricter than native and rejects the malformed half-word because accepting a partially decrypted image is not a useful protocol contract.

## Verification

- `GOODIX53X5_DEBUG=0 ./scripts/build-local.sh`
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `git diff --check`

No new tests are included.