### PR TITLE
Preserve Milan reverse manual FDT base

### DIFF
--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -502,8 +502,12 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
 
           goodix_scan_normalize_event (&fdt->event, current);
           if (data->event_type == GOODIX_FDT_EVENT_REVERSE)
-            for (guint i = 0; i < GOODIX_PROFILE9_FDT_AREA_COUNT; i++)
-              data->prior_down[i] = fdt->base_down[i * 2 + 1];
+            {
+              for (guint i = 0; i < GOODIX_PROFILE9_FDT_AREA_COUNT; i++)
+                data->prior_down[i] = fdt->base_down[i * 2 + 1];
+              memcpy (fdt->base_manual, fdt->base_down,
+                      sizeof (fdt->base_manual));
+            }
 
           goodix_device_generate_fdt_base (fdt->event.raw,
                                            GOODIX_FDT_BASE_LEN,


### PR DESCRIPTION
## Summary

- Snapshot the prior profile-9 FDT-down arm base into the manual-FDT store on reverse events.
- Preserve the existing reverse/up drift-anchor predicates, refresh ownership, and rearm ordering.
- Ensure the next TX-off manual command uses the same retained base as native.

Depends on #83 for the native-exact shared FDT transform.

## Native Contract

For each reverse IRQ, `usbinterface.dll` `FUN_180005b80` first snapshots the prior hardware down-arm base into the manual-FDT store, then transforms the current raw event into the replacement down-arm base. Up-event parsing does not replace the manual store. `MilanHV_Down_procedure` later consumes that retained snapshot in its immediate TX-off manual command.

The reverse/up software-anchor policy itself is exact: area changes use strict `> delta_down`, refresh requires seven of twelve changed areas, and anchor clearing requires every area to be strictly `< floor(delta_down / 3)`.

Durable native documentation: `milan-dev` commit [`3738e018`](https://github.com/seaweeduk/goodix53x5-libfprint/commit/3738e0184f8c4dc0d44aabdad6fd52e6b4482b65).

## Proven Divergence

A producer-valid reverse/up sequence used `delta_down = 13`:

- R1 normalized 110 seeded the empty anchor over prior down base 100.
- R2 target normalized 114 retained the anchor at the strict `delta_down / 3 == 4` boundary.
- The adjacent R2 control normalized 113 cleared the anchor because every difference was 3.
- U1 changed seven areas by 14, causing only the target to refresh.

The target refresh chronology was already native-exact. In the adjacent no-refresh control, native retained the prior reverse down base (`0x6e` bytes) as manual-FDT while current retained stale `0x64` bytes. The next complete TX-off command therefore differed: native sent `8d 01` plus 24 bytes `0x6e`; current sent `8d 01` plus 24 bytes `0x64`. No downstream overwrite occurred before that command.

## Exact Parity Proof

After the change, native/current are byte-exact after every R1/R2/U1 event for:

- normalized inputs and prior down base;
- anchor bytes and empty flag;
- validity and refresh count/reason/outcome;
- generation/reference and fresh preprocessing handoff;
- down/up/manual stores;
- FDT-down rearm and next TX-off manual command;
- wait mode and absence of extraneous retry/error/probe/match/lifecycle outputs.

The target still performs one up-owned successful refresh and publishes generation 42. The adjacent control performs no refresh, retains generation 41, and now sends the exact native manual command. Non-reverse up/down controls leave manual state unchanged. ASan/UBSan output matches optimized output byte-for-byte with empty sanitizer stderr.

## Validation

- Clean focused native/current R1/R2/U1 target and adjacent control
- Non-reverse up/down controls
- Final aggregate parent interaction controls
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` (127/127 actions)
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites (4/4 passed)
- Strict `-Wall -Wextra -Werror` focused builds
- ASan/UBSan and bounds-focused observers
- Uncrustify 0.83.0_f touched-hunk check
- `git diff --check`

The 126/189/210/450/643 runtime replay campaigns were not run because their backend does not compile `device/scan.c` or execute FDT parser/USB command chronology.

## Performance

The change adds one 24-byte copy per reverse IRQ. It does not affect image processing, matching, serialization, allocation, or the ordinary down/up path.