### PR TITLE
Match Milan low-count application gain reset

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -198,6 +198,11 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
         GOODIX_MILAN_SENSOR_COLUMNS, contrast_mask, &admitted_pixels) != 0)
     goto out;
 
+  /* Native refills retained low-count application gain before processing. */
+  if (state->sample_count > 0 && state->sample_count <= 3)
+    for (size_t i = 0; i < count; i++)
+      state->application_gain_map[i] = MILAN_FIXED_ONE;
+
   milan_profile9_make_reciprocal_plane (
     state->application_gain_map, count, reciprocal_plane);
   goodix_milan_profile9_update_gain_ready (


### PR DESCRIPTION
## Summary

Match the native profile-9/type-12 preprocessing behavior by refilling the application-gain map with Q13 unity for retained sample counts 1 through 3.

The correction is limited to `drivers/goodix53x5/milan/core.c`. It changes no thresholds, allocation, serialization, persisted state, or nested-update ownership.

## Native contract

After setup and raw admission succeed, native preprocessing:

- handles count zero through the full generation reset;
- explicitly refills the application-gain map for retained entry counts 1 through 3;
- performs that refill before reciprocal-plane construction and auxiliary-gain updates;
- retains the evolved map from count 4 onward;
- does not reset the nested forced-count-5 path.

## Observable divergence

The previous implementation initialized the application-gain map only during a full generation reset. After a retry, it could therefore reuse a map normalized by the preceding nested update.

In the producer-valid repeated-frame chronology, native retained coverage 18 while the current implementation dropped to coverage 11. Both returned retry status `0x7531`, but the reported coverage and retained primary gain state diverged and could affect subsequent attempts.

## Focused validation

| Case | Native | Before | After |
|---|---|---|---|
| Fresh use 1 | `0x7531 / quality 0 / coverage 18` | Same | Same |
| Retained use 2 | `0x7531 / quality 0 / coverage 18` | `0x7531 / quality 0 / coverage 11` | Matches native |

After the correction, the primary gain map remains identical across both uses. The adjacent nested-count-5 control also passed.

## Build and suites

The final formatted source passed:

- debug-disabled offline production build: 126 build actions;
- Milan synthetic suite: 9/9;
- Milan state suite: 6/6;
- Milan runtime suite: 7/7;
- focused `fpi-device` integration suite: 98/98;
- differential formatting and `git diff --check`.

No new tests were added, following the repository's no-new-tests policy.

## Strict parity campaigns

Both standing datasets were run sequentially against the final source identity using explicit selectors, current strict schemas, sealed build identities, and natural queue behavior:

- premerge dataset: 450/450 passed, zero differences or unavailable fields;
- enrollment follow-up dataset: 643/643 passed, zero differences or unavailable fields.

Every selected operation had complete projection equality, structural replay admissibility, and matching current/native queue observations.

## Reviews

Independent correctness reviews found no ownership, ordering, boundary, interaction, dead-code, redundancy, or adjacent-correction issue. Counts 0, 1 through 3, 4, and the nested forced count 5 retain their intended owners.

The added work is bounded to 9,504 `uint16_t` stores during retained counts 1 through 3. Across 8,000 measured retained calls per build, median movement was `+0.032 ms` (`+0.23%`), with no p95 or maximum regression. No material performance regression was found.

## Documentation

Durable native contract documentation: `db5902408271c6bcdab30a26c3a2ce7d52367f2c`