### PR TITLE
Match Milan guided affine scan width

### DIFF
--- a/drivers/goodix53x5/milan/match/correspondence.c
+++ b/drivers/goodix53x5/milan/match/correspondence.c
@@ -900,12 +900,14 @@ goodix_milan_match_cross_class_alternate_correspondences (
         (uint16_t) enrolled_records[enrolled_index].refined_x;
       int32_t enrolled_y =
         (uint16_t) enrolled_records[enrolled_index].refined_y;
-      int32_t inverse_x =
-        (((inverse[0] * enrolled_x + inverse[1] * enrolled_y +
-           inverse[2] * 0x100 + 0x80) >> 8) + 0x80) >> 8;
-      int32_t inverse_y =
-        (((inverse[3] * enrolled_x + inverse[4] * enrolled_y +
-           inverse[5] * 0x100 + 0x80) >> 8) + 0x80) >> 8;
+      int32_t inverse_x = milan_match_scan_round_pixel_s32 (
+        milan_match_scan_raw_s32 (
+          inverse[0], (uint32_t) enrolled_x,
+          inverse[1], (uint32_t) enrolled_y, inverse[2]));
+      int32_t inverse_y = milan_match_scan_round_pixel_s32 (
+        milan_match_scan_raw_s32 (
+          inverse[3], (uint32_t) enrolled_x,
+          inverse[4], (uint32_t) enrolled_y, inverse[5]));
       size_t probe_begin = enrolled_index < enrolled_partition_count
                              ? 0
                              : probe_partition_count;
@@ -927,19 +929,26 @@ goodix_milan_match_cross_class_alternate_correspondences (
             sibling_tail_hamming_limit);
           int32_t probe_x = (uint16_t) probe_records[probe_index].refined_x;
           int32_t probe_y = (uint16_t) probe_records[probe_index].refined_y;
-          int64_t raw_x = (int64_t) primary_transform[0] * probe_x +
-                          (int64_t) primary_transform[1] * probe_y +
-                          (int64_t) primary_transform[2] * 0x100;
-          int64_t raw_y = (int64_t) primary_transform[3] * probe_x +
-                          (int64_t) primary_transform[4] * probe_y +
-                          (int64_t) primary_transform[5] * 0x100;
-          int32_t transformed_x = (int32_t) (raw_x >> 8);
-          int32_t transformed_y = (int32_t) (raw_y >> 8);
-          int32_t pixel_x = (int32_t) (((raw_x + 0x80) >> 8) + 0x80) >> 8;
-          int32_t pixel_y = (int32_t) (((raw_y + 0x80) >> 8) + 0x80) >> 8;
+          int32_t raw_x = milan_match_scan_raw_s32 (
+            primary_transform[0], (uint32_t) probe_x,
+            primary_transform[1], (uint32_t) probe_y,
+            primary_transform[2]);
+          int32_t raw_y = milan_match_scan_raw_s32 (
+            primary_transform[3], (uint32_t) probe_x,
+            primary_transform[4], (uint32_t) probe_y,
+            primary_transform[5]);
+          int32_t transformed_x = goodix_milan_transform_sar32 (
+            (uint32_t) raw_x, 8);
+          int32_t transformed_y = goodix_milan_transform_sar32 (
+            (uint32_t) raw_y, 8);
+          int32_t pixel_x = milan_match_scan_round_pixel_s32 (raw_x);
+          int32_t pixel_y = milan_match_scan_round_pixel_s32 (raw_y);
 
-          if (distance < 0 || abs (transformed_x - enrolled_x) > 0x1500 ||
-              abs (transformed_y - enrolled_y) > 0x1500 ||
+          if (distance < 0 ||
+              !milan_match_scan_residual_within (
+                transformed_x, (uint32_t) enrolled_x) ||
+              !milan_match_scan_residual_within (
+                transformed_y, (uint32_t) enrolled_y) ||
               pixel_x <= 5 || pixel_x > 104 - 5 ||
               pixel_y <= 5 || pixel_y > 88 - 5)
             continue;


### PR DESCRIPTION
## Summary

- evaluate guided cross-class inverse and forward affine scans with native wrapped-dword arithmetic
- reuse the existing native-matched scan, arithmetic-shift, pixel-rounding, and residual helpers
- preserve descriptor selection, borders, ratio, partitions, capacity, and PR #62 collision ordering

## Native evidence

No retained natural operation approaches the overflow boundary. The correction is based on a direct approved-DLL/current final-output discriminator using valid type-12 record layouts, partitions, unsigned-16 coordinates, ordinary descriptor bytes, and an affine accepted by checked inversion.

For transform `[65536,0,5120,0,65536,5120]`, enrolled coordinate `(0,0)`, and probe coordinate `(65535,0)`:

- Windows wraps the forward dword sum, passes residual/pixel gates, and publishes pair `[0,0]`
- old current widens the forward x sum to 64 bits, fails residual admission, and publishes no pair
- patched current publishes the exact Windows count and pair array

Malformed native affine-division crashes remain deliberately fail-closed.

## Validation

- direct approved-DLL/current wrap discriminator: exact count 1 and pair `[0,0]`
- residual `0x1500/0x1501`, inverse and forward borders, threshold 16/17, best/second ties, ratio and two-partition ordering: exact
- retained sequence 100: exact six-pair array
- retained sequence 197: exact ten-pair array
- PR #62 collision/pruning regressions, including capacity ordering: exact
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- current-vs-DLL parity: 450/450 operations exact
- independent current-vs-DLL parity: 643/643 operations exact

No tests were added.

## Documentation

Durable profile-9/type-12 guided affine scan contracts were pushed separately to `milan-dev` at `a3c1f7d8`.