### PR TITLE
Match Milan type-12 post-veto branch

### DIFF
--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -721,6 +721,11 @@ post_veto (const int32_t metrics[77],
   if (metrics[14] == 1 && primary < 12 &&
       (combined < 385 || (combined < 395 && coverage < 100)))
     flags[0] = flags[1] = 0;
+  if (flags[1] != 0 && policy->configuration[18] != 0 && coverage > 200 &&
+      combined < 405 &&
+      ((metrics[10] < 45 && geometry < 15 && metrics[70] > 16) ||
+       metrics[4] == 128))
+    flags[0] = flags[1] = 0;
   if (flags[1] != 0 &&
       ((filtered < 22 && combined < 371) ||
        (filtered < 16 && combined < 381) ||


### PR DESCRIPTION
## Summary

- add the missing type-12 post-veto predicate in its native policy order
- clear both candidate flags for the native high-coverage, low-combined-detail condition
- preserve recognition mode, `configuration[19]`, and all later post-veto ownership

## Native contract

`FUN_180053680` applies this clear-only branch after the `metrics[14]` veto family and before generic `flags[1]` filtering. A producer-valid synthetic feature geometry establishes that an ordinary matcher evaluation can reach the coupled predicate.

At the exact coverage boundary:

- control `metrics[9] = 200`: DLL/current retain flags `0/1`, score 54
- target `metrics[9] = 201`: DLL/current clear flags `0/0`, score 92

Winner, queue, and action remain stable; exact after-match and final-candidate bytes now match the DLL for both controls.

Durable contracts are documented on `milan-dev` at `a1ea18d2` in `re/milan/functions/FUN_180053680.md` and related caller notes.

## Validation

- producer-valid DLL/current `metrics[9]` 200/201 target and boundary controls
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- strict current campaign: `450/450`, zero differences
- strict independent campaign: `643/643`, zero differences
- pre-campaign and post-campaign dead/performance reviews: clean; constant-time comparisons only

No tests were added.