### PR TITLE
Retry Milan failed live image reads

### DIFF
--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -898,6 +898,14 @@ typedef enum {
   GOODIX_CAPTURE_STORE,
   GOODIX_CAPTURE_NUM_STATES,
 } GoodixCaptureState;
+
+typedef struct
+{
+  FpiSsm  *parent_ssm;
+  gboolean command_started;
+  gboolean needs_reinit_before_read;
+} GoodixCaptureData;
+
 static void goodix_capture_ssm_handler (FpiSsm *ssm, FpDevice *dev);
 
 /* ========================================================================
@@ -914,16 +922,22 @@ goodix_capture_ssm_handler (FpiSsm   *ssm,
   switch (fpi_ssm_get_cur_state (ssm))
     {
     case GOODIX_CAPTURE_GET_IMAGE:
+      {
+        GoodixCaptureData *data = fpi_ssm_get_data (ssm);
+
 #ifdef GOODIX53X5_DEBUG
-      g_clear_pointer (&self->captured_image, g_free);
+        g_clear_pointer (&self->captured_image, g_free);
 #endif
-      g_clear_pointer (&self->captured_raw_image, g_free);
-      GOODIX53X5_DEBUG_ONLY (
-        self->debug_timing.capture_started_us = now_us;
-        self->debug_timing.capture_phase_started_us = now_us;)
-      /* Live TX-on finger frame */
-      goodix_cmd_request_image (ssm, dev, TRUE, TRUE, TRUE,
-                                self->calib.dac_h);
+        g_clear_pointer (&self->captured_raw_image, g_free);
+        GOODIX53X5_DEBUG_ONLY (
+          self->debug_timing.capture_started_us = now_us;
+          self->debug_timing.capture_phase_started_us = now_us;)
+        data->needs_reinit_before_read = self->needs_reinit;
+        data->command_started = self->cmd_owner == NULL && !self->rx_active;
+        /* Live TX-on finger frame */
+        goodix_cmd_request_image (ssm, dev, TRUE, TRUE, TRUE,
+                                  self->calib.dac_h);
+      }
       break;
 
     case GOODIX_CAPTURE_DECRYPT:
@@ -1027,7 +1041,58 @@ goodix_capture_ssm_handler (FpiSsm   *ssm,
     }
 }
 
-/* capture is used as a sub-SSM — no standalone run/done needed */
+static void
+goodix_capture_ssm_done (FpiSsm   *ssm,
+                         FpDevice *dev,
+                         GError   *error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  GoodixCaptureData *capture = fpi_ssm_get_data (ssm);
+  GoodixScanCoordinatorData *coordinator = fpi_ssm_get_data (
+    capture->parent_ssm);
+  gboolean read_failed;
+
+  read_failed = error && capture->command_started &&
+                 fpi_ssm_get_cur_state (ssm) == GOODIX_CAPTURE_GET_IMAGE &&
+                 !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
+  if (!read_failed)
+    {
+      if (error)
+        fpi_ssm_mark_failed (capture->parent_ssm, error);
+      else
+        fpi_ssm_next_state (capture->parent_ssm);
+      return;
+    }
+
+  g_assert (self->profile9_fdt.owner == capture->parent_ssm);
+  g_assert (fpi_ssm_get_cur_state (capture->parent_ssm) ==
+            GOODIX_SCAN_COORD_CAPTURE);
+  self->needs_reinit = capture->needs_reinit_before_read;
+#ifdef GOODIX53X5_DEBUG
+  g_clear_pointer (&self->captured_image, g_free);
+  self->debug_timing.capture_started_us = 0;
+  self->debug_timing.capture_phase_started_us = 0;
+#endif
+  g_clear_pointer (&self->captured_raw_image, g_free);
+  g_clear_error (&error);
+
+  if (coordinator->stop_requested ||
+      (coordinator->action_cancel &&
+       g_cancellable_is_cancelled (coordinator->action_cancel)))
+    {
+      coordinator->dispatching = FALSE;
+      if (coordinator->stop_requested)
+        goodix_scan_maybe_finish_requested (coordinator);
+      else
+        goodix_scan_request_stop (
+          coordinator,
+          g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED,
+                               "Profile-9 scan action cancelled"));
+    }
+  else
+    fpi_ssm_jump_to_state (capture->parent_ssm,
+                           GOODIX_SCAN_COORD_REARM_DOWN);
+}
 
 /* ========================================================================
  * Sub-SSM start wrappers
@@ -1036,8 +1101,11 @@ goodix_capture_ssm_handler (FpiSsm   *ssm,
 static void
 goodix_scan_start_capture_subsm (FpiSsm *parent_ssm, FpDevice *dev)
 {
+  GoodixCaptureData *data = g_new0 (GoodixCaptureData, 1);
   FpiSsm *sub = fpi_ssm_new (dev, goodix_capture_ssm_handler,
                              GOODIX_CAPTURE_NUM_STATES);
 
-  fpi_ssm_start_subsm (parent_ssm, sub);
+  data->parent_ssm = parent_ssm;
+  fpi_ssm_set_data (sub, data, g_free);
+  fpi_ssm_start (sub, goodix_capture_ssm_done);
 }

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -1067,13 +1067,10 @@ goodix_capture_ssm_done (FpiSsm   *ssm,
   g_assert (self->profile9_fdt.owner == capture->parent_ssm);
   g_assert (fpi_ssm_get_cur_state (capture->parent_ssm) ==
             GOODIX_SCAN_COORD_CAPTURE);
-  self->needs_reinit = capture->needs_reinit_before_read;
 #ifdef GOODIX53X5_DEBUG
-  g_clear_pointer (&self->captured_image, g_free);
   self->debug_timing.capture_started_us = 0;
   self->debug_timing.capture_phase_started_us = 0;
 #endif
-  g_clear_pointer (&self->captured_raw_image, g_free);
   g_clear_error (&error);
 
   if (coordinator->stop_requested ||
@@ -1090,8 +1087,11 @@ goodix_capture_ssm_done (FpiSsm   *ssm,
                                "Profile-9 scan action cancelled"));
     }
   else
-    fpi_ssm_jump_to_state (capture->parent_ssm,
-                           GOODIX_SCAN_COORD_REARM_DOWN);
+    {
+      self->needs_reinit = capture->needs_reinit_before_read;
+      fpi_ssm_jump_to_state (capture->parent_ssm,
+                             GOODIX_SCAN_COORD_REARM_DOWN);
+    }
 }
 
 /* ========================================================================


### PR DESCRIPTION
## Summary

- Keep a standard profile-9 capture action pending when its selected live TX-on/HV image read fails.
- Preserve the retained generation/reference and rearm FDT-down so the next real-finger event retries the same request.
- Preserve existing cancellation, FDT/manual, arm, parse/decode, cleanup, and unrelated transport-error ownership.

This correction is semantically independent of #83/#84. A transient aggregate with stack #85 was built and passed both the existing FDT/manual-base proofs and this live-read retry proof.

## Native Contract

Ordinary enrollment and identify/verify use WBDI IOCTL `0x440014`, handled by `usbinterface.dll` `FUN_180021978` (`OnCaptureData`). A valid request remains pending while profile-9 action 3 arms FDT-down. After real-finger FDT/manual validation, `FUN_1800150e0` reads the selected live TX-on/HV frame.

If that live callback returns `-1`, native frees temporary live storage but preserves the pending request, output pointer, completed-frame callback, retained reference/validity, one-shot marker, and unread capture count. `MilanHV_Down_procedure` skips sensor-mode publication, rearms FDT-down, and the worker resumes waiting. The next real-down event retries and can complete the same request. Identify/verify retain count one; enrollment retains the unread remainder of count two.

Durable native documentation: `milan-dev` commit [`3c8958bd`](https://github.com/seaweeduk/goodix53x5-libfprint/commit/3c8958bd2b3e9a830af2ef0b2930c0e688712ba9).

## Proven Divergence

The producer-valid target and adjacent control were exact through standard `OnCaptureData`, operation start, FDT-down event, manual-FDT validation, and the selected live read.

Before this change, current propagated the selected image-command failure through the capture and coordinator state machines, issued sleep and EC-off, returned `G_USB_DEVICE_ERROR_IO`, set `needs_reinit`, cleared coordinator/wait ownership, and required a later operation plus reinitialization. Native instead returned no operation result, rearmed down, and retained the same pending request. No downstream overwrite removed the difference.

## Exact Parity Proof

After the change:

- The failed read publishes no frame or operation result.
- Partial live storage is discarded and prior `needs_reinit` state is restored.
- The same coordinator, action, generation, reference, and unread count remain owned.
- FDT-down is rearmed and the next real-down retries successfully.
- The retry frame and subsequent ordinary operation match the adjacent success control.
- Native target retry, target-next request, and control-next request produce byte-identical successful outputs.
- Enrollment first-read failure retains count two; second-read failure retains count one; retry consumes only unread frames.
- Cancellation remains `G_IO_ERROR_CANCELLED`. FDT receive, manual-FDT, arm-down, and image-response parse failures remain fatal and do not publish capture-ready.
- ASan/UBSan/leak runs have empty sanitizer output.

Final production source identity: `4e0b88ded03f3fa8a3c01c813ffbe7576568daef2754812f016d226fb6c201e3`. Final focused evidence manifest SHA-256: `1e49bccf6ab776c046a7eb13b6539d3fd74c6ee1cedb03c525bf405589fb8513`.

## Validation

- Focused native/current failed-read target and adjacent success control
- Same-action retry and subsequent-operation continuation
- Native enrollment first/second-read failure boundaries
- Cancellation, FDT receive, manual-FDT, arm-down, parse-failure, and prior-reinit controls
- Strict `-Wall -Wextra -Werror` focused compilation
- ASan/UBSan/leak and bounds-focused execution
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` (127/127 actions)
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites (4/4 passed)
- Uncrustify 0.83.0_f touched-hunk inspection
- `git diff --check`
- Transient aggregate with stack #85: debug-disabled build, FDT/manual-base target/control, live-read target/control, negative controls, and sanitizers passed

The 126/189/210/450/643 runtime replay campaigns were not run. Their backend does not compile or execute `device/scan.c` or the live USB coordinator path, so those campaigns cannot observe this correction.

## Performance

The normal capture path adds a small per-capture state allocation and completion callback. No additional USB command, image processing, matching, serialization, or retry occurs unless the selected live read fails.