### PR TITLE
Remove unused Milan driver code

### DIFF
--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -276,14 +276,6 @@ goodix_milan_generation_note_identify_prelude (GoodixMilanGeneration *generation
     generation->identify_prelude_count++;
 }
 
-void
-goodix_milan_generation_note_enrollment_stage (GoodixMilanGeneration *generation)
-{
-  g_return_if_fail (generation != NULL);
-  if (generation->enrollment_stages < G_MAXUINT)
-    generation->enrollment_stages++;
-}
-
 gboolean
 goodix_milan_replace_raw_frame (guint16 **owner,
                                 guint16 **frame,

--- a/drivers/goodix53x5/device/base.h
+++ b/drivers/goodix53x5/device/base.h
@@ -120,7 +120,6 @@ typedef struct
   gboolean                   admitted;
   gboolean                   identify_prelude_seen;
   guint                      identify_prelude_count;
-  guint                      enrollment_stages;
   guint64                    use_count;
 } GoodixMilanGeneration;
 
@@ -167,7 +166,6 @@ void goodix_milan_generation_free (GoodixMilanGeneration *generation);
 void goodix_milan_generation_invalidate (GoodixMilanGeneration **generation);
 guint64 goodix_milan_generation_note_use (GoodixMilanGeneration *generation);
 void goodix_milan_generation_note_identify_prelude (GoodixMilanGeneration *generation);
-void goodix_milan_generation_note_enrollment_stage (GoodixMilanGeneration *generation);
 
 gboolean goodix_milan_replace_raw_frame (guint16 **owner,
                                          guint16 **frame,

--- a/drivers/goodix53x5/device/debug.c
+++ b/drivers/goodix53x5/device/debug.c
@@ -112,7 +112,6 @@ goodix_debug_write_dump (const gchar      *prefix,
     published = FALSE;
   if (fd >= 0 && close (fd) != 0)
     published = FALSE;
-  fd = -1;
   if (!published)
     {
       gint saved_errno = errno;
@@ -254,7 +253,6 @@ goodix_debug_publish_artifact (const gchar *prefix,
     published = FALSE;
   if (fd >= 0 && close (fd) != 0)
     published = FALSE;
-  fd = -1;
   if (!published)
     {
       gint saved_errno = errno;

--- a/drivers/goodix53x5/milan/match/lifecycle.c
+++ b/drivers/goodix53x5/milan/match/lifecycle.c
@@ -137,7 +137,6 @@ goodix_match_serialized_feature_result_internal (
               g_free (normalized_milan);
               return GOODIX_SIGFM_TEMPLATE_INVALID;
             }
-          matched_milan = updated_milan;
           normalized_milan_len = updated_milan_len;
         }
       if (updated_milan)

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -2029,38 +2029,6 @@ goodix_milan_match_info_result (
     );
 }
 
-int
-goodix_milan_match_probe_result (
-  const uint8_t                  probe_high_bitmap[286],
-  const uint8_t                  probe_enhanced_bitmap[286],
-  const uint8_t                  probe_low_bitmap[286],
-  const uint8_t                  probe_inline_mask[72],
-  const uint8_t                  probe_rescue_mask[308],
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                         probe_record_count,
-  size_t                         probe_partition_count,
-  int32_t                        image_quality,
-  int32_t                        image_coverage,
-  int32_t                        probe_optional_c7,
-  const GoodixMilanAntifakeBlob *probe_antifake,
-  const uint8_t                 *enrolled_template,
-  size_t                         enrolled_template_size,
-  GoodixMilanMatchResult        *match_result)
-{
-  return milan_match_probe_result_internal (
-    probe_high_bitmap, probe_enhanced_bitmap, probe_low_bitmap,
-    probe_inline_mask, probe_rescue_mask, probe_records, probe_record_count,
-    probe_partition_count, image_quality, image_coverage, probe_optional_c7,
-    MILAN_PROBE_PRIMARY_HISTOGRAM_CLASS_UNAVAILABLE,
-    probe_antifake, probe_antifake != NULL,
-    enrolled_template, enrolled_template_size, NULL, NULL, NULL, SIZE_MAX,
-    match_result
-#ifdef GOODIX53X5_DEBUG
-    , NULL
-#endif
-    );
-}
-
 #ifdef GOODIX53X5_DEBUG
 int
 goodix_milan_match_probe_result_debug (

--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -410,7 +410,6 @@ goodix_match_live_gallery_result (GoodixMatchInfo                 *probe,
           g_free (updated_milan);
           return GOODIX_SIGFM_TEMPLATE_INVALID;
         }
-      current_milan = updated_milan;
       current_milan_size = updated_milan_size;
     }
   if (updated_milan)

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -931,23 +931,6 @@ typedef struct
   int      valid;
 } GoodixMilanStudyTransientState;
 
-int goodix_milan_match_probe_result (
-  const uint8_t                  probe_high_bitmap[286],
-  const uint8_t                  probe_enhanced_bitmap[286],
-  const uint8_t                  probe_low_bitmap[286],
-  const uint8_t                  probe_inline_mask[72],
-  const uint8_t                  probe_rescue_mask[308],
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                         probe_record_count,
-  size_t                         probe_partition_count,
-  int32_t                        image_quality,
-  int32_t                        image_coverage,
-  int32_t                        probe_optional_c7,
-  const GoodixMilanAntifakeBlob *probe_antifake,
-  const uint8_t                 *enrolled_template,
-  size_t                         enrolled_template_size,
-  GoodixMilanMatchResult        *match_result);
-
 #ifdef GOODIX53X5_DEBUG
 int goodix_milan_match_probe_result_debug (
   const uint8_t                  probe_high_bitmap[286],

--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -194,7 +194,6 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
 
       if (scaled_area <= threshold)
         return 0;
-      selected = matched;
       selected_index = input->matched_feature_index;
     }
   else
@@ -313,11 +312,4 @@ goodix_milan_study_policy_full_footprint_area (const int32_t transform[6])
                   mapped_y >= 0 && mapped_y <= max_y);
       }
   return area;
-}
-
-int32_t
-goodix_milan_study_policy_footprint_percent (const int32_t transform[6])
-{
-  return study_policy_percent_from_area (
-    goodix_milan_study_policy_footprint_area (transform));
 }

--- a/drivers/goodix53x5/milan/study/policy.h
+++ b/drivers/goodix53x5/milan/study/policy.h
@@ -82,6 +82,3 @@ goodix_milan_study_policy_footprint_area (const int32_t transform[6]);
 
 int32_t
 goodix_milan_study_policy_full_footprint_area (const int32_t transform[6]);
-
-int32_t
-goodix_milan_study_policy_footprint_percent (const int32_t transform[6]);

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -899,7 +899,6 @@ goodix_milan_study_replace (
                 (uint32_t) target_feature.fields.optional_c7);
             }
           goodix_milan_template_write_u32 (cursor + 1, (uint32_t) (replacement_size - 5));
-          source = cursor;
           source_size = replacement_size;
         }
       else

--- a/tests/test-goodix53x5-milan-runtime.c
+++ b/tests/test-goodix53x5-milan-runtime.c
@@ -1058,7 +1058,6 @@ test_enrollment_combine_retry (void)
   g_assert_cmpint (progress.retry_code, ==, FP_DEVICE_RETRY_REMOVE_FINGER);
   g_assert_cmpint (self->enroll_stage, ==, 0);
   g_assert_cmpuint (self->enroll_features->len, ==, 0);
-  g_assert_cmpuint (self->milan_generation->enrollment_stages, ==, 0);
 
   fpi_ssm_mark_failed (paused_ssm, g_error_new_literal (
     G_IO_ERROR, G_IO_ERROR_CANCELLED, "combine retry observed"));


### PR DESCRIPTION
## Summary

- remove unused enrollment-generation bookkeeping
- remove unreferenced matcher and footprint-policy wrappers
- remove dead assignments reported by static analysis
- drop the obsolete runtime assertion for the removed generation field

## Testing

- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `GOODIX53X5_DEBUG=1 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- Clang dead-store and aggressive unreachable-code analysis in production and debug configurations