### PR TITLE
Match Milan raw-detail blocker predicates

### DIFF
--- a/drivers/goodix53x5/milan/match/selection.c
+++ b/drivers/goodix53x5/milan/match/selection.c
@@ -380,7 +380,7 @@ goodix_milan_match_selection_block_candidate (
   if (!selection_type12_blocked (
         feature_texture_delta, feature_shape_delta, feature_boundary_delta,
         feature_boundary_score, candidate_coverage, comparison_metrics[1],
-        comparison_metrics[2], comparison_metrics[3], adjusted_detail))
+        comparison_metrics[2], comparison_metrics[3], comparison_metrics[4]))
     return 0;
 
   selection->postloop_blocking_count =


### PR DESCRIPTION
## Summary

- Pass raw pair detail to all profile-9/type-12 blocker predicates, matching native ownership.
- Keep the existing `-20/-10/0` adjusted detail exclusively for blocker-sum evidence.
- Correct both false blocker admissions and missed native blockers without changing metric production, thresholds, traversal, or lifecycle policy.

## Native Contract

The native pair-metric result is exactly five signed dwords, indices `0..4`; indices 5 or 6 do not exist. For profile 9/type 12:

- `[1]`: mutual nearest-pair count
- `[2]`: rounded symmetric Q12 pair support
- `[3]`: rounded directional Q12 valid-support ratio
- `[4]`: raw lower-median descriptor distance

All 27 blocker predicates consume raw metric `[4]`. Native separately derives an adjusted detail using boundary state (`-20`, `-10`, or `0`) only after predicate evaluation. Only a successful blocker contributes that adjusted value to blocker-count/sum evidence and the terminal blocker-ratio decision. Contribution, score, retained-candidate ranking, fallback/rescue, lifecycle mutation, queue, and study do not consume adjusted detail directly.

Durable native documentation: `milan-dev` commit [`c701840e`](https://github.com/seaweeduk/goodix53x5-libfprint/commit/c701840e).

## Proven Divergence

A finalized physical campaign supplied the first retained complete witness. Current and native were exact through processed image, quality/coverage, 131-record probe, gallery entry 0, acceptance, winner position, queue observations, and lifecycle execution.

For gallery entry 1, physical feature 32 naturally produced pair metrics `[0,7,1043,3413,84]`. Boundary adjustment was `-20`, giving adjusted detail `64`.

Native blocker term 9 tests raw `84 <= 78`, does not block feature 32, and publishes score 16. Current tested adjusted `64`, falsely blocked feature 32, traversed to feature 35, published score 31, mutated the gallery differently, emitted a candidate, and selected study action 4 instead of native action 0.

The complete observable differences were score, after-match gallery, candidate publication, selected physical feature, and study action.

## Generic Proof

The correction is one argument substitution, not a probe-specific exception. Independent native recovery covered all 27 terms, every detail-sensitive term, all adjustment bands, exact signedness, thresholds, ordering, and consumers.

A finite-domain comparison evaluated 25,628,400 valid combinations across raw detail `0..224`, persisted boundary score `-1..224`, adjustment boundaries, and isolated threshold controls:

- Old false blockers: 36,400
- Old missed native blockers: 92,780
- Corrected native/current blocker mismatches: 0

Representative classes include native-unblocked/current-blocked raw `79 -> adjusted 59`, and native-blocked/current-unblocked raw `77 -> adjusted 57`. The defect is generic and bidirectional.

The natural complete target becomes byte-exact after the change: gallery scores `-4/16`, physical feature 32, exact after-match gallery, no candidate, queue `0/0/0`, study action 0, and exact persisted result.

## History

The blocker implementation and adjusted predicate argument were introduced together in source commit `c51c8b07`, shipped by PR #28 (`8897ae97`). Before that commit, this blocker path did not exist.

PR #82 did not modify the blocker call, pair metric, adjustment, predicates, or sum; it changed a separate low-metric bypass in `match.c`. No commit from PR #82 through current source changed this matcher path. The new physical campaign is therefore the first retained natural complete witness, not a later source regression.

## Independent Verification

A separate verifier independently recovered the complete metric schema, all native predicates, every current consumer, exact raw/adjusted ownership, native feature chronology, and complete operation output. It built a fresh native observer and finite-domain proof rather than reusing the first researcher’s executable.

Final post-implementation verification returned **APPROVE** with no production findings. It confirmed the one-line diff, no adjacent raw/adjusted misuse, exact natural target, zero finite mismatches, source history, build/sanitizer evidence, and every campaign report.

Final source identity: `52b53128758a3408b4d2007ba65ec2f14cbca9574dcd3caf658c47b613692225`. Production diff SHA-256: `8b6c2d83101c0ab30f93c35fad19a002a015364e67cd5b69499239a3780a7103`. Independent verification manifest SHA-256: `633c22c32ed1faa109494a10c974fd875e760077dab568566ff94ac4a4ef2026`.

## Validation

Strict `--compare-current` campaigns were run sequentially on the final source:

- New physical witness campaign: 119/119
- PR #82 composite authority: 126/126
- August 9 integration authority: 189/189
- Standing premerge authority: 450/450
- Standing readiness authority: 643/643
- Aggregate: **1,527/1,527**, zero differences, unavailable selected outputs, inadmissible selections, or current/native queue mismatches

The historical 210-selector authority was not reconstructed: its explicit selector file/report is no longer retained and the evolved dump now contains 228 gallery-bearing records. Inventing a replacement 210 set would violate strict selection provenance.

Additional gates:

- Focused native/current target and threshold-adjacent controls
- All 27 blocker terms and all `-20/-10/0` adjustment bands
- Strict `-Wall -Wextra -Werror` compilation and GCC analyzer
- ASan/UBSan/leak/bounds execution
- Debug-disabled build: 127/127 actions
- Existing Milan synthetic/state/runtime and `fpi-device` suites: 4/4
- Uncrustify 0.83.0_f, `git diff --check`, dead/redundancy review

## Performance

The change substitutes one already-available array value for one local value. It adds no allocation, loop, branch, scan, matching pass, serialization, or hot-path work.