### PR TITLE
Match Milan correspondence collision pruning

### DIFF
--- a/drivers/goodix53x5/milan/match/correspondence.c
+++ b/drivers/goodix53x5/milan/match/correspondence.c
@@ -37,6 +37,14 @@ milan_descriptor_distance (const GoodixMilanFeatureRecord *first,
   return distance;
 }
 
+static int32_t
+milan_spatial_distance_squared_s32 (int32_t dx,
+                                    int32_t dy)
+{
+  return goodix_milan_transform_s32 (
+    (uint32_t) dx * (uint32_t) dx + (uint32_t) dy * (uint32_t) dy);
+}
+
 size_t
 goodix_milan_match_feature_records (const GoodixMilanFeatureRecord *prior,
                              size_t                          prior_count,
@@ -83,7 +91,7 @@ goodix_milan_match_feature_records (const GoodixMilanFeatureRecord *prior,
           int32_t dy = (int32_t) current_y -
                        (int32_t) (uint16_t) selected->refined_y;
 
-          if ((int64_t) dx * dx + (int64_t) dy * dy >= 0x10000)
+          if (milan_spatial_distance_squared_s32 (dx, dy) >= 0x10000)
             {
               i++;
               continue;
@@ -271,7 +279,7 @@ goodix_milan_match_correspondences_partitioned (
           int32_t dy = (int32_t) probe_y -
                        (int32_t) (uint16_t) selected->refined_y;
 
-          if ((int64_t) dx * dx + (int64_t) dy * dy >= 0x10000)
+          if (milan_spatial_distance_squared_s32 (dx, dy) >= 0x10000)
             {
               i++;
               continue;
@@ -399,7 +407,7 @@ goodix_milan_match_relaxed_correspondences (
           int32_t dy = (int32_t) enrolled_y -
                        (int32_t) (uint16_t) selected->refined_y;
 
-          if ((int64_t) dx * dx + (int64_t) dy * dy >= 0x10000)
+          if (milan_spatial_distance_squared_s32 (dx, dy) >= 0x10000)
             {
               i++;
               continue;
@@ -608,7 +616,7 @@ goodix_milan_match_alternate_correspondences_internal (
               int32_t dy = (int32_t) probe_y -
                            (int32_t) (uint16_t) selected->refined_y;
 
-              if ((int64_t) dx * dx + (int64_t) dy * dy >= 0x10000)
+              if (milan_spatial_distance_squared_s32 (dx, dy) >= 0x10000)
                 {
                   i++;
                   continue;
@@ -737,7 +745,7 @@ milan_store_cross_class_match (
       int32_t dy = (int32_t) probe_y -
                    (int32_t) (uint16_t) selected->refined_y;
 
-      if ((int64_t) dx * dx + (int64_t) dy * dy >= 0x10000)
+      if (milan_spatial_distance_squared_s32 (dx, dy) >= 0x10000)
         {
           i++;
           continue;
@@ -745,8 +753,12 @@ milan_store_cross_class_match (
       if (best_distance >= matches[i].best_distance)
         {
           if (!replaced)
-            replaced = -1;
-          break;
+            {
+              replaced = -1;
+              break;
+            }
+          i++;
+          continue;
         }
       if (!replaced)
         {


### PR DESCRIPTION
## Summary

- continue native cross-class collision scanning after an incoming pair has already replaced one worse duplicate
- remove later worse collisions without changing native swap-skip ordering
- evaluate all correspondence spatial collisions with native signed 32-bit wrapped squared distance

## Native evidence

No retained natural operation contains the triggering multi-collision shape. The correction is based on direct approved-DLL/current controls using canonical type-12 records: extractor-valid classes, descriptors, coordinates inside the `104x88` image, and normal cross-class distance limits.

For the discriminator, old current retained three pairs while the DLL retained two. Patched current matches the DLL exactly for pair count, order, indices, and distances through both ordinary and guided cross-class builders. Independent controls also cover later-better, later-equal, multiple-later-worse, swap-skip, exact `0x10000`, and capacity-42 behavior.

The related wrapped-coordinate controls reproduce DLL signed-dword collision behavior across all five correspondence selector families. Canonical in-image natural controls remain unchanged.

The separate guided cross-class affine-widening finding is deliberately deferred and is not part of this PR.

## Validation

- direct approved-DLL/current ordinary and guided cross-class controls: exact
- retained sequence 100 correspondence arrays: unchanged and exact
- retained sequence 197 correspondence arrays: unchanged and exact
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- current-vs-DLL parity: 450/450 operations exact
- independent current-vs-DLL parity: 643/643 operations exact

No tests were added.

## Documentation

Durable profile-9/type-12 correspondence contracts were pushed separately to `milan-dev` at `6b7abbc1`.