### PR TITLE
Persist Milan preprocessing state

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -16,6 +16,7 @@
 #include "milan/print.h"
 #include "driver-private.h"
 #include "milan/runtime.h"
+#include "device/persistence.h"
 #include "device/scan.h"
 #include "device/session.h"
 
@@ -612,6 +613,7 @@ goodix_verify_ssm_done (FpiSsm   *ssm,
               fpi_print_set_raw_data (self->pending_update_target,
                                       self->pending_update_data);
               updated = TRUE;
+              goodix_milan_persistence_save (dev, self->milan_generation);
             }
           goodix_flush_pending_result_report (dev);
         }

--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -93,6 +93,7 @@ goodix_clear_pending_result_report (FpiDeviceGoodix53x5 *self)
   g_clear_object (&self->pending_identify_match);
   g_clear_object (&self->pending_update_target);
   g_clear_pointer (&self->pending_update_data, g_variant_unref);
+  g_clear_pointer (&self->pending_persistence_state, g_free);
   g_clear_error (&self->pending_result_error);
   g_clear_error (&self->pending_learning_error);
 }
@@ -149,6 +150,7 @@ goodix_flush_pending_result_report (FpDevice *dev)
   g_clear_object (&self->pending_identify_match);
   g_clear_object (&self->pending_update_target);
   g_clear_pointer (&self->pending_update_data, g_variant_unref);
+  g_clear_pointer (&self->pending_persistence_state, g_free);
   g_clear_error (&self->pending_learning_error);
 }
 
@@ -356,6 +358,9 @@ goodix_auth_task_done (GObject      *source_object,
           {
             self->pending_update_target = g_object_ref (original);
             self->pending_update_data = g_steal_pointer (&update_data);
+            if (output->preprocess_state_valid)
+              self->pending_persistence_state = g_memdup2 (
+                &output->preprocess_state, sizeof (output->preprocess_state));
           }
         if (output->learning_error)
           self->pending_learning_error = g_error_copy (output->learning_error);
@@ -613,7 +618,8 @@ goodix_verify_ssm_done (FpiSsm   *ssm,
               fpi_print_set_raw_data (self->pending_update_target,
                                       self->pending_update_data);
               updated = TRUE;
-              goodix_milan_persistence_save (dev, self->milan_generation);
+              goodix_milan_persistence_save (
+                dev, self->pending_persistence_state);
             }
           goodix_flush_pending_result_report (dev);
         }

--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -308,6 +308,7 @@ goodix_milan_replace_raw_frame (guint16 **owner,
 #include "device/calibration.h"
 #include "device/commands.h"
 #include "device/image.h"
+#include "device/persistence.h"
 #include "device/transport.h"
 
 typedef enum
@@ -725,6 +726,7 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
             return;
           }
 
+        goodix_milan_persistence_restore (dev, generation);
         goodix_milan_generation_invalidate (&self->milan_generation);
         self->milan_generation = generation;
         memcpy (self->profile9_fdt.base_down, data->candidate_base_down,

--- a/drivers/goodix53x5/device/enroll.c
+++ b/drivers/goodix53x5/device/enroll.c
@@ -17,6 +17,7 @@
 #include "milan/print.h"
 #include "driver-private.h"
 #include "milan/runtime.h"
+#include "device/persistence.h"
 #include "device/scan.h"
 #include "device/session.h"
 
@@ -491,6 +492,7 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
                    goodix_milan_enrollment_transaction_free);
   fp_info ("Native Milan enrollment complete with %d stages",
            GOODIX_ENROLL_SAMPLES);
+  goodix_milan_persistence_save (dev, self->milan_generation);
   goodix_debug_timing_action_done (self, dev, NULL);
   fpi_device_enroll_complete (dev, g_object_ref (print), NULL);
 }

--- a/drivers/goodix53x5/device/enroll.c
+++ b/drivers/goodix53x5/device/enroll.c
@@ -221,6 +221,10 @@ goodix_enroll_task_done (GObject      *source_object,
         goodix_debug_dump_pair (prefix, self->captured_raw_image,
                                 self->captured_image);
                             )
+      g_clear_pointer (&self->pending_persistence_state, g_free);
+      if (output->preprocess_state_valid)
+        self->pending_persistence_state = g_memdup2 (
+          &output->preprocess_state, sizeof (output->preprocess_state));
       self->enroll_stage = (gint) goodix_milan_enrollment_transaction_count (
         self->enroll_transaction);
       GOODIX53X5_DEBUG_ONLY (
@@ -450,6 +454,7 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
       g_clear_error (&self->pending_enroll_error);
       g_clear_pointer (&self->enroll_transaction,
                        goodix_milan_enrollment_transaction_free);
+      g_clear_pointer (&self->pending_persistence_state, g_free);
       goodix_debug_timing_action_done (self, dev, error->message);
       fpi_device_enroll_complete (dev, NULL, error);
       return;
@@ -458,7 +463,8 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
   if (self->enroll_stage != GOODIX_ENROLL_SAMPLES ||
       !self->enroll_transaction ||
       goodix_milan_enrollment_transaction_count (
-        self->enroll_transaction) != GOODIX_ENROLL_SAMPLES)
+        self->enroll_transaction) != GOODIX_ENROLL_SAMPLES ||
+      !self->pending_persistence_state)
     {
       GError *chronology_error = fpi_device_error_new_msg (
         FP_DEVICE_ERROR_GENERAL,
@@ -466,6 +472,7 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
 
       g_clear_pointer (&self->enroll_transaction,
                        goodix_milan_enrollment_transaction_free);
+      g_clear_pointer (&self->pending_persistence_state, g_free);
       fpi_device_enroll_complete (dev, NULL, chronology_error);
       return;
     }
@@ -478,6 +485,7 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
     {
       g_clear_pointer (&self->enroll_transaction,
                        goodix_milan_enrollment_transaction_free);
+      g_clear_pointer (&self->pending_persistence_state, g_free);
       if (!error)
         error = fpi_device_error_new_msg (FP_DEVICE_ERROR_GENERAL,
                                           "Failed to build native Milan template");
@@ -492,7 +500,8 @@ goodix_enroll_ssm_done (FpiSsm   *ssm,
                    goodix_milan_enrollment_transaction_free);
   fp_info ("Native Milan enrollment complete with %d stages",
            GOODIX_ENROLL_SAMPLES);
-  goodix_milan_persistence_save (dev, self->milan_generation);
+  goodix_milan_persistence_save (dev, self->pending_persistence_state);
+  g_clear_pointer (&self->pending_persistence_state, g_free);
   goodix_debug_timing_action_done (self, dev, NULL);
   fpi_device_enroll_complete (dev, g_object_ref (print), NULL);
 }
@@ -521,6 +530,7 @@ goodix_enroll_start (FpDevice *dev)
   g_clear_pointer (&self->captured_image, g_free);
 #endif
   g_clear_pointer (&self->captured_raw_image, g_free);
+  g_clear_pointer (&self->pending_persistence_state, g_free);
   if (!self->enroll_transaction)
     {
       fpi_device_enroll_complete (

--- a/drivers/goodix53x5/device/persistence.c
+++ b/drivers/goodix53x5/device/persistence.c
@@ -24,12 +24,40 @@
 
 #define GOODIX_MILAN_STATE_DIR "/var/lib/fprint"
 #define GOODIX_MILAN_STATE_PREFIX "goodix53x5-preprocess-"
-#define GOODIX_MILAN_STATE_VERSION 1u
+#define GOODIX_MILAN_STATE_VERSION 2u
 #define GOODIX_MILAN_STATE_HEADER_SIZE 64u
-#define GOODIX_MILAN_STATE_PAYLOAD_SIZE \
+#define GOODIX_MILAN_STATE_SAMPLE_FORMAT 2u
+#define GOODIX_MILAN_STATE_CALIBRATION_SIZE \
   (GOODIX_MILAN_SENSOR_PIXELS * sizeof (guint16))
+#define GOODIX_MILAN_STATE_RING_PLANES_SIZE \
+  (3u * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS)
+#define GOODIX_MILAN_STATE_AGE_PLANE_SIZE GOODIX_MILAN_SENSOR_PIXELS
+#define GOODIX_MILAN_STATE_REFERENCE_ROWS (GOODIX_MILAN_SENSOR_ROWS / 2u)
+#define GOODIX_MILAN_STATE_REFERENCE_COLUMNS (GOODIX_MILAN_SENSOR_COLUMNS / 2u)
+#define GOODIX_MILAN_STATE_REFERENCE_VALUES \
+  (GOODIX_MILAN_STATE_REFERENCE_ROWS * GOODIX_MILAN_STATE_REFERENCE_COLUMNS)
+#define GOODIX_MILAN_STATE_REFERENCE_SIZE \
+  (GOODIX_MILAN_STATE_REFERENCE_VALUES * sizeof (guint16))
 #define GOODIX_MILAN_STATE_DIGEST_SIZE 32u
 #define GOODIX_MILAN_STATE_PAYLOAD_OFFSET GOODIX_MILAN_STATE_HEADER_SIZE
+#define GOODIX_MILAN_STATE_CALIBRATION_OFFSET GOODIX_MILAN_STATE_PAYLOAD_OFFSET
+#define GOODIX_MILAN_STATE_RING_COUNT_OFFSET \
+  (GOODIX_MILAN_STATE_CALIBRATION_OFFSET + GOODIX_MILAN_STATE_CALIBRATION_SIZE)
+#define GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET \
+  (GOODIX_MILAN_STATE_RING_COUNT_OFFSET + 1u)
+#define GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET \
+  (GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET + 1u)
+#define GOODIX_MILAN_STATE_RING_PLANES_OFFSET \
+  (GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET + 1u)
+#define GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET \
+  (GOODIX_MILAN_STATE_RING_PLANES_OFFSET + GOODIX_MILAN_STATE_RING_PLANES_SIZE)
+#define GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET \
+  (GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET + GOODIX_MILAN_STATE_AGE_PLANE_SIZE)
+#define GOODIX_MILAN_STATE_REFERENCE_OFFSET \
+  (GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET + GOODIX_MILAN_STATE_AGE_PLANE_SIZE)
+#define GOODIX_MILAN_STATE_PAYLOAD_SIZE \
+  (GOODIX_MILAN_STATE_REFERENCE_OFFSET + GOODIX_MILAN_STATE_REFERENCE_SIZE - \
+   GOODIX_MILAN_STATE_PAYLOAD_OFFSET)
 #define GOODIX_MILAN_STATE_DIGEST_OFFSET \
   (GOODIX_MILAN_STATE_PAYLOAD_OFFSET + GOODIX_MILAN_STATE_PAYLOAD_SIZE)
 #define GOODIX_MILAN_STATE_FILE_SIZE \
@@ -53,7 +81,7 @@ static const guint8 goodix_milan_state_magic[8] = {
   'G', '5', '3', 'P', '9', 'P', 'S', '\0'
 };
 static const gchar goodix_milan_identity_domain[] =
-  "goodix53x5-preprocess-v1";
+  "goodix53x5-preprocess-v2";
 
 static void
 goodix_milan_write_u16 (guint8 *output,
@@ -87,6 +115,94 @@ goodix_milan_read_u32 (const guint8 *input)
 
   memcpy (&value, input, sizeof (value));
   return GUINT32_FROM_LE (value);
+}
+
+static gint32
+goodix_milan_shift_right (gint32 value,
+                          guint  shift)
+{
+  guint32 bits = (guint32) value;
+
+  if (value >= 0)
+    return (gint32) (bits >> shift);
+  return (gint32) ((bits >> shift) |
+                   (~UINT32_C (0) << (32u - shift)));
+}
+
+static void
+goodix_milan_restore_reference (const guint8 *packed,
+                                guint16      *output)
+{
+  gint16 source[GOODIX_MILAN_STATE_REFERENCE_VALUES];
+
+  for (gsize i = 0; i < G_N_ELEMENTS (source); i++)
+    source[i] = (gint16) goodix_milan_read_u16 (packed + i * sizeof (guint16));
+
+  for (gsize row = 0; row < GOODIX_MILAN_SENSOR_ROWS; row++)
+    for (gsize column = 0; column < GOODIX_MILAN_SENSOR_COLUMNS; column++)
+      {
+        gsize source_row = row / 2u;
+        gsize source_column = column / 2u;
+        gint32 values[4];
+        guint value_count = 0;
+        gint32 value;
+
+        for (gsize y = source_row;
+             y < source_row + 2u && y < GOODIX_MILAN_STATE_REFERENCE_ROWS;
+             y++)
+          for (gsize x = source_column;
+               x < source_column + 2u &&
+               x < GOODIX_MILAN_STATE_REFERENCE_COLUMNS;
+               x++)
+            values[value_count++] =
+              source[y * GOODIX_MILAN_STATE_REFERENCE_COLUMNS + x];
+
+        if (value_count == 4)
+          {
+            gint32 fx = (column & 1u) ? 128 : 0;
+            gint32 fy = (row & 1u) ? 128 : 0;
+            guint32 weighted =
+              (guint32) values[0] * (guint32) (256 - fx) *
+                (guint32) (256 - fy) +
+              (guint32) values[1] * (guint32) fx *
+                (guint32) (256 - fy) +
+              (guint32) values[2] * (guint32) (256 - fx) * (guint32) fy +
+              (guint32) values[3] * (guint32) fx * (guint32) fy + 0x8000u;
+
+            value = goodix_milan_shift_right ((gint32) weighted, 16);
+          }
+        else
+          {
+            gint32 sum = 0;
+
+            for (guint i = 0; i < value_count; i++)
+              sum += values[i];
+            value = sum / (gint32) value_count;
+          }
+        output[row * GOODIX_MILAN_SENSOR_COLUMNS + column] =
+          (guint16) (gint16) value;
+      }
+}
+
+static void
+goodix_milan_store_reference (const guint16 *input,
+                              guint8        *packed)
+{
+  for (gsize row = 0; row < GOODIX_MILAN_STATE_REFERENCE_ROWS; row++)
+    for (gsize column = 0; column < GOODIX_MILAN_STATE_REFERENCE_COLUMNS;
+         column++)
+      {
+        gsize source = row * 2u * GOODIX_MILAN_SENSOR_COLUMNS + column * 2u;
+        gint32 sum = (gint16) input[source] +
+                     (gint16) input[source + 1] +
+                     (gint16) input[source + GOODIX_MILAN_SENSOR_COLUMNS] +
+                     (gint16) input[source + GOODIX_MILAN_SENSOR_COLUMNS + 1];
+
+        goodix_milan_write_u16 (
+          packed + (row * GOODIX_MILAN_STATE_REFERENCE_COLUMNS + column) *
+                     sizeof (guint16),
+          (guint16) (gint16) goodix_milan_shift_right (sum, 2));
+      }
 }
 
 static void
@@ -225,7 +341,8 @@ goodix_milan_state_valid (
       goodix_milan_read_u16 (contents + GOODIX_MILAN_STATE_COLUMNS_OFFSET) !=
       GOODIX_MILAN_SENSOR_COLUMNS ||
       goodix_milan_read_u16 (
-        contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET) != 1 ||
+        contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET) !=
+      GOODIX_MILAN_STATE_SAMPLE_FORMAT ||
       goodix_milan_read_u32 (
         contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET) >
       GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT ||
@@ -233,8 +350,19 @@ goodix_milan_state_valid (
         contents + GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET) !=
       GOODIX_MILAN_STATE_PAYLOAD_SIZE ||
       memcmp (contents + GOODIX_MILAN_STATE_IDENTITY_OFFSET, identity,
-              GOODIX_MILAN_STATE_DIGEST_SIZE) != 0)
+              GOODIX_MILAN_STATE_DIGEST_SIZE) != 0 ||
+      contents[GOODIX_MILAN_STATE_RING_COUNT_OFFSET] > 3u ||
+      contents[GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET] > 5u ||
+      contents[GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET] > 50u)
     return FALSE;
+
+  for (gsize i = 0; i < GOODIX_MILAN_STATE_RING_PLANES_SIZE; i++)
+    if (contents[GOODIX_MILAN_STATE_RING_PLANES_OFFSET + i] > 2u)
+      return FALSE;
+  for (gsize i = 0; i < GOODIX_MILAN_STATE_AGE_PLANE_SIZE; i++)
+    if (contents[GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET + i] > 5u ||
+        contents[GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET + i] > 50u)
+      return FALSE;
 
   goodix_milan_sha256 (contents, GOODIX_MILAN_STATE_DIGEST_OFFSET, digest);
   return memcmp (contents + GOODIX_MILAN_STATE_DIGEST_OFFSET, digest,
@@ -287,6 +415,7 @@ goodix_milan_persistence_restore (FpDevice              *dev,
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   g_autofree gchar *path = NULL;
   g_autofree guint8 *contents = NULL;
+  g_autofree GoodixMilanPreprocessState *restored = NULL;
 
   g_autoptr(GError) error = NULL;
 
@@ -317,12 +446,38 @@ goodix_milan_persistence_restore (FpDevice              *dev,
       return;
     }
 
-  generation->state.sample_count = goodix_milan_read_u32 (
+  restored = g_new (GoodixMilanPreprocessState, 1);
+  goodix_milan_preprocess_reset (restored);
+  restored->sample_count = goodix_milan_read_u32 (
     contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET);
   for (gsize i = 0; i < GOODIX_MILAN_SENSOR_PIXELS; i++)
-    generation->state.calibration_map[i] = goodix_milan_read_u16 (
-      contents + GOODIX_MILAN_STATE_PAYLOAD_OFFSET +
+    restored->calibration_map[i] = goodix_milan_read_u16 (
+      contents + GOODIX_MILAN_STATE_CALIBRATION_OFFSET +
       i * sizeof (guint16));
+  restored->extraction_classification.retained_count =
+    contents[GOODIX_MILAN_STATE_RING_COUNT_OFFSET];
+  restored->extraction_persistence.retained_count =
+    contents[GOODIX_MILAN_STATE_RING_COUNT_OFFSET];
+  memcpy (restored->extraction_classification.retained_class_planes,
+          contents + GOODIX_MILAN_STATE_RING_PLANES_OFFSET,
+          GOODIX_MILAN_STATE_RING_PLANES_SIZE);
+  memcpy (restored->extraction_persistence.retained_class_planes,
+          contents + GOODIX_MILAN_STATE_RING_PLANES_OFFSET,
+          GOODIX_MILAN_STATE_RING_PLANES_SIZE);
+  restored->profile9_history_update_count =
+    contents[GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET];
+  restored->profile9_history_count =
+    contents[GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET];
+  memcpy (restored->profile9_component_age,
+          contents + GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET,
+          GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
+  memcpy (restored->profile9_reference_age,
+          contents + GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET,
+          GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
+  goodix_milan_restore_reference (
+    contents + GOODIX_MILAN_STATE_REFERENCE_OFFSET,
+    restored->profile9_history_reference);
+  generation->state = *restored;
   fp_info ("Restored Milan preprocessing state with %u samples",
            generation->state.sample_count);
 }
@@ -334,18 +489,41 @@ goodix_milan_persistence_save (FpDevice                    *dev,
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   g_autofree guint8 *contents = NULL;
   g_autofree gchar *path = NULL;
+  const guint8 *retained_planes;
 
   g_autoptr(GError) error = NULL;
 
   if (!generation || !generation->admitted ||
       !self->milan_persistence_identity_valid)
     return;
+  retained_planes = (const guint8 *)
+    generation->state.extraction_persistence.retained_class_planes;
   if (generation->state.sample_count > GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT)
     {
       fp_warn ("Refusing to save invalid Milan sample count %u",
                generation->state.sample_count);
       return;
     }
+  if (generation->state.extraction_persistence.retained_count > 3u ||
+      generation->state.profile9_history_update_count > 5u ||
+      generation->state.profile9_history_count > 50u)
+    {
+      fp_warn ("Refusing to save invalid Milan retained-state counters");
+      return;
+    }
+  for (gsize i = 0; i < GOODIX_MILAN_STATE_RING_PLANES_SIZE; i++)
+    if (retained_planes[i] > 2u)
+      {
+        fp_warn ("Refusing to save invalid Milan retained class plane");
+        return;
+      }
+  for (gsize i = 0; i < GOODIX_MILAN_STATE_AGE_PLANE_SIZE; i++)
+    if (generation->state.profile9_component_age[i] > 5u ||
+        generation->state.profile9_reference_age[i] > 50u)
+      {
+        fp_warn ("Refusing to save invalid Milan retained age plane");
+        return;
+      }
 
   contents = g_malloc0 (GOODIX_MILAN_STATE_FILE_SIZE);
   memcpy (contents + GOODIX_MILAN_STATE_MAGIC_OFFSET,
@@ -361,7 +539,7 @@ goodix_milan_persistence_save (FpDevice                    *dev,
   goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_COLUMNS_OFFSET,
                           GOODIX_MILAN_SENSOR_COLUMNS);
   goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET,
-                          1);
+                          GOODIX_MILAN_STATE_SAMPLE_FORMAT);
   goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET,
                           generation->state.sample_count);
   goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET,
@@ -371,8 +549,27 @@ goodix_milan_persistence_save (FpDevice                    *dev,
           sizeof (self->milan_persistence_identity));
   for (gsize i = 0; i < GOODIX_MILAN_SENSOR_PIXELS; i++)
     goodix_milan_write_u16 (
-      contents + GOODIX_MILAN_STATE_PAYLOAD_OFFSET + i * sizeof (guint16),
+      contents + GOODIX_MILAN_STATE_CALIBRATION_OFFSET +
+        i * sizeof (guint16),
       generation->state.calibration_map[i]);
+  contents[GOODIX_MILAN_STATE_RING_COUNT_OFFSET] =
+    (guint8) generation->state.extraction_persistence.retained_count;
+  contents[GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET] =
+    (guint8) generation->state.profile9_history_update_count;
+  contents[GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET] =
+    (guint8) generation->state.profile9_history_count;
+  memcpy (contents + GOODIX_MILAN_STATE_RING_PLANES_OFFSET,
+          retained_planes,
+          GOODIX_MILAN_STATE_RING_PLANES_SIZE);
+  memcpy (contents + GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET,
+          generation->state.profile9_component_age,
+          GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
+  memcpy (contents + GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET,
+          generation->state.profile9_reference_age,
+          GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
+  goodix_milan_store_reference (
+    generation->state.profile9_history_reference,
+    contents + GOODIX_MILAN_STATE_REFERENCE_OFFSET);
   goodix_milan_sha256 (contents, GOODIX_MILAN_STATE_DIGEST_OFFSET,
                        contents + GOODIX_MILAN_STATE_DIGEST_OFFSET);
 

--- a/drivers/goodix53x5/device/persistence.c
+++ b/drivers/goodix53x5/device/persistence.c
@@ -248,7 +248,7 @@ goodix_milan_state_directory_secure (GError **error)
       return FALSE;
     }
   if (!S_ISDIR (stat_buffer.st_mode) || stat_buffer.st_uid != geteuid () ||
-      (stat_buffer.st_mode & (S_IWGRP | S_IWOTH)) != 0)
+      (stat_buffer.st_mode & 0777) != 0700)
     {
       g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_ACCES,
                    "Milan state directory %s has unsafe ownership or permissions",
@@ -279,7 +279,7 @@ goodix_milan_state_read (const gchar *path,
     }
   if (fstat (descriptor, &stat_buffer) != 0 ||
       !S_ISREG (stat_buffer.st_mode) || stat_buffer.st_uid != geteuid () ||
-      (stat_buffer.st_mode & (S_IWGRP | S_IWOTH)) != 0 ||
+      (stat_buffer.st_mode & 0777) != 0600 ||
       stat_buffer.st_size != GOODIX_MILAN_STATE_FILE_SIZE)
     {
       g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
@@ -312,6 +312,56 @@ goodix_milan_state_read (const gchar *path,
     }
   close (descriptor);
   *contents = g_steal_pointer (&buffer);
+  return TRUE;
+}
+
+static gboolean
+goodix_milan_state_make_private (const gchar *path,
+                                 GError     **error)
+{
+  GStatBuf stat_buffer;
+  int descriptor;
+
+  descriptor = g_open (path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0);
+  if (descriptor < 0)
+    {
+      int saved_errno = errno;
+
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved_errno),
+                   "Failed to secure %s: %s", path,
+                   g_strerror (saved_errno));
+      return FALSE;
+    }
+  if (fstat (descriptor, &stat_buffer) != 0 ||
+      !S_ISREG (stat_buffer.st_mode) || stat_buffer.st_uid != geteuid () ||
+      stat_buffer.st_size != GOODIX_MILAN_STATE_FILE_SIZE)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                   "Milan preprocessing state %s has invalid size or ownership",
+                   path);
+      close (descriptor);
+      return FALSE;
+    }
+  if (fchmod (descriptor, 0600) != 0 || fsync (descriptor) != 0)
+    {
+      int saved_errno = errno;
+
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved_errno),
+                   "Failed to secure %s: %s", path,
+                   g_strerror (saved_errno));
+      close (descriptor);
+      return FALSE;
+    }
+  if (fstat (descriptor, &stat_buffer) != 0 ||
+      (stat_buffer.st_mode & 0777) != 0600)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_ACCES,
+                   "Milan preprocessing state %s did not retain private permissions",
+                   path);
+      close (descriptor);
+      return FALSE;
+    }
+  close (descriptor);
   return TRUE;
 }
 
@@ -483,8 +533,8 @@ goodix_milan_persistence_restore (FpDevice              *dev,
 }
 
 void
-goodix_milan_persistence_save (FpDevice                    *dev,
-                               const GoodixMilanGeneration *generation)
+goodix_milan_persistence_save (FpDevice                         *dev,
+                               const GoodixMilanPreprocessState *state)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   g_autofree guint8 *contents = NULL;
@@ -493,20 +543,19 @@ goodix_milan_persistence_save (FpDevice                    *dev,
 
   g_autoptr(GError) error = NULL;
 
-  if (!generation || !generation->admitted ||
-      !self->milan_persistence_identity_valid)
+  if (!state || !self->milan_persistence_identity_valid)
     return;
   retained_planes = (const guint8 *)
-    generation->state.extraction_persistence.retained_class_planes;
-  if (generation->state.sample_count > GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT)
+    state->extraction_persistence.retained_class_planes;
+  if (state->sample_count > GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT)
     {
       fp_warn ("Refusing to save invalid Milan sample count %u",
-               generation->state.sample_count);
+               state->sample_count);
       return;
     }
-  if (generation->state.extraction_persistence.retained_count > 3u ||
-      generation->state.profile9_history_update_count > 5u ||
-      generation->state.profile9_history_count > 50u)
+  if (state->extraction_persistence.retained_count > 3u ||
+      state->profile9_history_update_count > 5u ||
+      state->profile9_history_count > 50u)
     {
       fp_warn ("Refusing to save invalid Milan retained-state counters");
       return;
@@ -518,8 +567,8 @@ goodix_milan_persistence_save (FpDevice                    *dev,
         return;
       }
   for (gsize i = 0; i < GOODIX_MILAN_STATE_AGE_PLANE_SIZE; i++)
-    if (generation->state.profile9_component_age[i] > 5u ||
-        generation->state.profile9_reference_age[i] > 50u)
+    if (state->profile9_component_age[i] > 5u ||
+        state->profile9_reference_age[i] > 50u)
       {
         fp_warn ("Refusing to save invalid Milan retained age plane");
         return;
@@ -541,7 +590,7 @@ goodix_milan_persistence_save (FpDevice                    *dev,
   goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET,
                           GOODIX_MILAN_STATE_SAMPLE_FORMAT);
   goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET,
-                          generation->state.sample_count);
+                          state->sample_count);
   goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET,
                           GOODIX_MILAN_STATE_PAYLOAD_SIZE);
   memcpy (contents + GOODIX_MILAN_STATE_IDENTITY_OFFSET,
@@ -551,24 +600,24 @@ goodix_milan_persistence_save (FpDevice                    *dev,
     goodix_milan_write_u16 (
       contents + GOODIX_MILAN_STATE_CALIBRATION_OFFSET +
         i * sizeof (guint16),
-      generation->state.calibration_map[i]);
+      state->calibration_map[i]);
   contents[GOODIX_MILAN_STATE_RING_COUNT_OFFSET] =
-    (guint8) generation->state.extraction_persistence.retained_count;
+    (guint8) state->extraction_persistence.retained_count;
   contents[GOODIX_MILAN_STATE_COMPONENT_COUNT_OFFSET] =
-    (guint8) generation->state.profile9_history_update_count;
+    (guint8) state->profile9_history_update_count;
   contents[GOODIX_MILAN_STATE_REFERENCE_COUNT_OFFSET] =
-    (guint8) generation->state.profile9_history_count;
+    (guint8) state->profile9_history_count;
   memcpy (contents + GOODIX_MILAN_STATE_RING_PLANES_OFFSET,
           retained_planes,
           GOODIX_MILAN_STATE_RING_PLANES_SIZE);
   memcpy (contents + GOODIX_MILAN_STATE_COMPONENT_AGES_OFFSET,
-          generation->state.profile9_component_age,
+          state->profile9_component_age,
           GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
   memcpy (contents + GOODIX_MILAN_STATE_SUPPORT_AGES_OFFSET,
-          generation->state.profile9_reference_age,
+          state->profile9_reference_age,
           GOODIX_MILAN_STATE_AGE_PLANE_SIZE);
   goodix_milan_store_reference (
-    generation->state.profile9_history_reference,
+    state->profile9_history_reference,
     contents + GOODIX_MILAN_STATE_REFERENCE_OFFSET);
   goodix_milan_sha256 (contents, GOODIX_MILAN_STATE_DIGEST_OFFSET,
                        contents + GOODIX_MILAN_STATE_DIGEST_OFFSET);
@@ -595,6 +644,13 @@ goodix_milan_persistence_save (FpDevice                    *dev,
                path, error->message);
       return;
     }
+  g_clear_error (&error);
+  if (!goodix_milan_state_make_private (path, &error))
+    {
+      fp_warn ("Failed to secure Milan preprocessing state %s: %s",
+               path, error->message);
+      return;
+    }
   fp_info ("Saved Milan preprocessing state with %u samples",
-           generation->state.sample_count);
+           state->sample_count);
 }

--- a/drivers/goodix53x5/device/persistence.c
+++ b/drivers/goodix53x5/device/persistence.c
@@ -1,0 +1,403 @@
+/*
+ * Goodix 53x5 driver for libfprint - Milan preprocessing persistence
+ * Copyright (C) 2026 goodix-fp-linux-dev contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#define FP_COMPONENT "goodix53x5"
+
+#include "drivers_api.h"
+#include "driver-private.h"
+#include "device/persistence.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <glib/gstdio.h>
+
+#define GOODIX_MILAN_STATE_DIR "/var/lib/fprint"
+#define GOODIX_MILAN_STATE_PREFIX "goodix53x5-preprocess-"
+#define GOODIX_MILAN_STATE_VERSION 1u
+#define GOODIX_MILAN_STATE_HEADER_SIZE 64u
+#define GOODIX_MILAN_STATE_PAYLOAD_SIZE \
+  (GOODIX_MILAN_SENSOR_PIXELS * sizeof (guint16))
+#define GOODIX_MILAN_STATE_DIGEST_SIZE 32u
+#define GOODIX_MILAN_STATE_PAYLOAD_OFFSET GOODIX_MILAN_STATE_HEADER_SIZE
+#define GOODIX_MILAN_STATE_DIGEST_OFFSET \
+  (GOODIX_MILAN_STATE_PAYLOAD_OFFSET + GOODIX_MILAN_STATE_PAYLOAD_SIZE)
+#define GOODIX_MILAN_STATE_FILE_SIZE \
+  (GOODIX_MILAN_STATE_DIGEST_OFFSET + GOODIX_MILAN_STATE_DIGEST_SIZE)
+#define GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT 400u
+
+enum {
+  GOODIX_MILAN_STATE_MAGIC_OFFSET = 0,
+  GOODIX_MILAN_STATE_VERSION_OFFSET = 8,
+  GOODIX_MILAN_STATE_HEADER_SIZE_OFFSET = 12,
+  GOODIX_MILAN_STATE_SUBTYPE_OFFSET = 16,
+  GOODIX_MILAN_STATE_ROWS_OFFSET = 18,
+  GOODIX_MILAN_STATE_COLUMNS_OFFSET = 20,
+  GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET = 22,
+  GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET = 24,
+  GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET = 28,
+  GOODIX_MILAN_STATE_IDENTITY_OFFSET = 32,
+};
+
+static const guint8 goodix_milan_state_magic[8] = {
+  'G', '5', '3', 'P', '9', 'P', 'S', '\0'
+};
+static const gchar goodix_milan_identity_domain[] =
+  "goodix53x5-preprocess-v1";
+
+static void
+goodix_milan_write_u16 (guint8 *output,
+                        guint16 value)
+{
+  value = GUINT16_TO_LE (value);
+  memcpy (output, &value, sizeof (value));
+}
+
+static void
+goodix_milan_write_u32 (guint8 *output,
+                        guint32 value)
+{
+  value = GUINT32_TO_LE (value);
+  memcpy (output, &value, sizeof (value));
+}
+
+static guint16
+goodix_milan_read_u16 (const guint8 *input)
+{
+  guint16 value;
+
+  memcpy (&value, input, sizeof (value));
+  return GUINT16_FROM_LE (value);
+}
+
+static guint32
+goodix_milan_read_u32 (const guint8 *input)
+{
+  guint32 value;
+
+  memcpy (&value, input, sizeof (value));
+  return GUINT32_FROM_LE (value);
+}
+
+static void
+goodix_milan_sha256 (const guint8 *data,
+                     gsize         size,
+                     guint8        digest[GOODIX_MILAN_STATE_DIGEST_SIZE])
+{
+  g_autoptr(GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  gsize digest_size = GOODIX_MILAN_STATE_DIGEST_SIZE;
+
+  g_checksum_update (checksum, data, size);
+  g_checksum_get_digest (checksum, digest, &digest_size);
+}
+
+static gchar *
+goodix_milan_state_path (const guint8 identity[GOODIX_MILAN_STATE_DIGEST_SIZE])
+{
+  static const gchar hex[] = "0123456789abcdef";
+  gchar encoded[GOODIX_MILAN_STATE_DIGEST_SIZE * 2 + 1];
+
+  for (gsize i = 0; i < GOODIX_MILAN_STATE_DIGEST_SIZE; i++)
+    {
+      encoded[i * 2] = hex[identity[i] >> 4];
+      encoded[i * 2 + 1] = hex[identity[i] & 0x0f];
+    }
+  encoded[sizeof (encoded) - 1] = '\0';
+  return g_strdup_printf (GOODIX_MILAN_STATE_DIR "/" GOODIX_MILAN_STATE_PREFIX
+                          "%s.bin", encoded);
+}
+
+static gboolean
+goodix_milan_state_directory_secure (GError **error)
+{
+  GStatBuf stat_buffer;
+
+  if (g_lstat (GOODIX_MILAN_STATE_DIR, &stat_buffer) != 0)
+    {
+      int saved_errno = errno;
+
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved_errno),
+                   "Failed to inspect %s: %s", GOODIX_MILAN_STATE_DIR,
+                   g_strerror (saved_errno));
+      return FALSE;
+    }
+  if (!S_ISDIR (stat_buffer.st_mode) || stat_buffer.st_uid != geteuid () ||
+      (stat_buffer.st_mode & (S_IWGRP | S_IWOTH)) != 0)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_ACCES,
+                   "Milan state directory %s has unsafe ownership or permissions",
+                   GOODIX_MILAN_STATE_DIR);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+goodix_milan_state_read (const gchar *path,
+                         guint8     **contents,
+                         GError     **error)
+{
+  GStatBuf stat_buffer;
+  g_autofree guint8 *buffer = NULL;
+  gsize offset = 0;
+  int descriptor;
+
+  descriptor = g_open (path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0);
+  if (descriptor < 0)
+    {
+      int saved_errno = errno;
+
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved_errno),
+                   "Failed to open %s: %s", path, g_strerror (saved_errno));
+      return FALSE;
+    }
+  if (fstat (descriptor, &stat_buffer) != 0 ||
+      !S_ISREG (stat_buffer.st_mode) || stat_buffer.st_uid != geteuid () ||
+      (stat_buffer.st_mode & (S_IWGRP | S_IWOTH)) != 0 ||
+      stat_buffer.st_size != GOODIX_MILAN_STATE_FILE_SIZE)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                   "Milan preprocessing state %s has invalid size, ownership, or permissions",
+                   path);
+      close (descriptor);
+      return FALSE;
+    }
+
+  buffer = g_malloc (GOODIX_MILAN_STATE_FILE_SIZE);
+  while (offset < GOODIX_MILAN_STATE_FILE_SIZE)
+    {
+      ssize_t bytes_read = read (descriptor, buffer + offset,
+                                 GOODIX_MILAN_STATE_FILE_SIZE - offset);
+
+      if (bytes_read < 0 && errno == EINTR)
+        continue;
+      if (bytes_read <= 0)
+        {
+          int saved_errno = bytes_read < 0 ? errno : EIO;
+
+          g_set_error (error, G_FILE_ERROR,
+                       g_file_error_from_errno (saved_errno),
+                       "Failed to read %s: %s", path,
+                       g_strerror (saved_errno));
+          close (descriptor);
+          return FALSE;
+        }
+      offset += (gsize) bytes_read;
+    }
+  close (descriptor);
+  *contents = g_steal_pointer (&buffer);
+  return TRUE;
+}
+
+static gboolean
+goodix_milan_state_valid (
+  const guint8 *contents,
+  gsize         size,
+  const guint8  identity[GOODIX_MILAN_STATE_DIGEST_SIZE],
+  guint16       subtype)
+{
+  guint8 digest[GOODIX_MILAN_STATE_DIGEST_SIZE];
+
+  if (size != GOODIX_MILAN_STATE_FILE_SIZE ||
+      memcmp (contents + GOODIX_MILAN_STATE_MAGIC_OFFSET,
+              goodix_milan_state_magic,
+              sizeof (goodix_milan_state_magic)) != 0 ||
+      goodix_milan_read_u32 (
+        contents + GOODIX_MILAN_STATE_VERSION_OFFSET) !=
+      GOODIX_MILAN_STATE_VERSION ||
+      goodix_milan_read_u32 (
+        contents + GOODIX_MILAN_STATE_HEADER_SIZE_OFFSET) !=
+      GOODIX_MILAN_STATE_HEADER_SIZE ||
+      goodix_milan_read_u16 (
+        contents + GOODIX_MILAN_STATE_SUBTYPE_OFFSET) != subtype ||
+      goodix_milan_read_u16 (contents + GOODIX_MILAN_STATE_ROWS_OFFSET) !=
+      GOODIX_MILAN_SENSOR_ROWS ||
+      goodix_milan_read_u16 (contents + GOODIX_MILAN_STATE_COLUMNS_OFFSET) !=
+      GOODIX_MILAN_SENSOR_COLUMNS ||
+      goodix_milan_read_u16 (
+        contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET) != 1 ||
+      goodix_milan_read_u32 (
+        contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET) >
+      GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT ||
+      goodix_milan_read_u32 (
+        contents + GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET) !=
+      GOODIX_MILAN_STATE_PAYLOAD_SIZE ||
+      memcmp (contents + GOODIX_MILAN_STATE_IDENTITY_OFFSET, identity,
+              GOODIX_MILAN_STATE_DIGEST_SIZE) != 0)
+    return FALSE;
+
+  goodix_milan_sha256 (contents, GOODIX_MILAN_STATE_DIGEST_OFFSET, digest);
+  return memcmp (contents + GOODIX_MILAN_STATE_DIGEST_OFFSET, digest,
+                 sizeof (digest)) == 0;
+}
+
+void
+goodix_milan_persistence_prepare (FpDevice *dev)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  g_autoptr(GChecksum) checksum = NULL;
+  guint8 encoded[10];
+  gsize digest_size = sizeof (self->milan_persistence_identity);
+
+  goodix_milan_persistence_clear (dev);
+  if (!self->otp_data || self->otp_len == 0 || self->otp_len > G_MAXUINT32)
+    {
+      fp_warn ("Cannot key Milan preprocessing state without verified OTP");
+      return;
+    }
+
+  goodix_milan_write_u32 (encoded, self->chip_id);
+  goodix_milan_write_u16 (encoded + 4, self->milan_sensor_subtype);
+  goodix_milan_write_u32 (encoded + 6, (guint32) self->otp_len);
+  checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  g_checksum_update (checksum, (const guint8 *) goodix_milan_identity_domain,
+                     sizeof (goodix_milan_identity_domain) - 1);
+  g_checksum_update (checksum, encoded, sizeof (encoded));
+  g_checksum_update (checksum, self->otp_data, self->otp_len);
+  g_checksum_get_digest (checksum, self->milan_persistence_identity,
+                         &digest_size);
+  self->milan_persistence_identity_valid = TRUE;
+}
+
+void
+goodix_milan_persistence_clear (FpDevice *dev)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  memset (self->milan_persistence_identity, 0,
+          sizeof (self->milan_persistence_identity));
+  self->milan_persistence_identity_valid = FALSE;
+}
+
+void
+goodix_milan_persistence_restore (FpDevice              *dev,
+                                  GoodixMilanGeneration *generation)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  g_autofree gchar *path = NULL;
+  g_autofree guint8 *contents = NULL;
+
+  g_autoptr(GError) error = NULL;
+
+  g_return_if_fail (generation != NULL);
+  if (!self->milan_persistence_identity_valid)
+    return;
+
+  if (!goodix_milan_state_directory_secure (&error))
+    {
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        fp_warn ("Cannot use Milan preprocessing state directory: %s",
+                 error->message);
+      return;
+    }
+  path = goodix_milan_state_path (self->milan_persistence_identity);
+  if (!goodix_milan_state_read (path, &contents, &error))
+    {
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        fp_warn ("Failed to read Milan preprocessing state %s: %s",
+                 path, error->message);
+      return;
+    }
+  if (!goodix_milan_state_valid (contents, GOODIX_MILAN_STATE_FILE_SIZE,
+                                 self->milan_persistence_identity,
+                                 self->milan_sensor_subtype))
+    {
+      fp_warn ("Ignoring invalid Milan preprocessing state %s", path);
+      return;
+    }
+
+  generation->state.sample_count = goodix_milan_read_u32 (
+    contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET);
+  for (gsize i = 0; i < GOODIX_MILAN_SENSOR_PIXELS; i++)
+    generation->state.calibration_map[i] = goodix_milan_read_u16 (
+      contents + GOODIX_MILAN_STATE_PAYLOAD_OFFSET +
+      i * sizeof (guint16));
+  fp_info ("Restored Milan preprocessing state with %u samples",
+           generation->state.sample_count);
+}
+
+void
+goodix_milan_persistence_save (FpDevice                    *dev,
+                               const GoodixMilanGeneration *generation)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  g_autofree guint8 *contents = NULL;
+  g_autofree gchar *path = NULL;
+
+  g_autoptr(GError) error = NULL;
+
+  if (!generation || !generation->admitted ||
+      !self->milan_persistence_identity_valid)
+    return;
+  if (generation->state.sample_count > GOODIX_MILAN_STATE_MAX_SAMPLE_COUNT)
+    {
+      fp_warn ("Refusing to save invalid Milan sample count %u",
+               generation->state.sample_count);
+      return;
+    }
+
+  contents = g_malloc0 (GOODIX_MILAN_STATE_FILE_SIZE);
+  memcpy (contents + GOODIX_MILAN_STATE_MAGIC_OFFSET,
+          goodix_milan_state_magic, sizeof (goodix_milan_state_magic));
+  goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_VERSION_OFFSET,
+                          GOODIX_MILAN_STATE_VERSION);
+  goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_HEADER_SIZE_OFFSET,
+                          GOODIX_MILAN_STATE_HEADER_SIZE);
+  goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_SUBTYPE_OFFSET,
+                          self->milan_sensor_subtype);
+  goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_ROWS_OFFSET,
+                          GOODIX_MILAN_SENSOR_ROWS);
+  goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_COLUMNS_OFFSET,
+                          GOODIX_MILAN_SENSOR_COLUMNS);
+  goodix_milan_write_u16 (contents + GOODIX_MILAN_STATE_SAMPLE_FORMAT_OFFSET,
+                          1);
+  goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET,
+                          generation->state.sample_count);
+  goodix_milan_write_u32 (contents + GOODIX_MILAN_STATE_PAYLOAD_SIZE_OFFSET,
+                          GOODIX_MILAN_STATE_PAYLOAD_SIZE);
+  memcpy (contents + GOODIX_MILAN_STATE_IDENTITY_OFFSET,
+          self->milan_persistence_identity,
+          sizeof (self->milan_persistence_identity));
+  for (gsize i = 0; i < GOODIX_MILAN_SENSOR_PIXELS; i++)
+    goodix_milan_write_u16 (
+      contents + GOODIX_MILAN_STATE_PAYLOAD_OFFSET + i * sizeof (guint16),
+      generation->state.calibration_map[i]);
+  goodix_milan_sha256 (contents, GOODIX_MILAN_STATE_DIGEST_OFFSET,
+                       contents + GOODIX_MILAN_STATE_DIGEST_OFFSET);
+
+  if (g_mkdir_with_parents (GOODIX_MILAN_STATE_DIR, 0700) != 0)
+    {
+      fp_warn ("Failed to create Milan state directory %s: %s",
+               GOODIX_MILAN_STATE_DIR, g_strerror (errno));
+      return;
+    }
+  if (!goodix_milan_state_directory_secure (&error))
+    {
+      fp_warn ("Cannot use Milan preprocessing state directory: %s",
+               error->message);
+      return;
+    }
+  path = goodix_milan_state_path (self->milan_persistence_identity);
+  if (!g_file_set_contents_full (
+        path, (const gchar *) contents, GOODIX_MILAN_STATE_FILE_SIZE,
+        G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE,
+        0600, &error))
+    {
+      fp_warn ("Failed to save Milan preprocessing state %s: %s",
+               path, error->message);
+      return;
+    }
+  fp_info ("Saved Milan preprocessing state with %u samples",
+           generation->state.sample_count);
+}

--- a/drivers/goodix53x5/device/persistence.h
+++ b/drivers/goodix53x5/device/persistence.h
@@ -16,5 +16,5 @@ void goodix_milan_persistence_prepare (FpDevice *dev);
 void goodix_milan_persistence_clear (FpDevice *dev);
 void goodix_milan_persistence_restore (FpDevice              *dev,
                                        GoodixMilanGeneration *generation);
-void goodix_milan_persistence_save (FpDevice                    *dev,
-                                    const GoodixMilanGeneration *generation);
+void goodix_milan_persistence_save (FpDevice                         *dev,
+                                    const GoodixMilanPreprocessState *state);

--- a/drivers/goodix53x5/device/persistence.h
+++ b/drivers/goodix53x5/device/persistence.h
@@ -1,0 +1,20 @@
+/*
+ * Goodix 53x5 driver for libfprint - Milan preprocessing persistence
+ * Copyright (C) 2026 goodix-fp-linux-dev contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "device/base.h"
+
+void goodix_milan_persistence_prepare (FpDevice *dev);
+void goodix_milan_persistence_clear (FpDevice *dev);
+void goodix_milan_persistence_restore (FpDevice              *dev,
+                                       GoodixMilanGeneration *generation);
+void goodix_milan_persistence_save (FpDevice                    *dev,
+                                    const GoodixMilanGeneration *generation);

--- a/drivers/goodix53x5/device/session.c
+++ b/drivers/goodix53x5/device/session.c
@@ -25,6 +25,7 @@
 #include "device/commands.h"
 #include "device/calibration.h"
 #include "device/base.h"
+#include "device/persistence.h"
 #include "device/scan.h"
 #include "device/session.h"
 
@@ -353,6 +354,7 @@ goodix_open_ssm_handler (FpiSsm   *ssm,
             return;
           }
 
+        goodix_milan_persistence_prepare (dev);
         goodix_device_parse_otp (pl, pl_len, &self->calib);
         if (!goodix_load_psk (self, &error))
           {
@@ -689,6 +691,7 @@ goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
     {
       self->open_ref_powered = FALSE;
       goodix_milan_generation_invalidate (&self->milan_generation);
+      goodix_milan_persistence_clear (dev);
       OPENSSL_cleanse (self->psk, sizeof (self->psk));
       OPENSSL_cleanse (self->gtls.psk, sizeof (self->gtls.psk));
       self->psk_imported = FALSE;

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -120,6 +120,9 @@ struct _FpiDeviceGoodix53x5
   GoodixMilanGeneration *milan_generation;
   guint64                last_milan_generation_id;
 
+  /* Action-owned state to commit after post-scan hardware cleanup. */
+  GoodixMilanPreprocessState *pending_persistence_state;
+
   /* TRUE while verifying a PSK write during open. */
   gboolean psk_write_verify_pending;
 

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -112,6 +112,10 @@ struct _FpiDeviceGoodix53x5
   guint32 chip_id;
   guint16 milan_sensor_subtype;
 
+  /* Device-keyed identity for the persisted preprocessing subset. */
+  guint8   milan_persistence_identity[32];
+  gboolean milan_persistence_identity_valid;
+
   /* One admitted TX-on setup generation per valid hardware session. */
   GoodixMilanGeneration *milan_generation;
   guint64                last_milan_generation_id;

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -65,6 +65,7 @@ goodix_close (FpDevice *dev)
   g_clear_pointer (&self->captured_image, g_free);
 #endif
   g_clear_pointer (&self->captured_raw_image, g_free);
+  g_clear_pointer (&self->pending_persistence_state, g_free);
   goodix_milan_generation_invalidate (&self->milan_generation);
   g_clear_pointer (&self->enroll_transaction,
                    goodix_milan_enrollment_transaction_free);

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -24,6 +24,7 @@
 #include "device/session.h"
 #include "device/enroll.h"
 #include "device/auth.h"
+#include "device/persistence.h"
 
 #include <string.h>
 #include <openssl/crypto.h>
@@ -67,6 +68,7 @@ goodix_close (FpDevice *dev)
   goodix_milan_generation_invalidate (&self->milan_generation);
   g_clear_pointer (&self->enroll_transaction,
                    goodix_milan_enrollment_transaction_free);
+  goodix_milan_persistence_clear (dev);
   g_clear_error (&self->pending_enroll_error);
   OPENSSL_cleanse (self->psk, sizeof (self->psk));
   OPENSSL_cleanse (self->gtls.psk, sizeof (self->gtls.psk));

--- a/drivers/goodix53x5/meson.build
+++ b/drivers/goodix53x5/meson.build
@@ -21,6 +21,7 @@ goodix53x5_sources = files(
     'milan/feature/materialization.c',
     'milan/feature/record.c',
     'device/image.c',
+    'device/persistence.c',
     'milan/match/admission.c',
     'milan/match/candidate.c',
     'milan/match/correspondence.c',

--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -80,6 +80,55 @@ static int milan_profile9_post_render (
   GoodixMilanPreprocessPurpose purpose,
   uint32_t                     calibration_ready);
 
+static void
+profile9_initialize_gain_state (GoodixMilanPreprocessState *state)
+{
+  const size_t count = GOODIX_MILAN_SENSOR_PIXELS;
+  uint32_t sum = 0;
+  uint32_t mean;
+
+  if (state->sample_count == 0)
+    {
+      for (size_t i = 0; i < count; i++)
+        {
+          state->calibration_map[i] = 0;
+          state->auxiliary_gain_map[i] = MILAN_FIXED_ONE;
+          state->secondary_auxiliary_gain_map[i] = MILAN_FIXED_ONE;
+          state->application_gain_map[i] = MILAN_FIXED_ONE;
+        }
+      state->auxiliary_sample_count = 0;
+      state->application_gain_initialized = 1;
+      return;
+    }
+
+  if (state->sample_count <= 3)
+    {
+      for (size_t i = 0; i < count; i++)
+        state->application_gain_map[i] = MILAN_FIXED_ONE;
+      return;
+    }
+
+  if (state->application_gain_initialized)
+    return;
+
+  for (size_t i = 0; i < count; i++)
+    sum += state->calibration_map[i];
+  mean = (sum + count / 2) / count;
+  if (mean == 0)
+    {
+      state->sample_count = 0;
+      state->application_gain_initialized = 1;
+      return;
+    }
+
+  for (size_t i = 0; i < count; i++)
+    state->application_gain_map[i] =
+      (uint16_t) (((uint32_t) state->calibration_map[i] * MILAN_FIXED_ONE +
+                   mean / 2) /
+                  mean);
+  state->application_gain_initialized = 1;
+}
+
 void
 goodix_milan_preprocess_reset (GoodixMilanPreprocessState *state)
 {
@@ -198,15 +247,11 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
         GOODIX_MILAN_SENSOR_COLUMNS, contrast_mask, &admitted_pixels) != 0)
     goto out;
 
-  /* Native refills retained low-count application gain before processing. */
-  if (state->sample_count > 0 && state->sample_count <= 3)
-    for (size_t i = 0; i < count; i++)
-      state->application_gain_map[i] = MILAN_FIXED_ONE;
-
+  profile9_initialize_gain_state (state);
   milan_profile9_make_reciprocal_plane (
     state->application_gain_map, count, reciprocal_plane);
   goodix_milan_profile9_update_gain_ready (
-    state->sample_count, state->stable_count,
+    state->auxiliary_sample_count, state->sample_count,
     &profile_state->calibration_ready);
 
   if (admitted_pixels * 10 > count * 9)

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -273,6 +273,17 @@ goodix_match_update_extraction_classification (
 }
 
 static void
+goodix_match_snapshot_extraction_classification (
+  GoodixMilanPreprocessState *state)
+{
+  memcpy (state->extraction_persistence.retained_class_planes,
+          state->extraction_classification.retained_class_planes,
+          sizeof (state->extraction_persistence.retained_class_planes));
+  state->extraction_persistence.retained_count =
+    state->extraction_classification.retained_count;
+}
+
+static void
 goodix_match_decode_entry_classes (const guint8 *image,
                                     gint32       *packed,
                                     gint32       *low_class,
@@ -378,6 +389,9 @@ goodix_match_extract_native_result (
       !preprocess_state->primary_contrast_valid || !info)
     return GOODIX_MILAN_EXTRACTION_INVALID;
 
+  if (sensor_subtype == 12)
+    goodix_match_snapshot_extraction_classification (preprocess_state);
+
   return goodix_match_extract_planes (
     image, preprocess_state->primary_contrast,
     &preprocess_state->extraction_classification,
@@ -410,6 +424,9 @@ goodix_match_extract_native_result_debug (
   if (!image || !preprocess_state || !raw_frame ||
       !preprocess_state->primary_contrast_valid || !info)
     return GOODIX_MILAN_EXTRACTION_INVALID;
+
+  if (sensor_subtype == 12)
+    goodix_match_snapshot_extraction_classification (preprocess_state);
 
   return goodix_match_extract_planes (
     image, preprocess_state->primary_contrast,

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -269,6 +269,13 @@ typedef struct
 
 typedef struct
 {
+  uint8_t  retained_class_planes[3]
+                                [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
+  uint32_t retained_count;
+} GoodixMilanExtractionPersistenceState;
+
+typedef struct
+{
   uint8_t primary_histogram_state;
   uint8_t prior_selected_plane;
   uint8_t promoted_secondary_histogram_state;
@@ -302,6 +309,9 @@ typedef struct
    * Auxiliary bytes describe the latest completed preprocessing call and feed
    * extraction/matcher policy. */
   GoodixMilanExtractionClassificationState extraction_classification;
+  /* Native serializes the retained ring before extraction appends the current
+   * sample, so persistence needs the corresponding entry snapshot. */
+  GoodixMilanExtractionPersistenceState extraction_persistence;
   GoodixMilanExtractionAuxiliaryState extraction_auxiliary;
   uint8_t application_gain_initialized;
 } GoodixMilanPreprocessState;
@@ -418,15 +428,25 @@ _Static_assert (offsetof (GoodixMilanExtractionClassificationState,
 _Static_assert (offsetof (GoodixMilanExtractionClassificationState,
                           prior_merged_high_class) == 27468,
                 "Milan extraction prior high class moved");
+_Static_assert (sizeof (GoodixMilanExtractionPersistenceState) == 27460,
+                "Milan extraction persistence state size changed");
+_Static_assert (_Alignof (GoodixMilanExtractionPersistenceState) == 4,
+                "Milan extraction persistence state alignment changed");
+_Static_assert (offsetof (GoodixMilanExtractionPersistenceState,
+                          retained_count) == 27456,
+                "Milan persisted extraction retained count moved");
+_Static_assert (offsetof (GoodixMilanPreprocessState,
+                          extraction_persistence) == 174868,
+                "Milan extraction persistence state moved");
 _Static_assert (sizeof (GoodixMilanExtractionAuxiliaryState) == 3,
                 "Milan extraction auxiliary state size changed");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
-                          extraction_auxiliary) == 174868,
+                          extraction_auxiliary) == 202328,
                 "Milan extraction auxiliary state moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
-                          application_gain_initialized) == 174871,
+                          application_gain_initialized) == 202331,
                 "Milan application gain initialization state moved");
-_Static_assert (sizeof (GoodixMilanPreprocessState) == 174872,
+_Static_assert (sizeof (GoodixMilanPreprocessState) == 202332,
                 "Milan preprocess state size changed");
 _Static_assert (_Alignof (GoodixMilanPreprocessState) == 4,
                 "Milan preprocess state alignment changed");

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -303,6 +303,7 @@ typedef struct
    * extraction/matcher policy. */
   GoodixMilanExtractionClassificationState extraction_classification;
   GoodixMilanExtractionAuxiliaryState extraction_auxiliary;
+  uint8_t application_gain_initialized;
 } GoodixMilanPreprocessState;
 
 _Static_assert (sizeof (GoodixMilanProfile9ClassCounts) == 12,
@@ -422,6 +423,9 @@ _Static_assert (sizeof (GoodixMilanExtractionAuxiliaryState) == 3,
 _Static_assert (offsetof (GoodixMilanPreprocessState,
                           extraction_auxiliary) == 174868,
                 "Milan extraction auxiliary state moved");
+_Static_assert (offsetof (GoodixMilanPreprocessState,
+                          application_gain_initialized) == 174871,
+                "Milan application gain initialization state moved");
 _Static_assert (sizeof (GoodixMilanPreprocessState) == 174872,
                 "Milan preprocess state size changed");
 _Static_assert (_Alignof (GoodixMilanPreprocessState) == 4,


### PR DESCRIPTION
## Summary

- persist the sensor-specific calibration and classifier history that Windows keeps across device opens
- save the exact preprocessing snapshot that produced an accepted enrollment or learned template update, even if hardware refresh completes before action cleanup
- require owner-only state storage and repair an existing broadly readable state file to mode `0600`

## Problem

This is not fingerprint-template persistence. It is the preprocessing state used to turn raw sensor readings into a stable fingerprint image:

- a per-pixel calibration/gain map and its sample count
- history of pixels repeatedly classified as noisy or damaged
- a compact reference image and per-pixel support ages
- the recent extraction-classification ring

Windows saves this state after enrollment completion or a successful template update and reloads it on the next engine attachment. Linux discarded it whenever libfprint closed the device, so the next open processed the same sensor as though it had no calibration history. Device reopening includes normal `fprintd` enrollment/verification sessions, lock-screen use, service restart, suspend recovery, and release/reclaim, not only USB unplugging.

## Observable difference

With a producer-valid saved state loaded before an enrollment image:

- Windows: status/quality/coverage `0/94/100`, 38 class-1 pixels
- old Linux fresh path: `0/95/100`, 899 class-1 pixels
- this layer: `0/94/100`, 38 class-1 pixels

Invalidating the saved state makes both sides take the same fresh fallback path at `0/95/100` with 899 class-1 pixels. This isolates the defect to missing preprocessing persistence rather than the raw image or fingerprint template.

## Lifecycle and security

The final enrollment/auth result now owns a copy of the runtime preprocessing state until post-scan cleanup commits it. A finger-up base refresh may replace the active generation, but it cannot replace the state being saved. This matches Windows, where refresh only latches a marker and cannot reload the engine workspace before commit without another sample callback.

The fixed-size device-bound file is checksummed and fully validated before use. Restore requires an owner-only `0700` directory and exact `0600` regular file opened without following symlinks. Save atomically replaces the file, securely reopens it, forces and verifies `0600`, and syncs it. Missing, corrupt, mismatched, inaccessible, or insecure state remains warning-only fallback.

## Required stack

This is the bottom layer of required stack #80 and must not be merged alone:

- #77 restores native retained-state metadata selection
- #78 feeds the native enhanced/validity matrices into the persisted extraction ring
- #79 preserves process-lifetime state during an in-place base refresh

Together the stack closes the bounded persisted preprocessing/raw-to-probe path. It does not claim whole-driver native parity.

## Validation

- source-sealed production persistence harness under ASan/UBSan: codec, save/restore, atomic replacement, `0644` to `0600` repair, corruption, size, identity, symlink, insecure path, ring, and reference/support controls all passed
- independent action-ownership and security reviews: clean
- debug-disabled production build: 127/127 actions
- existing Milan synthetic, state, runtime, and `fpi-device` suites: 4/4 passed
- strict premerge dataset: 450/450, zero differences
- strict readiness dataset: 643/643, zero differences
- final post-campaign dead-code, ABI, bounds, security, and performance review: clean
- no tests added

The strict datasets provide broad identify/verify non-regression evidence. The focused sanitizer harness and lifecycle trace prove persistence behavior; they do not claim physical-device integration coverage.

Durable native contracts are documented separately on `milan-dev` at `d2eb5a20`. 