### PR TITLE
Remove unreachable Milan selector-two state

### DIFF
--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -146,7 +146,8 @@ goodix_match_update_extraction_classification (
   GoodixMilanExtractionClassificationState *state,
   const guint8 classification_source[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
   const guint8 classification_validity[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS],
-  const guint8 auxiliary[3],
+  guint8       primary_histogram_state,
+  guint8       promoted_secondary_histogram_state,
   gint         coverage,
   gint32       entry_low_class,
   gint32       entry_high_class)
@@ -163,7 +164,7 @@ goodix_match_update_extraction_classification (
                                   GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   guint stable_class1_count = 0;
   guint stable_class2_count = 0;
-  gint32 current_class = auxiliary[0];
+  gint32 current_class = primary_histogram_state;
   gint32 high_class;
   gint32 packed;
   gboolean append;
@@ -226,29 +227,21 @@ goodix_match_update_extraction_classification (
     current_class = 2;
 
   high_class = MAX (entry_high_class, current_class);
-  if (high_class < 2 && auxiliary[2] > 0)
+  if (high_class < 2 && promoted_secondary_histogram_state > 0)
     high_class++;
-  if (auxiliary[1] == 2)
-    high_class = MAX (high_class, state->prior_merged_high_class);
-  else if (high_class > 1 || current_class > 1 || auxiliary[2] > 1)
+  if (high_class > 1 || current_class > 1 ||
+      promoted_secondary_histogram_state > 1)
     {
       if (state->high_class_hysteresis < 5)
         state->high_class_hysteresis++;
     }
   else if (state->high_class_hysteresis != 0)
     state->high_class_hysteresis--;
-  state->prior_merged_high_class = high_class;
   if (state->high_class_hysteresis >= 3)
     high_class = MAX (high_class, 1);
   packed = high_class * 0x100 + entry_low_class;
 
-  if (auxiliary[1] == 2)
-    append = state->prior_coverage < 75;
-  else
-    {
-      state->prior_coverage = coverage;
-      append = coverage >= 75;
-    }
+  append = coverage >= 75;
   if (append)
     {
       if (state->retained_count < 3)
@@ -481,7 +474,6 @@ goodix_match_extract_planes (const guint8  *image,
   size_t feature_element_size = 0;
   size_t milan_template_size = 0;
   guint8 enhanced_threshold;
-  guint8 auxiliary[3];
   gint32 entry_low_class = 0;
   gint32 entry_high_class = 0;
   int quality;
@@ -492,9 +484,6 @@ goodix_match_extract_planes (const guint8  *image,
   if (!image || !primary_contrast_plane || !classification_state ||
       !auxiliary_state)
     return status;
-  auxiliary[0] = auxiliary_state->primary_histogram_state;
-  auxiliary[1] = auxiliary_state->prior_selected_plane;
-  auxiliary[2] = auxiliary_state->promoted_secondary_histogram_state;
   info = g_new0 (GoodixMatchInfo, 1);
   cropped = g_malloc (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS);
   high = g_malloc0 (286);
@@ -542,8 +531,10 @@ goodix_match_extract_planes (const guint8  *image,
       /* Native commits history before record extraction, anti-fake, or packing
        * failures. */
       fields.optional_c7 = goodix_match_update_extraction_classification (
-        classification_state, enhanced, validity_mask, auxiliary,
-        coverage, entry_low_class, entry_high_class);
+        classification_state, enhanced, validity_mask,
+        auxiliary_state->primary_histogram_state,
+        auxiliary_state->promoted_secondary_histogram_state, coverage,
+        entry_low_class, entry_high_class);
     }
   if (goodix_milan_feature_extract_records_mode_masked (
         image, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, records,

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -266,9 +266,7 @@ typedef struct
   uint8_t  retained_class_planes[3]
                                 [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
   uint32_t retained_count;
-  int32_t  prior_coverage;
   uint32_t high_class_hysteresis;
-  int32_t  prior_merged_high_class;
 } GoodixMilanExtractionClassificationState;
 
 typedef struct
@@ -281,7 +279,6 @@ typedef struct
 typedef struct
 {
   uint8_t primary_histogram_state;
-  uint8_t prior_selected_plane;
   uint8_t promoted_secondary_histogram_state;
 } GoodixMilanExtractionAuxiliaryState;
 
@@ -413,7 +410,7 @@ _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
                   offsetof (GoodixMilanPostRenderObservations, status) == 147392,
                 "Milan preprocess post-render status moved");
-_Static_assert (sizeof (GoodixMilanExtractionClassificationState) == 27472,
+_Static_assert (sizeof (GoodixMilanExtractionClassificationState) == 27464,
                 "Milan extraction classification state size changed");
 _Static_assert (_Alignof (GoodixMilanExtractionClassificationState) == 4,
                 "Milan extraction classification state alignment changed");
@@ -424,14 +421,8 @@ _Static_assert (offsetof (GoodixMilanExtractionClassificationState,
                           retained_count) == 27456,
                 "Milan extraction retained count moved");
 _Static_assert (offsetof (GoodixMilanExtractionClassificationState,
-                          prior_coverage) == 27460,
-                "Milan extraction prior coverage moved");
-_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
-                          high_class_hysteresis) == 27464,
+                          high_class_hysteresis) == 27460,
                 "Milan extraction hysteresis moved");
-_Static_assert (offsetof (GoodixMilanExtractionClassificationState,
-                          prior_merged_high_class) == 27468,
-                "Milan extraction prior high class moved");
 _Static_assert (sizeof (GoodixMilanExtractionPersistenceState) == 27460,
                 "Milan extraction persistence state size changed");
 _Static_assert (_Alignof (GoodixMilanExtractionPersistenceState) == 4,
@@ -440,17 +431,17 @@ _Static_assert (offsetof (GoodixMilanExtractionPersistenceState,
                           retained_count) == 27456,
                 "Milan persisted extraction retained count moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
-                          extraction_persistence) == 174868,
+                          extraction_persistence) == 174860,
                 "Milan extraction persistence state moved");
-_Static_assert (sizeof (GoodixMilanExtractionAuxiliaryState) == 3,
+_Static_assert (sizeof (GoodixMilanExtractionAuxiliaryState) == 2,
                 "Milan extraction auxiliary state size changed");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
-                          extraction_auxiliary) == 202328,
+                          extraction_auxiliary) == 202320,
                 "Milan extraction auxiliary state moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
-                          application_gain_initialized) == 202331,
+                          application_gain_initialized) == 202322,
                 "Milan application gain initialization state moved");
-_Static_assert (sizeof (GoodixMilanPreprocessState) == 202332,
+_Static_assert (sizeof (GoodixMilanPreprocessState) == 202324,
                 "Milan preprocess state size changed");
 _Static_assert (_Alignof (GoodixMilanPreprocessState) == 4,
                 "Milan preprocess state alignment changed");

--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -1129,11 +1129,8 @@ static int
 milan_profile9_prepare_history (GoodixMilanPreprocessState *state,
                                 const uint16_t             *prepared,
                                 const uint8_t              *contrast_mask,
-                                size_t                      count,
-                                uint8_t                     prior_selected_plane)
+                                size_t                      count)
 {
-  if (prior_selected_plane == 2)
-    return 0;
   if (state->profile9_history_count == 0 && state->sample_count > 1)
     {
       uint32_t retained_count = state->sample_count < 21
@@ -1497,7 +1494,6 @@ goodix_milan_profile9_build_broken_mask (
   int low;
   int high;
   size_t active_count = 0;
-  uint8_t prior_selected_plane;
   uint8_t primary_histogram_state;
   uint8_t secondary_histogram_state = 0;
   uint8_t secondary_count_state = 0;
@@ -1510,7 +1506,6 @@ goodix_milan_profile9_build_broken_mask (
       columns > SIZE_MAX / rows || rows * columns > GOODIX_MILAN_SENSOR_PIXELS)
     return -1;
   count = rows * columns;
-  prior_selected_plane = (uint8_t) state->selected_refined;
   for (size_t i = 0; i < count; i++)
     active_count += contrast_mask[i] != 0;
   prepared = malloc (count * sizeof(*prepared));
@@ -1540,7 +1535,7 @@ goodix_milan_profile9_build_broken_mask (
     memcpy (prepared, difference, count * sizeof(*prepared));
   milan_profile9_erode_valid (contrast_mask, valid, rows, columns, 8);
   history_initialized = milan_profile9_prepare_history (
-    state, prepared, contrast_mask, count, prior_selected_plane);
+    state, prepared, contrast_mask, count);
   milan_profile9_filter_q16 (
     prepared, rows, columns, primary_kernel, 3, blurred);
   primary_histogram_state = milan_profile9_histogram_state (
@@ -1778,7 +1773,6 @@ goodix_milan_profile9_build_broken_mask (
   state->profile9_class_counts.profile9_class3_count = (uint32_t) class3_count;
   state->extraction_auxiliary.primary_histogram_state =
     primary_histogram_state;
-  state->extraction_auxiliary.prior_selected_plane = prior_selected_plane;
   *mode = 0;
   *apply_mask = 0;
   if (class3_count * 100 > mask_count * 15)


### PR DESCRIPTION
## Summary

- Remove the unreachable selector-2 preprocessing-history and extraction branches.
- Remove prior coverage, prior merged-high, and selector transport state that had no ordinary producer or remaining consumer.
- Keep retained extraction planes/count, hysteresis, ordinary coverage admission, packing, and mutation order unchanged.

## Reachability proof

Two independent approved-DLL audits traced the complete producer sets. Native ordinary enrollment hardcodes the selector-producing argument to zero. Native identify forwards a byte whose sole ordinary adapter producer also hardcodes zero. Current `selected_refined` is produced only as 0 or 1. Persistence, refresh, retry, and process lifetime cannot widen either ordinary domain to 2.

The removed branches therefore could not affect enrollment, identify, verify, retries, probes, templates, queues, or persisted output. For current values 0 and 1, the old code always took the same non-2 history, hysteresis, and `coverage >= 75` ring-admission path retained by this layer.

## Verification

- Independent native reachability adjudication approved the dead-code classification.
- Debug-disabled offline production build passes.
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites pass 4/4.
- `git diff --check` passes.
- Removed fields are transient internal state and are absent from persistence, runtime/debug schemas, templates, and installed ABI.

Standing campaigns were not run because no selected ordinary WBF operation can produce selector 2 or enter a removed branch. Replaying selector-0 operations cannot distinguish this cleanup from its parent.

Durable native documentation: `aa40f4376a1108d4055811aa11d8a8d2f676afad`.