### PR TITLE
Match Milan strict policy output gate

### DIFF
--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -854,7 +854,7 @@ late_eligibility (const int32_t metrics[77],
           break;
         }
     }
-  output[0] = strict;
+  output[0] = strict && image_quality > 15 && image_coverage > 64;
   output[1] = strict || broad;
 }
 


### PR DESCRIPTION
## Summary

- require raw image quality greater than 15 and raw image coverage greater than 64 before publishing a strict policy match
- preserve strict candidate publication independently of the match gate
- match the profile-9 DLL strict sink and its downstream selection/study behavior

## Native contract

At the strict sink, the DLL always publishes the candidate output after a strict threshold hit. It publishes the match output only when raw image quality is at least 16 and raw image coverage is at least 65. The raw inputs remain distinct from the normalized quality band used to select policy threshold rows.

A producer-valid boundary target previously diverged in score, selected candidate state, after-match template, and study action. The corrected target and adjacent control now match the DLL exactly. Durable reverse-engineering notes are available on `milan-dev` at `5ba73ba3`.

## Validation

- focused DLL/current target and adjacent control: exact
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh`
- `goodix53x5-milan-synthetic`
- `goodix53x5-milan-state`
- `goodix53x5-milan-runtime`
- current campaign snapshot: 450/450, zero differences
- prior independent campaign: 643/643, zero differences
- pre- and post-campaign ownership, dead-code, boundary, and performance review: clean