### PR TITLE
Match Milan extraction ring inputs

### DIFF
--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -145,7 +145,7 @@ static gint32
 goodix_match_update_extraction_classification (
   GoodixMilanExtractionClassificationState *state,
   const guint8 classification_source[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
-  const guint8 cropped_primary_contrast[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
+  const guint8 classification_validity[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
   const guint8 auxiliary[3],
   gint         coverage,
   gint32       entry_low_class,
@@ -178,7 +178,7 @@ goodix_match_update_extraction_classification (
 
   for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
     component_mask[i] = classification_source[i] >= 0x80 &&
-                         cropped_primary_contrast[i] != 0 ? UINT8_MAX : 0;
+                         classification_validity[i] != 0 ? UINT8_MAX : 0;
   goodix_match_retain_class_components (
     component_mask, 71, 500, labels, queue);
   for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
@@ -460,7 +460,6 @@ goodix_match_extract_planes (const guint8  *image,
   g_autofree GoodixMilanAntifakeBlob *diagnostic_antifake = NULL;
 #endif
   guint8 *cropped = NULL;
-  guint8 *cropped_primary_contrast = NULL;
   guint8 *high = NULL;
   guint8 *low = NULL;
   guint8 *feature_mask = NULL;
@@ -498,8 +497,6 @@ goodix_match_extract_planes (const guint8  *image,
   auxiliary[2] = auxiliary_state->promoted_secondary_histogram_state;
   info = g_new0 (GoodixMatchInfo, 1);
   cropped = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
-  cropped_primary_contrast = g_malloc (
-    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   high = g_malloc0 (286);
   low = g_malloc0 (286);
   feature_mask = g_malloc0 (52 * 44);
@@ -520,11 +517,6 @@ goodix_match_extract_planes (const guint8  *image,
       memcpy (cropped +
                 row * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
               image + row * GOODIX_MILAN_SENSOR_COLUMNS + 2,
-              GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS);
-      memcpy (cropped_primary_contrast +
-                row * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
-              primary_contrast_plane +
-                row * GOODIX_MILAN_SENSOR_COLUMNS + 2,
               GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS);
     }
   if (sensor_subtype == 12)
@@ -653,7 +645,6 @@ out:
   g_free (feature_mask);
   g_free (low);
   g_free (high);
-  g_free (cropped_primary_contrast);
   g_free (cropped);
   if (!info->template)
     g_clear_pointer (&info, g_free);

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -550,7 +550,7 @@ goodix_match_extract_planes (const guint8  *image,
       /* Native commits history before record extraction, anti-fake, or packing
        * failures. */
       fields.optional_c7 = goodix_match_update_extraction_classification (
-        classification_state, cropped, cropped_primary_contrast, auxiliary,
+        classification_state, enhanced, validity_mask, auxiliary,
         coverage, entry_low_class, entry_high_class);
     }
   if (goodix_milan_feature_extract_records_mode_masked (


### PR DESCRIPTION
## Summary

- update the retained extraction ring from the enhanced image and validity mask used by the Windows driver
- preserve existing classifier arithmetic and update timing
- remove the obsolete cropped contrast buffer after its last consumer is replaced
- save the same ring after enrollment and restore it on the next device open

## Native contract

Windows updates its three-frame extraction history from the enhanced fingerprint image and dense validity mask. Current used the earlier raw crop and primary-contrast crop.

The immediate probe happened to be unchanged, hiding the defect during ordinary comparisons. Across a natural 12-stage enrollment, the wrong inputs changed 3,417 retained-ring bytes that #76 would restore on reopening.

This layer changes those two inputs. Corrected entry rings and appended sources match native through all 12 stages, and completed enrollment saves/restores the corrected pre-append ring. The previous 9,152-byte primary-contrast crop then had no remaining consumer and is removed. An adjacent coverage-65 control remains byte-exact.

This layer depends on #76 and #77 for the persisted lifecycle and authoritative processed image.

## Validation

- 12-stage exported enrollment chronology and persisted ring restore: exact
- adjacent coverage-65 control: exact
- dead-buffer use audit: no remaining consumer
- debug-disabled production build: 127/127 actions
- existing Milan synthetic, state, runtime, and `fpi-device` suites: 4/4 passed
- strict premerge dataset: 450/450, zero differences
- strict readiness dataset: 643/643, zero differences
- final correctness, dead-code, ABI, bounds, security, and performance reviews: clean
- no tests added

Durable native contracts are documented separately on `milan-dev` at `d2eb5a20`. 