### PR TITLE
Match Milan invalid-reference recovery

### DIFF
--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -492,6 +492,13 @@ goodix_base_complete_recovery (FpiSsm              *ssm,
 
   goodix_milan_base_attempt_reset (&data->attempt);
   self->profile9_fdt.base_valid = FALSE;
+  goodix_device_generate_fdt_base (data->fdt_tx_on_before,
+                                   GOODIX_FDT_BASE_LEN,
+                                   self->profile9_fdt.base_down);
+  memcpy (self->profile9_fdt.base_up, self->profile9_fdt.base_down,
+          sizeof (self->profile9_fdt.base_up));
+  memcpy (self->profile9_fdt.base_manual, self->profile9_fdt.base_down,
+          sizeof (self->profile9_fdt.base_manual));
 
   if (data->forced_refresh)
     {
@@ -510,18 +517,11 @@ goodix_base_complete_recovery (FpiSsm              *ssm,
   memcpy (self->profile9_fdt.event.raw, fdt_tx_on, GOODIX_FDT_BASE_LEN);
   self->profile9_fdt.event.pending = TRUE;
   self->profile9_fdt.initial_recovery_pending = TRUE;
-  goodix_device_generate_fdt_up_base (self->profile9_fdt.event.raw,
-                                      self->profile9_fdt.event.touch_flag,
-                                      &self->calib,
-                                      self->profile9_fdt.base_up);
   data->leave_powered = FALSE;
 
-  fp_info ("Milan base acquisition needs %s at %s (touch_flag=0x%03x)",
-           (touch_flag & 0x0fff) != 0 ? "finger removal" : "a later event",
+  fp_info ("Milan base acquisition validation failed at %s (touch_flag=0x%03x)",
            checkpoint, touch_flag & 0x0fff);
-  goodix_base_timing_done (
-    self, dev,
-    (touch_flag & 0x0fff) != 0 ? "remove_finger" : "pending_event");
+  goodix_base_timing_done (self, dev, "validation_failed");
   fpi_ssm_mark_completed (ssm);
 }
 
@@ -533,9 +533,13 @@ goodix_base_timing_done (FpiDeviceGoodix53x5 *self,
 {
   const gint64 now_us = g_get_monotonic_time ();
 
-  goodix_debug_timing_log (dev, "ref_capture", event,
-                           now_us - self->debug_timing.ref_capture_phase_started_us,
-                           NULL);
+  if (self->debug_timing.ref_capture_phase_started_us != 0)
+    {
+      goodix_debug_timing_log (
+        dev, "ref_capture", event,
+        now_us - self->debug_timing.ref_capture_phase_started_us,
+        NULL);
+    }
   if (self->debug_timing.ref_capture_started_us != 0)
     goodix_debug_timing_log (dev, "ref_capture", "total",
                              now_us - self->debug_timing.ref_capture_started_us,

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -373,16 +373,9 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
         }
 
       data->recovering_generation = TRUE;
-      goodix_device_generate_fdt_base (fdt->event.raw, GOODIX_FDT_BASE_LEN,
-                                       fdt->base_down);
       if ((fdt->event.touch_flag & 0x0fff) != 0)
-        {
-          goodix_device_generate_fdt_up_base (fdt->event.raw,
-                                              fdt->event.touch_flag,
-                                              &self->calib, fdt->base_up);
-          fpi_device_report_finger_status_changes (
-            dev, FP_FINGER_STATUS_PRESENT, FP_FINGER_STATUS_NEEDED);
-        }
+        fpi_device_report_finger_status_changes (
+          dev, FP_FINGER_STATUS_PRESENT, FP_FINGER_STATUS_NEEDED);
       else
         fpi_device_report_finger_status_changes (
           dev, FP_FINGER_STATUS_NEEDED, FP_FINGER_STATUS_PRESENT);
@@ -404,11 +397,7 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
                                            "Scan EC power-on failed"));
           return;
         }
-      if (data->recovering_generation &&
-          (fdt->event.touch_flag & 0x0fff) != 0)
-        fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_RECOVERY_ARM_UP);
-      else
-        fpi_ssm_next_state (ssm);
+      fpi_ssm_next_state (ssm);
       break;
 
     case GOODIX_SCAN_COORD_ARM_DOWN:
@@ -485,13 +474,6 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
             goodix_device_generate_fdt_up_base (fdt->event.raw,
                                                 fdt->event.touch_flag,
                                                 &self->calib, fdt->base_up);
-            if (data->recovering_generation || !self->milan_generation)
-              {
-                data->recovering_generation = TRUE;
-                fpi_ssm_jump_to_state (
-                  ssm, GOODIX_SCAN_COORD_RECOVERY_ARM_UP);
-                return;
-              }
             fpi_ssm_next_state (ssm);
             return;
           }
@@ -588,6 +570,12 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
 
         fpi_device_report_finger_status_changes (dev, FP_FINGER_STATUS_PRESENT,
                                                   FP_FINGER_STATUS_NEEDED);
+        if (data->recovering_generation || !self->milan_generation)
+          {
+            data->recovering_generation = TRUE;
+            fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_RECOVERY_ARM_UP);
+            return;
+          }
         fpi_ssm_next_state (ssm);
       }
       break;


### PR DESCRIPTION
## Summary

- Preserve native first-TX-on down/up/manual bases when initial post-capture FDT validation rejects.
- Start the first invalid-reference action in FDT-down mode and retain manual TX-off validation before recovery.
- Keep the same request pending through down, release/up refresh, down rearm, and the next successful press.
- Preserve the existing intentional libfprint finger-status behavior; checkpoint touch state no longer affects hardware or policy decisions.
- Make reference-capture timing finalization idempotent so recovery cleanup cannot log system uptime as a phase duration.

## Physical Failure

A finalized main build was observed after cold fprintd activation with a finger present during initial reference acquisition. Final post-capture FDT validation rejected with `touch_flag=0xfff`. The identify action began 62 ms later, but repeated finger lifts and presses produced no FDT event, image, or runtime record for 11 seconds. Password cancellation ended the wait; the next open admitted a generation and matched normally.

Current had retained the contaminated checkpoint and armed FDT-up before any real down/manual validation. Repeated presses were therefore not capture candidates.

## Native Contract

On first D0 initialization, native action `0x0c` performs full-base acquisition. If final TX-on FDT validation rejects, native:

- returns success while image/reference validity remains clear;
- publishes primary/down/up/manual bases transformed from the first TX-on FDT;
- does not retain a touch word from the failed manual checkpoint;
- arms no mode during initialization.

The first ordinary WBDI `OnCaptureData` action arms FDT-down. With an invalid reference, native performs:

```text
DOWN -> manual TX-off validation -> UP -> full refresh -> DOWN -> next press
```

The same WBF request remains pending and completes after the next press. No timeout, polling, synthetic release, or status policy is involved. This state is ordinarily Windows-reachable: the continuous reader starts before asynchronous `deviceInit`, and a finger can contaminate automatic reference acquisition before a biometric request exists. Windows service persistence does not prevent it.

Durable native documentation: `milan-dev` commit [`a7a7d080`](https://github.com/seaweeduk/goodix53x5-libfprint/commit/a7a7d08027396417fc993288f238313919d3037c).

## Regression Ownership

- PR #28 introduced the underlying final-checkpoint/touch-derived recovery divergence.
- PR #32 bounded that behavior with open-time removal/reacquisition, timeout, and explicit failure.
- PR #34 introduced the exact silent first-action UP wait by transferring the stale snapshot into the event coordinator. This identifies one transition, not the overall coordinator architecture, which remains the correct foundation.
- PRs #83, #84, and #86 do not execute or alter this physical branch. Their focused controls remain exact.

## Independent Verification

A separate verifier independently re-derived the native instructions, callback ABI, FDT source ownership, D0/WBDI reachability, current source, and Git history, then built a separate native oracle before inspecting the first researcher’s outputs.

Pre-implementation gates passed for native contract, Windows reachability, producer-valid physical state, complete divergence, repeated-touch causality, historical ownership, recent-PR non-ownership, smallest correction, and timing ownership.

Post-implementation verification independently rebuilt the edited source and returned **APPROVE** with no findings:

- Native target status `0`, validity `0/0`, first transformed word `12850`, and exact 120,976-byte completion.
- Native target/control differ only at the one-shot refresh marker byte.
- Current target uses exact first-TX-on stores and `DOWN -> manual -> UP -> refresh -> DOWN -> manual -> capture`.
- No-finger and false-down controls remain exact.
- Checkpoint touch variants preserve intentional status differences but have identical hardware projection.
- Real FDT events overwrite checkpoint raw/touch before hardware or policy decisions.
- PR #83 pair-rejection, PR #84 reverse/manual, and PR #86 live-read/suspend-race controls are unchanged.
- Cancellation at down wait, up wait, refresh, and next press leaves no stale SSM, USB, command, event, wait, or lifecycle owner.
- ASan/UBSan/bounds/leak checks are clean.

Final source identity: `1e9a5f0aa2b090c21f586459c66d56d8c8317e2a3be4ab224a324030daabe5d8`. Independent verification manifest SHA-256: `a052180032c08c2779577c7eb18f9466ac978c0de8ab969cc263764f09f1cdec`.

## Timing Fix

The early-recovery path finalized reference timing before powered cleanup, then cleanup finalized it again after timestamps were cleared. The second calculation subtracted zero and logged monotonic system uptime (`74948383.29 ms`). Phase and total timestamps are now guarded independently and always cleared, preserving valid partial measurements while making duplicate finalization and pre-EC cancellation silent.

## Validation

- Independent native/current target and adjacent controls
- Repeated press/lift same-request progression
- No-finger, false-down, and status variants
- Cancellation at each recovery wait
- PR #83/#84/#86 focused regression controls
- Timing normal, duplicate, pre-EC, and partial-state controls
- Strict `-Wall -Wextra -Werror` focused compilation
- ASan/UBSan/bounds/leak execution
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` (127/127 actions)
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites (4/4 passed)
- Uncrustify 0.83.0_f touched-file inspection
- `git diff --check` and dead/redundancy checks

The standing runtime replay campaigns were not run because their backend does not compile or execute `device/base.c` or `device/scan.c`; they cannot observe this correction. The active physical campaign containing the incident remains unmodified for follow-up integration testing.

## Performance

The correction removes stale base calculations and one premature branch. It adds no allocation, polling, timeout, USB command, image processing, matching, or serialization work.