### PR TITLE
Gate Milan biometric diagnostics to debug builds

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -392,10 +392,11 @@ goodix_auth_task_done (GObject      *source_object,
       g_assert_not_reached ();
     }
 
-  fp_dbg ("Native Milan %s score=%d winner=%u action=%u quality=%d coverage=%d",
-          data->action == FPI_DEVICE_ACTION_IDENTIFY ? "identify" : "verify",
-          output->score, output->winner_index, output->study_action,
-          output->quality, output->coverage);
+  GOODIX53X5_DEBUG_ONLY (
+    fp_dbg ("Native Milan %s score=%d winner=%u action=%u quality=%d coverage=%d",
+            data->action == FPI_DEVICE_ACTION_IDENTIFY ? "identify" : "verify",
+            output->score, output->winner_index, output->study_action,
+            output->quality, output->coverage);)
   goodix_auth_log_runtime_result (dev, data, output, FALSE);
 out:
   goodix_milan_runtime_output_free (output);

--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -742,10 +742,11 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
         if (data->forced_refresh)
           self->profile9_fdt.refresh_outcome =
             GOODIX_PROFILE9_FDT_REFRESH_OUTCOME_PUBLISHED;
-        fp_info ("Admitted Milan generation id=%" G_GUINT64_FORMAT
-                 " subtype=%u MAD=%" G_GUINT64_FORMAT,
-                 generation_id, self->milan_sensor_subtype,
-                 data->attempt.mad);
+        GOODIX53X5_DEBUG_ONLY (
+          fp_info ("Admitted Milan generation id=%" G_GUINT64_FORMAT
+                   " subtype=%u MAD=%" G_GUINT64_FORMAT,
+                   generation_id, self->milan_sensor_subtype,
+                   data->attempt.mad);)
         data->leave_powered = TRUE;
         goodix_base_timing_done (self, dev, "base_generation");
         fpi_ssm_mark_completed (ssm);

--- a/drivers/goodix53x5/device/enroll.c
+++ b/drivers/goodix53x5/device/enroll.c
@@ -223,11 +223,13 @@ goodix_enroll_task_done (GObject      *source_object,
       g_ptr_array_add (self->enroll_features,
                        g_bytes_ref (output->probe_template));
       self->enroll_stage++;
-      fp_dbg ("Native Milan enrollment stage %d/%d quality=%d coverage=%d "
-              "records=%u partitions=%u/%u",
-              self->enroll_stage, GOODIX_ENROLL_SAMPLES, output->quality,
-              output->coverage, output->probe_record_count,
-              output->probe_partition0_count, output->probe_partition1_count);
+      GOODIX53X5_DEBUG_ONLY (
+        fp_dbg ("Native Milan enrollment stage %d/%d quality=%d coverage=%d "
+                "records=%u partitions=%u/%u",
+                self->enroll_stage, GOODIX_ENROLL_SAMPLES, output->quality,
+                output->coverage, output->probe_record_count,
+                output->probe_partition0_count,
+                output->probe_partition1_count);)
       self->pending_enroll_progress = TRUE;
       self->pending_enroll_stage = self->enroll_stage;
       g_clear_error (&self->pending_enroll_error);

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -990,11 +990,13 @@ goodix_capture_ssm_handler (FpiSsm   *ssm,
     case GOODIX_CAPTURE_STORE:
       if (self->milan_generation)
         {
+          GOODIX53X5_DEBUG_ONLY (
           guint64 use = goodix_milan_generation_note_use (self->milan_generation);
 
           fp_info ("Using Milan generation id=%" G_GUINT64_FORMAT
                    " use=%" G_GUINT64_FORMAT,
                    self->milan_generation->generation_id, use);
+          )
         }
       fpi_ssm_mark_completed (ssm);
       break;

--- a/tools/milan-parity/build-current-runner
+++ b/tools/milan-parity/build-current-runner
@@ -3,17 +3,15 @@ set -euo pipefail
 
 repo=
 output=
-debug=0
 while (( $# )); do
   case "$1" in
     --repo) repo=$2; shift 2 ;;
     --output) output=$2; shift 2 ;;
-    --debug) debug=$2; shift 2 ;;
-    *) printf 'usage: %s --repo PATH --output PATH [--debug 0|1]\n' "$0" >&2; exit 2 ;;
+    *) printf 'usage: %s --repo PATH --output PATH\n' "$0" >&2; exit 2 ;;
   esac
 done
-if [[ -z $repo || -z $output || ( $debug != 0 && $debug != 1 ) ]]; then
-  printf 'usage: %s --repo PATH --output PATH [--debug 0|1]\n' "$0" >&2
+if [[ -z $repo || -z $output ]]; then
+  printf 'usage: %s --repo PATH --output PATH\n' "$0" >&2
   exit 2
 fi
 

--- a/tools/milan-parity/current-runner
+++ b/tools/milan-parity/current-runner
@@ -62,7 +62,7 @@ def resolve_backend(repo: Path, tool: Path, *, build: bool,
     if not backend.exists() and build:
         backend.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         subprocess.run((str(tool / "build-current-runner"), "--repo", str(repo),
-                        "--output", str(backend), "--debug", "1"), check=True)
+                        "--output", str(backend)), check=True)
     if not backend.is_file() or not os.access(backend, os.X_OK):
         raise SystemExit(f"current-runner backend is absent or not executable: {backend}")
     backend_sha256 = sha256_file(backend)


### PR DESCRIPTION
## Summary

- compile biometric quality, score, coverage, record-count, and generation chronology logging only into debug builds
- stop release captures from incrementing the debug-only generation-use chronology
- remove the parity runner's misleading `--debug` option because the runner always requires debug/parity structures

## Testing

- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `GOODIX53X5_DEBUG=1 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- verified the gated messages are absent from the release shared library
- field-tested the release stack with fresh enrollment and repeated authentication
- installed a fresh debug build and confirmed two complete enrollments plus identify/verify evidence are being captured under its sealed build manifest