### PR TITLE
Match Milan fallback physical ordering

### DIFF
--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -772,6 +772,8 @@ milan_match_prepared_probe (
   size_t rescue_order_count = 0;
   GoodixMilanMatchRescueResult rescue_result;
   GoodixMilanMatchFallback match_fallback;
+  GoodixMilanMatchFallbackWorkspace
+    *fallback_by_feature[GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT] = { 0 };
   int rescue_applied = 0;
   int retention_gate = 0;
   int retention_gate_latched = 0;
@@ -962,6 +964,7 @@ milan_match_prepared_probe (
             goto out;
           fallback_workspace =
             &match_fallback.workspaces[match_fallback.workspace_count - 1];
+          fallback_by_feature[feature_index] = fallback_workspace;
         }
       if (enrolled->metadata.sensor_type == 12)
         {
@@ -1738,10 +1741,11 @@ milan_match_prepared_probe (
     }
   if (enrolled->metadata.sensor_type == 12)
     {
-      for (size_t i = 0; i < match_fallback.workspace_count; i++)
+      for (size_t feature_index = 0; feature_index < enrolled->feature_count;
+           feature_index++)
         {
           const GoodixMilanMatchFallbackWorkspace *workspace =
-            &match_fallback.workspaces[i];
+            fallback_by_feature[feature_index];
           GoodixMilanFeatureView feature;
           int32_t fallback_candidate_transform[6];
           size_t filtered_count;
@@ -1754,7 +1758,7 @@ milan_match_prepared_probe (
           int32_t absolute_dot_q16;
           int32_t transform_classifier;
 
-          if (!workspace->enabled || workspace->pair_count < 3 ||
+          if (!workspace || !workspace->enabled || workspace->pair_count < 3 ||
               workspace->feature < 0 ||
               (size_t) workspace->feature >= enrolled->feature_count ||
                goodix_milan_template_parse_feature_element (


### PR DESCRIPTION
## Summary

- finalize type-12 fallback candidates in physical feature order, matching the DLL
- preserve lifecycle-order collection and all existing fallback producer/comparator arithmetic
- use a fixed physical-feature workspace map with no allocation or repeated scan

## Native contract

The DLL resolves equal fallback ranks in physical feature order. Current source collected and finalized workspaces in lifecycle order, so valid nonphysical lifecycle order could select a different tied feature whose non-comparator diagnostics change final acceptance.

A producer-valid identify-326 witness ties physical features 22 and 23 at rank `(218,8,100)`:

- DLL/current after fix retain physical feature 22, gate 417, score 19, accepted
- old current retained lifecycle-first feature 23, gate 404, score -1, rejected
- adjacent rank `(217,8,100)` rejects identically at score -1

Exact after-match bytes remain unchanged; study attempted/action ownership now matches the DLL.

Durable native ordering is documented on `milan-dev` at `d1fddd7f` in `re/milan/functions/FUN_18005d5f0.md`.

## Validation

- bounded producer-valid fallback rank 218/217 DLL/current target and control
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- strict current campaign: `450/450`, zero differences
- strict independent campaign: `643/643`, zero differences
- pre-campaign and post-campaign dead/performance reviews: clean; fixed 40-pointer map, no allocations or extra expensive scans

No tests were added.