### PR TITLE
Preserve Milan state across base refresh

### DIFF
--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -198,6 +198,50 @@ goodix_milan_generation_reset_preprocess (GoodixMilanGeneration *generation)
   memset (&generation->profile_state, 0, sizeof (generation->profile_state));
 }
 
+static void
+goodix_milan_generation_transfer_process_state (
+  GoodixMilanGeneration       *destination,
+  const GoodixMilanGeneration *source)
+{
+  destination->state.stable_count = source->state.stable_count;
+  destination->state.auxiliary_sample_count =
+    source->state.auxiliary_sample_count;
+  destination->state.application_gain_initialized =
+    source->state.application_gain_initialized;
+  memcpy (destination->state.coarse_reference, source->state.coarse_reference,
+          sizeof (destination->state.coarse_reference));
+  memcpy (destination->state.auxiliary_gain_map,
+          source->state.auxiliary_gain_map,
+          sizeof (destination->state.auxiliary_gain_map));
+  memcpy (destination->state.secondary_auxiliary_gain_map,
+          source->state.secondary_auxiliary_gain_map,
+          sizeof (destination->state.secondary_auxiliary_gain_map));
+  memcpy (destination->state.application_gain_map,
+          source->state.application_gain_map,
+          sizeof (destination->state.application_gain_map));
+  destination->state.profile9_history_count =
+    source->state.profile9_history_count;
+  destination->state.profile9_history_update_count =
+    source->state.profile9_history_update_count;
+  destination->state.profile9_history_mask_threshold =
+    source->state.profile9_history_mask_threshold;
+  destination->state.profile9_history_mask_average =
+    source->state.profile9_history_mask_average;
+  memcpy (destination->state.profile9_history_reference,
+          source->state.profile9_history_reference,
+          sizeof (destination->state.profile9_history_reference));
+  memcpy (destination->state.profile9_reference_age,
+          source->state.profile9_reference_age,
+          sizeof (destination->state.profile9_reference_age));
+  memcpy (destination->state.profile9_component_age,
+          source->state.profile9_component_age,
+          sizeof (destination->state.profile9_component_age));
+  destination->state.extraction_classification =
+    source->state.extraction_classification;
+  destination->profile_state.calibration_ready =
+    source->profile_state.calibration_ready;
+}
+
 gboolean
 goodix_milan_base_attempt_publish (GoodixMilanBaseAttempt  *attempt,
                                    guint64                  generation_id,
@@ -727,6 +771,9 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
           }
 
         goodix_milan_persistence_restore (dev, generation);
+        if (data->forced_refresh && self->milan_generation)
+          goodix_milan_generation_transfer_process_state (
+            generation, self->milan_generation);
         goodix_milan_generation_invalidate (&self->milan_generation);
         self->milan_generation = generation;
         memcpy (self->profile9_fdt.base_down, data->candidate_base_down,

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -80,6 +80,7 @@ typedef struct
   gboolean                      stop_requested;
   gboolean                      cpu_done;
   gboolean                      cpu_outstanding;
+  gboolean                      refresh_deferred;
   gboolean                      cycle_active;
   gboolean                      recovering_generation;
   gboolean                      release_settled;
@@ -207,6 +208,13 @@ goodix_scan_maybe_finish_requested (GoodixScanCoordinatorData *data)
         fpi_ssm_jump_to_state (data->ssm, GOODIX_SCAN_COORD_WAIT_CPU);
       return;
     }
+  if (data->refresh_deferred)
+    {
+      data->refresh_deferred = FALSE;
+      data->dispatching = TRUE;
+      fpi_ssm_jump_to_state (data->ssm, GOODIX_SCAN_COORD_REFRESH);
+      return;
+    }
   goodix_scan_finish_requested (data);
 }
 
@@ -312,7 +320,16 @@ goodix_scan_prepare_refresh (FpiSsm                        *ssm,
 {
   data->refresh_reason = reason;
   self->profile9_fdt.base_valid = FALSE;
-  fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_REFRESH);
+  if (data->cpu_outstanding)
+    {
+      data->refresh_deferred = TRUE;
+      data->dispatching = FALSE;
+      /* The matching release was consumed; no FDT arm remains to drain. */
+      self->profile9_fdt.wait_mode = GOODIX_PROFILE9_FDT_WAIT_NONE;
+      fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_WAIT_CPU);
+    }
+  else
+    fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_REFRESH);
 }
 
 static void
@@ -652,7 +669,8 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
       break;
 
     case GOODIX_SCAN_COORD_CYCLE_SETTLED:
-      if (data->disposition == GOODIX_SCAN_DISPOSITION_AUTH_RETRY_AFTER_UP ||
+      if (data->disposition == GOODIX_SCAN_DISPOSITION_AUTH_SUCCESS ||
+          data->disposition == GOODIX_SCAN_DISPOSITION_AUTH_RETRY_AFTER_UP ||
           data->disposition == GOODIX_SCAN_DISPOSITION_ENROLL_FINAL_AFTER_UP)
         data->cleanup_drain_mode = fdt->wait_mode;
       if (data->cycle_settled)
@@ -834,7 +852,13 @@ goodix_scan_set_disposition (FpDevice             *dev,
   else
     {
       g_clear_error (&error);
-      if (!goodix_scan_disposition_waits_for_up (disposition))
+      if (data->refresh_deferred)
+        {
+          data->refresh_deferred = FALSE;
+          data->dispatching = TRUE;
+          fpi_ssm_jump_to_state (data->ssm, GOODIX_SCAN_COORD_REFRESH);
+        }
+      else if (!goodix_scan_disposition_waits_for_up (disposition))
         goodix_scan_request_stop (data, NULL);
       else if (data->release_settled && !data->dispatching &&
                !data->receive_active && !self->cmd_owner)


### PR DESCRIPTION
## Summary

- preserve attachment-local gain, classifier, and extraction history across a successful FDT/base refresh
- wait for an active sample result to commit before publishing forced refresh
- retain the existing forced-refresh, rearm, cancellation, and FDT-drain lifecycle

## Native contract

A successful Windows base refresh reloads saved calibration and initializes the new setup frame, but it does not restart the preprocessing DLL. Live gain maps, history/reference state, extraction ring, adaptive counters, and readiness therefore survive refresh.

The approved DLL calls `_InitPreProcessor_Unify` synchronously near the start of `EngineAdapterAcceptSampleData`, before preprocessing/extraction. A hardware refresh only marks a later sample; it cannot replace the workspace while the active callback is still mutating it.

Current intentionally overlaps CPU processing with finger-up receive. Before this layer, refresh could publish first, copy pre-worker state, and invalidate the generation; the completed worker then correctly refused to commit into the replacement. A continuing enrollment could therefore lose the preceding stage history.

This layer waits in the existing `WAIT_CPU` state when release requests refresh. The worker commits first, then the original forced-refresh event flow resumes and transfers the completed process state. Cancellation still finishes forced refresh, rearms DOWN, resolves the matching one-shot receive, and uses the existing drain-capable cleanup path.

After 16 ordinary enrollment frames, the old behavior differed from native in 6,377 non-metadata bytes and changed coverage from 99 to 100. With the complete stack, refreshed and no-refresh controls are byte-exact at quality/coverage `94/99`. Initial device open remains reset.

The bottom layer separately keeps final enrollment/auth persistence action-owned. This is the top of required stack #80 and must be merged with #76, #77, and #78.

## Validation

- approved-DLL setup/preprocess call ordering independently verified in Ghidra
- marker-triggered refresh and adjacent no-refresh control: byte-exact
- CPU-first/event-first, all dispositions, cancellation during CPU/refresh/rearm, false-down, recovery, and validation-failure transitions independently reviewed: clean
- debug-disabled production build: 127/127 actions
- existing Milan synthetic, state, runtime, and `fpi-device` suites: 4/4 passed
- strict premerge dataset: 450/450, zero differences
- strict readiness dataset: 643/643, zero differences
- exact-source ASan/UBSan persistence/ring/history proof: clean
- final correctness, dead-code, ABI, bounds, security, and performance review: clean
- no tests added

Durable native contracts are documented separately on `milan-dev` at `d2eb5a20`. 