### PR TITLE
Match Milan action 2 active count

### DIFF
--- a/drivers/goodix53x5/milan/study/policy.c
+++ b/drivers/goodix53x5/milan/study/policy.c
@@ -173,7 +173,7 @@ goodix_milan_study_policy_select (const GoodixMilanStudyPolicyInput *input,
           size_t zero_count = 0;
 
           for (size_t i = 0; i < input->feature_count; i++)
-            zero_count += input->features[i].active != 0 &&
+            zero_count += input->features[i].active == 1 &&
                           input->features[i].residual == 0;
           if (selected->residual != 0 || zero_count < 3)
             {


### PR DESCRIPTION
## Summary

- count only exact active value 1 in the action-2 three-zero-residual gate, matching GoodixEngineAdapter.dll
- preserve nonzero active-value eligibility for candidate ranking
- avoid publishing an action-2 update for valid packed non-Boolean active state that the DLL rejects

The corresponding reverse-engineering documentation is available on `milan-dev` at `99bdc043`.

## Verification

- focused `b5=2` discriminator: corrected from action/index `2/1` to action `0` with no selected index
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- approved-DLL current comparison: `450/450` operations
- independent approved-DLL current comparison: `643/643` operations