### PR TITLE
Preserve Milan late-status rescue rows

### DIFF
--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -1179,6 +1179,8 @@ milan_match_prepared_probe (
           memcpy (direct_metrics + 15, direct_candidate.words + 15,
                   6 * sizeof(*direct_metrics));
         }
+      memcpy (rescue_records[feature_index], direct_metrics,
+              sizeof(rescue_records[feature_index]));
       if (enrolled->metadata.sensor_type == 12)
         {
           int status;
@@ -1202,8 +1204,6 @@ milan_match_prepared_probe (
             late_policy_context.accumulated_high_class,
             late_policy_state[1], 0, &match_flag, &candidate_flag);
         }
-      memcpy (rescue_records[feature_index], direct_metrics,
-              sizeof(rescue_records[feature_index]));
       memset (&contribution_event, 0, sizeof(contribution_event));
       int contributes = 0;
       int retained = 0;


### PR DESCRIPTION
## Summary
- publish completed Milan candidate metrics to the physical rescue row before mutable policy can continue traversal
- preserve existing contribution, selection, lifecycle, fallback, and rescue threshold behavior
- fix both observed outcomes: a retained row enabling rescue and a retained row preventing rescue at the strict weighted threshold

## Validation
- focused approved-DLL parity: 2/2
- immutable integration snapshot parity: 126/126 on the main branch and 126/126 after cherry-picking into the integration branch
- standing approved-DLL parity: 450/450 and 643/643
- Milan synthetic, state, and runtime suites: 3/3
- release build: passed

The broad Meson run passed all Milan suites; its only failure was the unrelated AppStream metadata validator reporting the upstream issue URL as unreachable.

Reverse-engineering contract notes were committed and pushed separately to milan-dev as 909cc552.