### PR TITLE
Match Milan retained-state mode promotion

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -1736,8 +1736,12 @@ goodix_milan_profile9_build_broken_mask (
         state->profile9_history_reference, history_qualified, rows, columns);
       if (secondary_histogram_state == 0 && secondary_count_state == 0 &&
           !history_initialized)
-        secondary_histogram_state = milan_profile9_histogram_state (
-          state->calibration_map, history_qualified, count, 0);
+        {
+          secondary_histogram_state = milan_profile9_histogram_state (
+            state->calibration_map, history_qualified, count, 0);
+          secondary_count_state = milan_profile9_secondary_count_state (
+            state->calibration_map, history_qualified, rows, columns);
+        }
       milan_profile9_temporal_class3 (
         state, history_qualified, rows, columns, broken_mask);
     }
@@ -1753,8 +1757,6 @@ goodix_milan_profile9_build_broken_mask (
 
   directional_state = milan_profile9_directional_state (
     normalized_live, valid, rows, columns, active_count);
-  if (primary_histogram_state == 2 || directional_state == 2)
-    secondary_histogram_state++;
 
   size_t class1_count = 0;
   size_t class2_count = 0;
@@ -1777,8 +1779,6 @@ goodix_milan_profile9_build_broken_mask (
   state->extraction_auxiliary.primary_histogram_state =
     primary_histogram_state;
   state->extraction_auxiliary.prior_selected_plane = prior_selected_plane;
-  state->extraction_auxiliary.promoted_secondary_histogram_state =
-    secondary_histogram_state;
   *mode = 0;
   *apply_mask = 0;
   if (class3_count * 100 > mask_count * 15)
@@ -1816,6 +1816,17 @@ goodix_milan_profile9_build_broken_mask (
       *mode = 9;
       result = GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION;
     }
+  if (*mode < 8 && directional_state == 2)
+    *mode = 8;
+  else if (*mode < 6 &&
+           (directional_state == 1 || secondary_histogram_state >= 1))
+    *mode = 6;
+  if (primary_histogram_state == 2 || directional_state == 2)
+    secondary_histogram_state++;
+  if (*mode == 0 && secondary_count_state > 0)
+    *mode = 5;
+  state->extraction_auxiliary.promoted_secondary_histogram_state =
+    secondary_histogram_state;
 
 out:
   free (class2_scores);


### PR DESCRIPTION
## Summary

- rerun both native secondary classifiers against the saved calibration map when retained-reference classification produces no result
- apply the native state-based metadata promotion order
- make the first persisted-state enrollment image byte-exact with the Windows driver

## Native contract

PR #76 restores the preprocessing history Windows keeps across device opens. With that history restored, current and native produce the same class plane: 38 class-1 pixels instead of the fresh-state 899.

The remaining mismatch was metadata mode selection. When retained-reference histogram and count classification both return zero, Windows retries both classifiers against the saved calibration map. Current retried only the histogram. Windows then uses the resulting count state to promote base mode 0 to mode 5; current omitted that promotion order.

This layer makes the complete processed image byte-exact with native. The invalid-state control remains byte-exact on the fresh fallback path at `0/95/100`. It depends on #76 because this target exists only after persisted history is restored.

## Validation

- persisted target and invalid-state control: byte-exact with the approved DLL
- debug-disabled production build: 127/127 actions
- existing Milan synthetic, state, runtime, and `fpi-device` suites: 4/4 passed
- strict premerge dataset: 450/450, zero differences
- strict readiness dataset: 643/643, zero differences
- final correctness, dead-code, ABI, bounds, security, and performance reviews: clean
- no tests added

Durable native contracts are documented separately on `milan-dev` at `d2eb5a20`. 