### PR TITLE
Match Milan bypassed low-metric state

### DIFF
--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -1046,11 +1046,11 @@ milan_match_prepared_probe (
         {
           direct_metrics[0] = (int32_t) primary_filtered_count;
           direct_metrics[1] = (int32_t) filtered_count;
+          memcpy (direct_metrics + 6, low_bitmap_metrics,
+                  sizeof(low_bitmap_metrics));
         }
       direct_metrics[4] = overlap_score;
       direct_metrics[5] = overlap_detail;
-      memcpy (direct_metrics + 6, low_bitmap_metrics,
-              sizeof(low_bitmap_metrics));
       direct_metrics[9] = overlap_coverage * 246 >> 8;
       direct_metrics[10] = topology_percent;
       direct_metrics[11] = geometric_percent;
@@ -1135,8 +1135,12 @@ milan_match_prepared_probe (
                       sizeof(refined_transform));
               direct_metrics[4] = refined_overlap_score;
               direct_metrics[5] = refined_overlap_detail;
-              memcpy (direct_metrics + 6, refined_low_metrics,
-                      sizeof(refined_low_metrics));
+              if (enrolled->metadata.sensor_type == 12)
+                memcpy (low_bitmap_metrics, refined_low_metrics,
+                        sizeof(low_bitmap_metrics));
+              else
+                memcpy (direct_metrics + 6, refined_low_metrics,
+                        sizeof(refined_low_metrics));
               direct_metrics[9] = refined_overlap_coverage * 246 >> 8;
               goodix_milan_match_record_metrics_internal (
                 enrolled_records, feature.record_count, probe_records,
@@ -1178,6 +1182,10 @@ milan_match_prepared_probe (
           goodix_milan_match_candidate_materialize_dispatch (&direct_candidate);
           memcpy (direct_metrics + 15, direct_candidate.words + 15,
                   6 * sizeof(*direct_metrics));
+          if (match_flag != 2 ||
+              late_policy_context.accumulated_high_class > 1)
+            memcpy (direct_metrics + 6, low_bitmap_metrics,
+                    sizeof(low_bitmap_metrics));
         }
       memcpy (rescue_records[feature_index], direct_metrics,
               sizeof(rescue_records[feature_index]));


### PR DESCRIPTION
## Summary

- preserve zero-initialized low-bitmap metric words on the native type-12 policy bypass
- materialize final low-bitmap metrics only on the non-bypass path before policy, rescue, and selection
- retain existing non-type-12 and refined-metric behavior

## Native contract

For profile 9 / sensor type 12, `FUN_180055a40:0x180056236..0x180056244` bypasses both low-bitmap materialization and mutable policy dispatch when `flag60 == 2` and the signed accumulated high class is at most one. Candidate words 6 through 8 therefore retain their zero initialization when the later `FUN_180058700` policy consumes them.

A natural accepted match reached this path with a class-3-close transform, policy coverage 62, metric 5 equal to 202, and zero metric 8. The DLL cleared only `flag60`, preserving authentication while suppressing study. Source had prematurely materialized metric 8 as 207, retained study evidence, and returned Action 4 with a candidate instead of native Action 0 with no candidate.

The caller-side five-term veto is also skipped by native control flow, but no paired source change is needed: producing `flag60 == 2` requires metric 11 at least 36, while every veto arm requires metric 11 below 20. The existing extra source call is therefore side-effect-free for every producer-valid bypass state.

## Validation

- focused natural target and Action 4 controls: 4/4
- production build with debug disabled
- Milan synthetic, state, and runtime suites: 3/3
- new physical snapshot on standalone branch: 210/210
- current integration composite snapshots: 126/126 and 210/210
- later August 9 integration campaign: 189/189
- standing main authorities: 450/450 and 643/643
- pre-campaign correctness/performance review: no findings; no additional bitmap work and only a cheap conditional copy
- `git diff --check`

## Documentation

Durable native function contracts were corrected separately on `milan-dev` in commit `d664a9c7`.