### PR TITLE
Match Milan low-coverage quality gate

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -272,6 +272,8 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
         output, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
         quality, coverage) != 0)
     goto out;
+  if (*coverage <= 5)
+    *quality = 0;
   memcpy (state->setup_map, setup_map, count * sizeof(*setup_map));
   memcpy (state->primary_contrast, contrast, count);
   state->primary_contrast_valid = 1;


### PR DESCRIPTION
## Summary

- zero profile-9 preprocessing quality when signed coverage is at most 5
- apply the native gate after quality calculation and before preprocessing state publication
- preserve processed bytes, status selection, coverage, and next-call state

## Native contract

The DLL computes direct quality and coverage, resolves late retry/status ownership, then zeros quality when coverage is `<=5`. Current source published the direct quality unchanged.

A full valid type-12 raw-input target reaches successful preprocessing with direct quality/coverage `100/4`:

- DLL/current after fix: status 0, quality/coverage `0/4`
- old current: status 0, quality/coverage `100/4`
- processed bytes are identical

The adjacent coverage-6 control remains `100/6` on both sides, including when run immediately after the target, proving state commit remains exact.

Durable producer and publication contracts are documented on `milan-dev` at `a174c9e0` in the relevant preprocessing function notes.

## Validation

- full raw-input quality/coverage 100/4 target and 100/6 boundary control
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime`
- strict current campaign: `450/450`, zero differences
- strict independent campaign: `643/643`, zero differences
- pre-campaign and post-campaign dead/performance reviews: clean; one signed comparison and conditional store

No tests were added.