### PR TITLE
Match Milan append relation activation

### DIFF
--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -552,7 +552,7 @@ goodix_milan_study_append (
       current->metadata.graph_reference_index = (int32_t) matched_feature_index;
       current->metadata.graph_established = 1;
     }
-  if ((!graph_was_established || matched_active != 0) &&
+  if ((!graph_was_established || matched_active == 1) &&
       goodix_milan_relation_matrix_store_reference (
         relation_matrix, old_feature_count, relation_values + 1) != 0)
     goto out;


### PR DESCRIPTION
## Summary

- install an established-graph append relation only when the matched feature active value is exactly 1, matching GoodixEngineAdapter.dll
- continue inheriting arbitrary matched active values into the appended feature
- avoid emitting an extra packed relation for valid non-Boolean active state

The corresponding action-1/action-4/action-5 re-audit documentation is available on `milan-dev` at `1d798747`.

## Verification

- focused matched-`b5=2` direct current/DLL append control: byte-identical 39,723-byte output, SHA-256 `a37131112c97939b40d2e228a677c9cc861fa0f9205546e15e84c1d78b215aa4`
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- approved-DLL current comparison: `450/450` operations
- independent approved-DLL current comparison: `643/643` operations