### PR TITLE
Preserve Milan blocked-match lifecycle updates

### DIFF
--- a/drivers/goodix53x5/milan/match/lifecycle.c
+++ b/drivers/goodix53x5/milan/match/lifecycle.c
@@ -123,8 +123,7 @@ goodix_match_serialized_feature_result_internal (
 
   if (updated_feature)
     {
-      if (match_result->score > 0 &&
-          match_result->lifecycle_update_feature_mask != 0)
+      if (match_result->lifecycle_update_feature_mask != 0)
         {
           updated_milan = g_malloc (normalized_milan_len);
           if (goodix_milan_template_update_match_lifecycle (


### PR DESCRIPTION
## Summary

- apply matcher-owned lifecycle updates even when the final type-12 aggregate blocker overrides the published score to `-65536`
- preserve the DLL ordering where direct feature lifecycle counters advance before the score-only blocker override
- leave matching, blocker thresholds, score publication, and positive-match behavior unchanged

## Native contract

A valid profile-9/type-12 transaction can contain one direct-contributing feature and at least six independent blocker contributions within the 40-feature template limit. The DLL applies the direct lifecycle increment before evaluating the aggregate blocker score override. Current source preserved the lifecycle mask through finalization but discarded it in serialized lifecycle handling whenever the final score was nonpositive.

The focused `6/414` blocker control now matches the DLL exactly at score `-65536`, feature lifecycle `be: 6 -> 7`, and packed template bytes. The adjacent `6/360` below-threshold control remains unchanged and exact.

Durable native contracts are documented in `re/milan/MATCH-CONTRIBUTION-CONTRACT.md` on `milan-dev` at `a1174d4c`.

## Validation

- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- focused DLL/current `6/414` target and `6/360` boundary controls
- strict current campaign: `450/450`, zero differences
- strict independent campaign: `643/643`, zero differences

No tests were added.