### PR TITLE
Match Milan FDT refresh base publication

### DIFF
--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -711,6 +711,19 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
           {
             if (error)
               fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
+            else if (data->forced_refresh &&
+                     data->attempt.mad >= GOODIX_MILAN_BASE_MAD_LIMIT)
+              {
+                goodix_device_generate_fdt_base (
+                  data->fdt_tx_on_before, GOODIX_FDT_BASE_LEN,
+                  self->profile9_fdt.base_down);
+                memcpy (self->profile9_fdt.base_up,
+                        self->profile9_fdt.base_down, GOODIX_FDT_BASE_LEN);
+                memcpy (self->profile9_fdt.base_manual,
+                        self->profile9_fdt.base_down, GOODIX_FDT_BASE_LEN);
+                goodix_base_complete_recovery (
+                  ssm, dev, data, data->fdt_tx_on_before, 0, "tx-on/tx-off");
+              }
             else
               {
                 goodix_milan_base_attempt_reset (&data->attempt);

--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -711,8 +711,7 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
           {
             if (error)
               fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
-            else if (data->forced_refresh &&
-                     data->attempt.mad >= GOODIX_MILAN_BASE_MAD_LIMIT)
+            else if (data->attempt.mad >= GOODIX_MILAN_BASE_MAD_LIMIT)
               {
                 goodix_device_generate_fdt_base (
                   data->fdt_tx_on_before, GOODIX_FDT_BASE_LEN,
@@ -721,8 +720,15 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
                         self->profile9_fdt.base_down, GOODIX_FDT_BASE_LEN);
                 memcpy (self->profile9_fdt.base_manual,
                         self->profile9_fdt.base_down, GOODIX_FDT_BASE_LEN);
-                goodix_base_complete_recovery (
-                  ssm, dev, data, data->fdt_tx_on_before, 0, "tx-on/tx-off");
+                if (data->forced_refresh)
+                  goodix_base_complete_recovery (
+                    ssm, dev, data, data->fdt_tx_on_before, 0, "tx-on/tx-off");
+                else
+                  {
+                    goodix_milan_base_attempt_reset (&data->attempt);
+                    fpi_ssm_jump_to_state (
+                      ssm, GOODIX_BASE_RECOVERY_FDT_TX_ON);
+                  }
               }
             else
               {

--- a/drivers/goodix53x5/device/calibration.c
+++ b/drivers/goodix53x5/device/calibration.c
@@ -344,7 +344,7 @@ goodix_device_is_fdt_base_valid (const guint8 *first_base,
  *
  * Generate FDT base from FDT event data.
  * For each 16-bit LE pair:
- *   fdt_base_val = (val & 0xFFFE) * 0x80 | (val >> 1)
+ *   fdt_base_val = (val & 0xFFFE) * 0x80 + (val >> 1)
  */
 void
 goodix_device_generate_fdt_base (const guint8 *fdt_data,
@@ -354,7 +354,7 @@ goodix_device_generate_fdt_base (const guint8 *fdt_data,
   for (gsize i = 0; i < len; i += 2)
     {
       guint16 fdt_sample = fdt_data[i] | ((guint16) fdt_data[i + 1] << 8);
-      guint16 fdt_base_word = (guint16) (((fdt_sample & 0xFFFE) * 0x80) | (fdt_sample >> 1));
+      guint16 fdt_base_word = (guint16) (((fdt_sample & 0xFFFE) * 0x80) + (fdt_sample >> 1));
 
       fdt_base[i] = fdt_base_word & 0xFF;
       fdt_base[i + 1] = (fdt_base_word >> 8) & 0xFF;


### PR DESCRIPTION
## Summary

- Match the native unsigned wrapping-add transform for profile-9 FDT base words.
- Publish the first TX-on FDT base when TX-on/TX-off image-pair admission rejects.
- Preserve native ownership: rejection does not publish a Milan generation, replace a valid image reference, allocate an ID, set a preprocessing handoff, or report an error.
- Preserve current initial-recovery chronology while forced refresh rejection skips the native-absent third FDT read.

## Native Contract

`usbinterface.dll` `FUN_1800048d0` transforms each of 12 unsigned 16-bit samples as `((sample & 0xfffe) * 0x80 + (sample >> 1)) mod 0x10000`. `MilanHV_update_allbase` applies that transform to the first TX-on FDT vector and publishes it to the profile-9 down, up, and manual stores even when image-pair MAD is rejected. Initial action `0x0c` and later forced refreshes share this common postlude.

Image-pair admission is strict: MAD 199 is accepted and MAD 200 is rejected. Rejection preserves prior image validity/reference state. Initial rejection therefore leaves no valid image; later refresh rejection retains the prior valid reference.

Durable native documentation: `milan-dev` commit [`3738e018`](https://github.com/seaweeduk/goodix53x5-libfprint/commit/3738e0184f8c4dc0d44aabdad6fd52e6b4482b65).

## Proven Divergence

The old transform used bitwise OR. Across the complete parser-accepted `uint16` domain, 56,788 of 65,536 values differed from native; the first mismatch was `0x0202`. Those bytes reached complete down/up/manual USB command frames without masking.

On MAD-200 rejection, native programmed the first TX-on FDT base while current retained stale stores. During initial acquisition, the subsequent retry therefore issued manual-FDT commands using zero/stale bytes. During forced refresh, current rearmed FDT-down with the old base.

## Exact Parity Proof

- Complete transform domain: 65,536/65,536 native-exact after the change.
- Distinguishing transform target: native/current SHA-256 `5f442f0b987ba9806cef7f2de9521895d0c9d0aa40cac991ad40c5a4eb83739c`.
- Adjacent equal-output control: native/current SHA-256 `4699135f9e604d386e71a70cce8b79bcb854175d75d316f5220753c8662ad02c`.
- Forced MAD 200: exact down/up/manual/rearm bytes, zero recovery reads, old generation/reference retained, validity clear, and no publication/error.
- Forced MAD 199 and immediate retry: exact base bytes and admitted generation/reference publication.
- Initial MAD 200: exact stores and manual commands, recovery event preserved, no generation/error, and later retry publishes the first valid reference.
- Initial MAD 199: exact stores, valid generation/reference, no recovery-pending state.
- ASan/UBSan observers matched optimized output byte-for-byte with empty sanitizer stderr.

## Validation

- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` (127/127 actions)
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites (4/4 passed)
- Strict `-Wall -Wextra -Werror` focused builds
- ASan/UBSan and bounds-focused observers
- Uncrustify 0.83.0_f touched-hunk check
- `git diff --check`

The 126/189/210/450/643 runtime replay campaigns were not run: their backend compiles `drivers/goodix53x5/milan/**` and starts from recorded runtime inputs. It neither compiles `device/calibration.c`/`device/base.c` nor executes FDT acquisition and USB command chronology, so those campaigns cannot observe this change.

## Performance

The transform replaces one integer operator. The additional three 24-byte copies execute only on image-pair rejection; no image-processing, matching, allocation, serialization, or normal successful-capture hot path is added.