### PR TITLE
Filter Milan features near broken pixels

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -1592,14 +1592,49 @@ out:
   return result;
 }
 
-int
-goodix_milan_feature_base_maps (const uint8_t *frame,
+void
+goodix_milan_feature_pack_inline_mask (const uint8_t *validity_mask,
                                        size_t         rows,
                                        size_t         columns,
-                                       uint8_t       *high_bitmap,
-                                       uint8_t       *low_bitmap,
-                                       uint8_t       *feature_mask,
                                        uint8_t       *inline_mask)
+{
+  size_t block_rows = (rows + 3) / 4;
+  size_t block_columns = (columns + 3) / 4;
+
+  memset (inline_mask, 0, (block_rows * block_columns + 7) / 8);
+  for (size_t block_row = 0; block_row < block_rows; block_row++)
+    for (size_t block_column = 0; block_column < block_columns; block_column++)
+      {
+        size_t foreground = 0;
+        size_t pixels = 0;
+
+        for (size_t y = block_row * 4;
+             y < rows && y < block_row * 4 + 4; y++)
+          for (size_t x = block_column * 4;
+               x < columns && x < block_column * 4 + 4; x++)
+            {
+              foreground += validity_mask[y * columns + x] != 0;
+              pixels++;
+            }
+        if (foreground * 2 >= pixels)
+          {
+            size_t bit = block_row * block_columns + block_column;
+
+            inline_mask[bit / 8] |= (uint8_t) (1U << (bit & 7));
+          }
+      }
+}
+
+int
+goodix_milan_feature_base_maps_with_validity (
+  const uint8_t *frame,
+  size_t         rows,
+  size_t         columns,
+  uint8_t       *high_bitmap,
+  uint8_t       *low_bitmap,
+  uint8_t       *feature_mask,
+  uint8_t       *inline_mask,
+  uint8_t       *validity_mask)
 {
   size_t cropped_columns;
   size_t cropped_count;
@@ -1640,6 +1675,8 @@ goodix_milan_feature_base_maps (const uint8_t *frame,
   if (quality_coverage_mask_core (cropped, rows, cropped_columns, 0x6e, 1,
                                   mask, &ignored_coverage) != 0)
     goto out;
+  if (validity_mask)
+    memcpy (validity_mask, mask, cropped_count);
 
   for (size_t row = 0; row < rows; row++)
     {
@@ -1696,34 +1733,8 @@ goodix_milan_feature_base_maps (const uint8_t *frame,
         }
     }
   if (inline_mask)
-    {
-      size_t block_rows = (rows + 3) / 4;
-      size_t block_columns = (cropped_columns + 3) / 4;
-
-      memset (inline_mask, 0, (block_rows * block_columns + 7) / 8);
-      for (size_t block_row = 0; block_row < block_rows; block_row++)
-        for (size_t block_column = 0; block_column < block_columns;
-             block_column++)
-          {
-            size_t foreground = 0;
-            size_t pixels = 0;
-
-            for (size_t y = block_row * 4;
-                 y < rows && y < block_row * 4 + 4; y++)
-              for (size_t x = block_column * 4;
-                   x < cropped_columns && x < block_column * 4 + 4; x++)
-                {
-                  foreground += mask[y * cropped_columns + x] != 0;
-                  pixels++;
-                }
-            if (foreground * 2 >= pixels)
-              {
-                size_t bit = block_row * block_columns + block_column;
-
-                inline_mask[bit / 8] |= (uint8_t) (1U << (bit & 7));
-              }
-          }
-    }
+    goodix_milan_feature_pack_inline_mask (
+      mask, rows, cropped_columns, inline_mask);
   result = 0;
 
 out:
@@ -1732,6 +1743,20 @@ out:
   free (mask);
   free (cropped);
   return result;
+}
+
+int
+goodix_milan_feature_base_maps (const uint8_t *frame,
+                                size_t         rows,
+                                size_t         columns,
+                                uint8_t       *high_bitmap,
+                                uint8_t       *low_bitmap,
+                                uint8_t       *feature_mask,
+                                uint8_t       *inline_mask)
+{
+  return goodix_milan_feature_base_maps_with_validity (
+    frame, rows, columns, high_bitmap, low_bitmap, feature_mask, inline_mask,
+    NULL);
 }
 
 

--- a/drivers/goodix53x5/milan/feature/extraction.c
+++ b/drivers/goodix53x5/milan/feature/extraction.c
@@ -318,8 +318,93 @@ goodix_milan_feature_should_retry_scale_space (size_t       materialized_count,
          configured_retry != 0;
 }
 
-int
-goodix_milan_feature_extract_records_mode_configured (
+static int
+feature_filter_broken_pixels (GoodixMilanFeatureRecord *records,
+                              size_t                   *record_count,
+                              const uint8_t            *broken_mask,
+                              size_t                    rows,
+                              size_t                    columns,
+                              uint8_t                  *validity_mask,
+                              int                       high_class)
+{
+  size_t stride = columns + 1;
+  size_t radius = high_class < 4 ? 2 : 5;
+  int16_t *integral = calloc ((rows + 1) * stride, sizeof(*integral));
+  uint16_t *local_zeros = calloc (rows * columns, sizeof(*local_zeros));
+  int global_zeros = 0;
+  int result = -1;
+
+  if (!integral || !local_zeros)
+    goto out;
+  for (size_t y = 0; y < rows; y++)
+    for (size_t x = 0; x < columns; x++)
+      {
+        size_t source = y * columns + x;
+        size_t destination = (y + 1) * stride + x + 1;
+        int zero = broken_mask[source] == 0;
+
+        global_zeros += zero;
+        integral[destination] = (int16_t) (
+          integral[destination - stride] + integral[destination - 1] -
+          integral[destination - stride - 1] + zero);
+      }
+  if (global_zeros >= 50)
+    {
+      for (size_t y = 0; y < rows; y++)
+        for (size_t x = 0; x < columns; x++)
+          {
+            size_t left = x > radius ? x - radius : 0;
+            size_t top = y > radius ? y - radius : 0;
+            size_t right = x + radius + 1 < columns
+                             ? x + radius + 1
+                             : columns;
+            size_t bottom = y + radius + 1 < rows ? y + radius + 1 : rows;
+
+            local_zeros[y * columns + x] = (uint16_t) (
+              integral[bottom * stride + right] -
+              integral[top * stride + right] -
+              integral[bottom * stride + left] +
+              integral[top * stride + left]);
+          }
+      if (high_class >= 4)
+        {
+          size_t validity_columns = columns / 8 * 8;
+
+          for (size_t y = 0; y < rows; y++)
+            for (size_t x = 0; x < validity_columns; x++)
+              if (local_zeros[y * columns + x] != 0)
+                validity_mask[y * validity_columns + x] = 0;
+        }
+      for (size_t i = 0; i < *record_count;)
+        {
+          size_t x = ((uint16_t) records[i].refined_x + 0x80) >> 8;
+          size_t y = ((uint16_t) records[i].refined_y + 0x80) >> 8;
+
+          /* Native checks only x before indexing the unshifted 108-wide map. */
+          if (x < columns && local_zeros[y * columns + x] > 1)
+            {
+              (*record_count)--;
+              if (i != *record_count)
+                {
+                  records[i] = records[*record_count];
+                  memset (&records[*record_count], 0,
+                          sizeof(records[*record_count]));
+                }
+              continue;
+            }
+          i++;
+        }
+    }
+  result = 0;
+
+out:
+  free (local_zeros);
+  free (integral);
+  return result;
+}
+
+static int
+feature_extract_records (
   const uint8_t            *frame,
   size_t                    rows,
   size_t                    columns,
@@ -328,7 +413,10 @@ goodix_milan_feature_extract_records_mode_configured (
   size_t                   *record_count,
   size_t                   *zero_flag_count,
   int                       expand_records,
-  int                       configured_retry)
+  int                       configured_retry,
+  const uint8_t            *broken_mask,
+  uint8_t                  *validity_mask,
+  int                       high_class)
 {
   GoodixMilanFeatureRecord
     materialized[MILAN_FEATURE_MATERIALIZED_LIMIT];
@@ -404,6 +492,11 @@ goodix_milan_feature_extract_records_mode_configured (
   *record_count = feature_finish_pretransform_records (
     magnitude, gradient_orientation, rows, cropped_columns, records, limit,
     materialized, ranks, auxiliary, materialized_count);
+  if (broken_mask && *record_count != 0 &&
+      feature_filter_broken_pixels (
+        records, record_count, broken_mask, rows, columns, validity_mask,
+        high_class) != 0)
+    goto out;
   for (size_t i = 0; i < *record_count; i++)
     goodix_milan_feature_transform_record ((uint8_t *) &records[i],
                                             expand_records);
@@ -421,6 +514,42 @@ out:
   free (dense_orientation);
   free (cropped);
   return result;
+}
+
+int
+goodix_milan_feature_extract_records_mode_configured (
+  const uint8_t            *frame,
+  size_t                    rows,
+  size_t                    columns,
+  GoodixMilanFeatureRecord *records,
+  size_t                    capacity,
+  size_t                   *record_count,
+  size_t                   *zero_flag_count,
+  int                       expand_records,
+  int                       configured_retry)
+{
+  return feature_extract_records (
+    frame, rows, columns, records, capacity, record_count, zero_flag_count,
+    expand_records, configured_retry, NULL, NULL, 0);
+}
+
+int
+goodix_milan_feature_extract_records_mode_masked (
+  const uint8_t            *frame,
+  size_t                    rows,
+  size_t                    columns,
+  GoodixMilanFeatureRecord *records,
+  size_t                    capacity,
+  size_t                   *record_count,
+  size_t                   *zero_flag_count,
+  int                       expand_records,
+  const uint8_t            *broken_mask,
+  uint8_t                  *validity_mask,
+  int                       high_class)
+{
+  return feature_extract_records (
+    frame, rows, columns, records, capacity, record_count, zero_flag_count,
+    expand_records, 1, broken_mask, validity_mask, high_class);
 }
 
 int

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -15,6 +15,7 @@
 #include "milan/match/info-private.h"
 #include "milan/match/rescue.h"
 #include "milan/milan.h"
+#include "milan/private.h"
 
 #include <string.h>
 
@@ -273,9 +274,10 @@ goodix_match_update_extraction_classification (
 
 static void
 goodix_match_decode_entry_classes (const guint8 *image,
-                                   gint32       *packed,
-                                   gint32       *low_class,
-                                   gint32       *high_class)
+                                    gint32       *packed,
+                                    gint32       *low_class,
+                                    gint32       *high_class,
+                                    guint8      **broken_mask)
 {
   static const gint32 low_classes[4] = { 0, 2, 2, 3 };
   static const gint32 high_classes[8] = { 0, 1, 2, 4, 5, 5, 0, 0 };
@@ -286,6 +288,7 @@ goodix_match_decode_entry_classes (const guint8 *image,
   *packed = 0;
   *low_class = 0;
   *high_class = 0;
+  *broken_mask = NULL;
   for (guint column = 0; column < metadata_start; column++)
     if ((image[column] & 1) != (column & 1))
       return;
@@ -298,6 +301,14 @@ goodix_match_decode_entry_classes (const guint8 *image,
   *packed = (gint32) (raw_low + (raw_high << 8));
   *low_class = low_classes[raw_low];
   *high_class = high_classes[raw_high];
+  if ((image[metadata_start + 2] & 1) != 0)
+    {
+      *broken_mask = g_malloc (GOODIX_MILAN_SENSOR_PIXELS);
+      memset (*broken_mask, 1, GOODIX_MILAN_SENSOR_COLUMNS);
+      for (guint pixel = GOODIX_MILAN_SENSOR_COLUMNS;
+           pixel < GOODIX_MILAN_SENSOR_PIXELS; pixel++)
+        (*broken_mask)[pixel] = image[pixel] & 1;
+    }
 }
 
 static GoodixMilanExtractionStatus goodix_match_extract_planes (
@@ -440,6 +451,8 @@ goodix_match_extract_planes (const guint8  *image,
   guint8 *enhanced = NULL;
   guint8 *enhanced_bitmap = NULL;
   guint8 *inline_mask = NULL;
+  guint8 *validity_mask = NULL;
+  guint8 *broken_mask = NULL;
   GoodixMilanAntifakeBlob *antifake = NULL;
   GoodixMilanFeatureRecord *records = NULL;
   guint8 *feature_element = NULL;
@@ -453,8 +466,8 @@ goodix_match_extract_planes (const guint8  *image,
   size_t milan_template_size = 0;
   guint8 enhanced_threshold;
   guint8 auxiliary[3];
-  gint32 entry_low_class;
-  gint32 entry_high_class;
+  gint32 entry_low_class = 0;
+  gint32 entry_high_class = 0;
   int quality;
   int coverage;
   GoodixMilanExtractionStatus status = GOODIX_MILAN_EXTRACTION_INVALID;
@@ -477,6 +490,7 @@ goodix_match_extract_planes (const guint8  *image,
   enhanced = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   enhanced_bitmap = g_malloc0 (286);
   inline_mask = g_malloc0 (72);
+  validity_mask = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   antifake = g_malloc0 (sizeof(*antifake));
   records = g_new0 (GoodixMilanFeatureRecord, 150);
   feature_element = g_malloc (7945 + 150 * 32 + GOODIX_MILAN_OPTIONAL_C7_LEN);
@@ -496,14 +510,18 @@ goodix_match_extract_planes (const guint8  *image,
                 row * GOODIX_MILAN_SENSOR_COLUMNS + 2,
               GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS);
     }
+  if (sensor_subtype == 12)
+    goodix_match_decode_entry_classes (
+      image, &fields.optional_c7, &entry_low_class, &entry_high_class,
+      &broken_mask);
   if (goodix_milan_preprocess_quality (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
         &quality, &coverage) != 0)
     goto out;
   record_limit = goodix_match_record_limit (sensor_subtype, coverage, 150);
-  if (goodix_milan_feature_base_maps (
+  if (goodix_milan_feature_base_maps_with_validity (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
-        high, low, feature_mask, inline_mask) != 0 ||
+        high, low, feature_mask, inline_mask, validity_mask) != 0 ||
       goodix_milan_feature_enhance (
         cropped, 88, 104, orientation, enhanced) != 0 ||
       goodix_milan_feature_enhanced_bitmap (
@@ -512,18 +530,23 @@ goodix_match_extract_planes (const guint8  *image,
     goto out;
   if (sensor_subtype == 12)
     {
-      goodix_match_decode_entry_classes (
-        image, &fields.optional_c7, &entry_low_class, &entry_high_class);
       /* Native commits history before record extraction, anti-fake, or packing
        * failures. */
       fields.optional_c7 = goodix_match_update_extraction_classification (
         classification_state, cropped, cropped_primary_contrast, auxiliary,
         coverage, entry_low_class, entry_high_class);
     }
-  if (goodix_milan_feature_extract_records_mode (
+  if (goodix_milan_feature_extract_records_mode_masked (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, records,
-        record_limit, &record_count, &zero_count, 1) != 0)
+        record_limit, &record_count, &zero_count, 1, broken_mask, validity_mask,
+        entry_high_class) != 0)
     goto out;
+  if (broken_mask && entry_high_class >= 4)
+    /* The owned half-resolution mask was copied before filtering; only the
+     * later inline reduction observes the cleared dense validity mask. */
+    goodix_milan_feature_pack_inline_mask (
+      validity_mask, GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS,
+      GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS, inline_mask);
   if (calibration && raw_frame &&
       goodix_milan_antifake_build (
         calibration, raw_frame, primary_contrast_plane, feature_mask,
@@ -603,6 +626,8 @@ out:
   g_free (feature_element);
   g_free (records);
   g_free (antifake);
+  g_free (broken_mask);
+  g_free (validity_mask);
   g_free (inline_mask);
   g_free (enhanced_bitmap);
   g_free (enhanced);

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -581,6 +581,7 @@ goodix_match_extract_planes (const guint8  *image,
         }
     }
 #endif
+  goodix_milan_feature_mask_expand (inline_mask, feature_mask);
   if (calibration && raw_frame &&
       goodix_milan_template_initialize_tail (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, tail_state,

--- a/drivers/goodix53x5/milan/private.h
+++ b/drivers/goodix53x5/milan/private.h
@@ -44,6 +44,31 @@ int feature_build_dense_orientation (const uint8_t *frame,
                                      uint8_t       *orientation);
 void goodix_milan_feature_mask_expand (const uint8_t packed[72],
                                 uint8_t       mask[44 * 52]);
+int goodix_milan_feature_base_maps_with_validity (
+  const uint8_t *frame,
+  size_t         rows,
+  size_t         columns,
+  uint8_t       *high_bitmap,
+  uint8_t       *low_bitmap,
+  uint8_t       *feature_mask,
+  uint8_t       *inline_mask,
+  uint8_t       *validity_mask);
+void goodix_milan_feature_pack_inline_mask (const uint8_t *validity_mask,
+                                            size_t         rows,
+                                            size_t         columns,
+                                            uint8_t       *inline_mask);
+int goodix_milan_feature_extract_records_mode_masked (
+  const uint8_t            *frame,
+  size_t                    rows,
+  size_t                    columns,
+  GoodixMilanFeatureRecord *records,
+  size_t                    capacity,
+  size_t                   *record_count,
+  size_t                   *zero_flag_count,
+  int                       expand_records,
+  const uint8_t            *broken_mask,
+  uint8_t                  *validity_mask,
+  int                       high_class);
 void milan_compose_transform (const int32_t first[6],
                               const int32_t second[6],
                               int32_t       output[6]);


### PR DESCRIPTION
## Summary

- decode the optional broken-pixel mask embedded in profile-9/type-12 processed images
- remove extracted records near broken regions with the native radius, thresholds, and swap ordering
- rebuild the packed inline validity mask when the native high-class path clears dense validity

## Validation

- focused approved-DLL fixture: exact 141-record pre-filter stream, exact 133-record filtered stream, and byte-identical final records
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- current-vs-DLL parity: 450/450 operations exact
- independent current-vs-DLL parity: 643/643 operations exact

## Documentation

Durable profile-9/type-12 contracts were pushed separately to `milan-dev` at `b0650543`. No tests were added.