### PR TITLE
Finalize Milan enrollment at physical capacity

### DIFF
--- a/drivers/goodix53x5/milan/enrollment/template.c
+++ b/drivers/goodix53x5/milan/enrollment/template.c
@@ -170,12 +170,14 @@ goodix_match_combine_templates (GPtrArray *templates)
   GoodixMilanTemplateMetadata metadata = { 0 };
   guint8 tail_state[0x520] = { 0 };
   guint8 *combined = NULL;
+  guint8 *normalized = NULL;
   size_t combined_capacity = 1433;
   size_t combined_size = 0;
+  size_t normalized_size = 0;
   GBytes *result = NULL;
 
   if (!templates || templates->len == 0 ||
-      templates->len > GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
+      templates->len > GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT)
     return NULL;
   unpacked = g_new0 (GoodixMilanUnpackedTemplate, 1);
   relation_matrix = g_new0 (GoodixMilanRelationMatrix, 1);
@@ -392,6 +394,9 @@ goodix_match_combine_templates (GPtrArray *templates)
         }
       metadata.registration_count += i;
     }
+  if (templates->len == GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT &&
+      goodix_milan_relation_matrix_close (relation_matrix, active) < 0)
+    goto out;
   for (guint i = 0; i < templates->len; i++)
     goodix_match_set_feature_scalar (
       element_copies[i], element_sizes[i], 0, active[i] ? 1 : 0);
@@ -410,13 +415,27 @@ goodix_match_combine_templates (GPtrArray *templates)
         tail_state, sizeof(tail_state), combined, combined_capacity,
         &combined_size) != 0)
     goto out;
-  result = g_bytes_new_take (combined, combined_size);
-  combined = NULL;
+  if (templates->len == GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT)
+    {
+      normalized = g_malloc (combined_capacity);
+      if (goodix_milan_template_normalize (
+            combined, combined_size, normalized, combined_capacity,
+            &normalized_size) != 0)
+        goto out;
+      result = g_bytes_new_take (normalized, normalized_size);
+      normalized = NULL;
+    }
+  else
+    {
+      result = g_bytes_new_take (combined, combined_size);
+      combined = NULL;
+    }
 
 out:
   for (guint i = 0; i < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY; i++)
     g_free (element_copies[i]);
   g_free (combined);
+  g_free (normalized);
   g_free (relation_matrix);
   g_free (unpacked);
   return result;

--- a/drivers/goodix53x5/milan/relations.c
+++ b/drivers/goodix53x5/milan/relations.c
@@ -474,6 +474,154 @@ goodix_milan_relation_matrix_replace (
     matrix, feature_index, new_feature_to_reference);
 }
 
+static int
+goodix_milan_relation_matrix_read_to_first (
+  GoodixMilanRelationMatrix *matrix,
+  size_t                          first,
+  size_t                          second,
+  int32_t                        *rank,
+  int32_t                         transform[6])
+{
+  GoodixMilanRelationSlot *slot;
+
+  if (!matrix || !rank || !transform || first == second)
+    return -1;
+  slot = goodix_milan_enrollment_relation_slot (matrix, first, second);
+  if (!slot)
+    return -1;
+  *rank = slot->values[0];
+  if (second > first)
+    memcpy (transform, slot->values + 1, 6 * sizeof(*transform));
+  else if (goodix_milan_transform_invert (
+             slot->values + 1, transform) != 0)
+    return -1;
+  return 0;
+}
+
+static int
+goodix_milan_relation_matrix_store_to_first (
+  GoodixMilanRelationMatrix *matrix,
+  size_t                          first,
+  size_t                          second,
+  const int32_t                   transform[6])
+{
+  GoodixMilanRelationSlot *slot;
+
+  if (!matrix || !transform || first == second)
+    return -1;
+  slot = goodix_milan_enrollment_relation_slot (matrix, first, second);
+  if (!slot)
+    return -1;
+  if (second > first)
+    memcpy (slot->values + 1, transform, 6 * sizeof(*transform));
+  else if (goodix_milan_transform_invert (
+             transform, slot->values + 1) != 0)
+    return -1;
+  slot->values[0] = 2;
+  return 0;
+}
+
+int
+goodix_milan_relation_matrix_close (
+  GoodixMilanRelationMatrix *matrix,
+  int32_t                         active_markers[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY])
+{
+  static const int32_t identity[6] = { 0x100, 0, 0, 0, 0x100, 0 };
+  int32_t path_quality[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY]
+                      [GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
+  int32_t visited[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
+  size_t worklist[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
+  int changed = 0;
+
+  if (!matrix || !active_markers || matrix->feature_count == 0 ||
+      matrix->feature_count > GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
+    return -1;
+  for (size_t feature = 0; feature < matrix->feature_count; feature++)
+    if (matrix->row_bases[feature] !=
+        goodix_milan_relation_matrix_expected_row_base (feature))
+      return -1;
+
+  /* Native scans candidates downward and consumes each root's worklist LIFO. */
+  for (size_t root = 0; root < matrix->feature_count; root++)
+    {
+      size_t worklist_size = 1;
+
+      for (size_t feature = 0; feature < matrix->feature_count; feature++)
+        visited[feature] = -1;
+      visited[root] = 0;
+      worklist[0] = root;
+
+      while (worklist_size != 0)
+        {
+          size_t current = worklist[--worklist_size];
+          int32_t current_to_root[6];
+          int32_t root_quality = 0;
+
+          memcpy (current_to_root, identity, sizeof(current_to_root));
+          if (current != root)
+            {
+              if (goodix_milan_relation_matrix_read_to_first (
+                    matrix, root, current, &root_quality,
+                    current_to_root) != 0)
+                return -1;
+              path_quality[root][current] = root_quality;
+              path_quality[current][root] = root_quality;
+            }
+
+          for (size_t candidate = matrix->feature_count; candidate-- > 0;)
+            {
+              int32_t candidate_to_current[6];
+              int32_t edge_rank;
+              int32_t direct_rank;
+              int32_t direct_transform[6];
+              int32_t bottleneck;
+              int32_t candidate_to_root[6];
+
+              if (visited[candidate] > -1 || candidate == current)
+                continue;
+              if (goodix_milan_relation_matrix_read_to_first (
+                    matrix, current, candidate, &edge_rank,
+                    candidate_to_current) != 0)
+                return -1;
+              if (edge_rank <= 0)
+                continue;
+
+              path_quality[current][candidate] = edge_rank;
+              path_quality[candidate][current] = edge_rank;
+              visited[candidate] = (int32_t) root;
+              if (worklist_size >= matrix->feature_count)
+                return -1;
+              worklist[worklist_size++] = candidate;
+              bottleneck = root_quality < edge_rank ? root_quality : edge_rank;
+
+              if (current == root)
+                continue;
+              if (goodix_milan_relation_matrix_read_to_first (
+                    matrix, root, candidate, &direct_rank,
+                    direct_transform) != 0)
+                return -1;
+              if (direct_rank > 2 ||
+                  (direct_rank == 2 &&
+                   path_quality[root][candidate] >= bottleneck))
+                continue;
+
+              goodix_milan_transform_compose (
+                current_to_root, candidate_to_current, candidate_to_root);
+              if (goodix_milan_relation_matrix_store_to_first (
+                    matrix, root, candidate, candidate_to_root) != 0)
+                return -1;
+              path_quality[root][candidate] = bottleneck;
+              path_quality[candidate][root] = bottleneck;
+              changed = 1;
+              if (active_markers[root] == 1 ||
+                  active_markers[candidate] == 1)
+                active_markers[root] = active_markers[candidate] = 1;
+            }
+        }
+    }
+  return changed;
+}
+
 int
 goodix_milan_relation_matrix_project_reference_star (
   const GoodixMilanRelationMatrix *matrix,

--- a/drivers/goodix53x5/milan/relations.h
+++ b/drivers/goodix53x5/milan/relations.h
@@ -134,6 +134,11 @@ goodix_milan_relation_matrix_replace (
   const int32_t                   new_feature_to_reference[6]);
 
 int
+goodix_milan_relation_matrix_close (
+  GoodixMilanRelationMatrix *matrix,
+  int32_t                         active_markers[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY]);
+
+int
 goodix_milan_relation_matrix_project_reference_star (
   const GoodixMilanRelationMatrix *matrix,
   GoodixMilanTemplateRelation          *relations,


### PR DESCRIPTION
## Summary

- preserve the current Windows-compatible 12-accepted-stage enrollment path byte-for-byte
- when the internal enrollment combiner is explicitly given all 40 physical-capacity features, run the DLL-equivalent relation closure and type-12 normalization before publication
- reject 41-50 input features immediately instead of relying on later pack failure

## Scope

Profile-9 Windows enrollment uses the Glass configuration with 12 accepted stages, and this PR does not change `GOODIX_ENROLL_SAMPLES` or normal enrollment behavior. Rejected attempts can still require more than 12 physical touches.

The corrected branch is reached only if the internal combiner is supplied exactly 40 enrollment stages. This keeps a hypothetical future 40-stage configuration native-compatible; the driver remains at 12 because current work targets Windows parity.

## Validation

- exact approved-DLL/current controls for graphless, partially connected, fully connected, and sparse 40-feature compositions
- sparse control synthesized the exact native relation, active markers, reference-star projection, packed size, and normalized lifecycle values
- 13 independent adversarial closure controls matched all 849 relation slots, transforms, active vectors, and return values
- 39-feature output remained byte-identical to the pre-change implementation
- 41-feature input rejected before composition
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`

The standing identify campaigns were not rerun because they cannot execute enrollment composition at 40 and therefore provide no coverage of this branch. No tests were added.

## Documentation

Durable profile-9/type-12 enrollment graph contracts were pushed separately to `milan-dev` at `664ec2bd`.