### PR TITLE
Initialize Milan zero-overlap confidence

### DIFF
--- a/drivers/goodix53x5/milan/match/score.c
+++ b/drivers/goodix53x5/milan/match/score.c
@@ -57,6 +57,14 @@ goodix_milan_match_overlap_result (
         result -= ((15 - match_fraction) >> 1) + 3;
       *detail = result;
     }
+  if (mode != 0)
+    {
+      if (!context_confidence)
+        return -1;
+      if (*context_confidence < 0)
+        *context_confidence = classes[3] * 0x100 /
+                              (classes[1] + classes[2] + classes[3] + 1);
+    }
   if (valid_count == 0)
     {
       *score = 128;
@@ -77,11 +85,6 @@ goodix_milan_match_overlap_result (
                  : 128;
       return 0;
     }
-  if (!context_confidence)
-    return -1;
-  if (*context_confidence < 0)
-    *context_confidence = classes[3] * 0x100 /
-                          (classes[1] + classes[2] + classes[3] + 1);
   *score = quality > 23 ||
              (quality > 18 && *context_confidence > 62) ||
              (quality > 19 && *context_confidence > 50) ||


### PR DESCRIPTION
## Summary

- initialize negative shared overlap confidence before returning from a nonzero-mode zero-valid pass
- preserve mode-zero behavior and all nonzero-valid score formulas
- keep current fail-closed null handling rather than reproducing native faults

## Native evidence

No retained natural operation contains zero-valid overlap. The correction is based on direct approved-DLL/current controls using a native-valid zero class vector and positive overlap area.

Windows publishes coverage/detail, initializes negative confidence to zero, then returns score 128. Old current returned score 128 first and left confidence negative.

A direct two-pass shared-context discriminator proves observable behavior:

- pass 1 `{0,0,0,0}`: Windows confidence becomes 0; old current remains negative
- pass 2 `{13,2,0,1}` with production weights `{3,2,3}`: Windows keeps score 128/confidence 0; old current recomputes confidence 64 and promotes score 217

Patched current matches Windows exactly for score, coverage, detail, and confidence across both passes.

The broader score audit found no difference in final-score dispatch, secondary relatching, type thresholds, signed arithmetic, or first-positive selection.

## Validation

- direct approved-DLL/current zero-valid controls for confidence `-2`, `-1`, `0`, and `17`: exact
- mode-zero and optional-output controls: exact
- retained nonzero overlap vector: exact
- two-pass shared-context score discriminator: exact
- 23 overlap and 68 finalizer boundary controls: exact
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- current-vs-DLL parity: 450/450 operations exact
- independent current-vs-DLL parity: 643/643 operations exact

No tests were added.

## Documentation

Durable profile-9/type-12 score/finalization contracts were pushed separately to `milan-dev` at `5272e034`.