### PR TITLE
Defer Milan setup admission to completed samples

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -468,7 +468,10 @@ goodix_auth_start_task (FpDevice *dev)
     goodix_debug_capture_runtime_metadata (
       &task_data->debug_metadata, action,
       self->milan_generation->setup_tx_on, self->captured_raw_image,
-      self->milan_generation->use_count);)
+      self->milan_generation->use_count,
+      self->milan_generation->profile_state.setup_initialized,
+      self->milan_generation->profile_state.setup_refresh_pending,
+      self->milan_generation->profile_state.setup_not_ready);)
 
   if (action == FPI_DEVICE_ACTION_VERIFY)
     {

--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -155,17 +155,6 @@ goodix_milan_base_attempt_admit (GoodixMilanBaseAttempt *attempt,
       return FALSE;
     }
 
-  if (!goodix_milan_preprocess_clamp_and_admit_raw (
-        attempt->tx_on, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
-        GOODIX_MILAN_BASE_BORDER, 85))
-    {
-      attempt->admission_status =
-        GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION;
-      goodix_milan_base_attempt_release_frames (attempt);
-      attempt->stage = GOODIX_MILAN_BASE_STAGE_REJECTED;
-      return FALSE;
-    }
-
   attempt->admitted = TRUE;
   return TRUE;
 }
@@ -238,8 +227,9 @@ goodix_milan_generation_transfer_process_state (
           sizeof (destination->state.profile9_component_age));
   destination->state.extraction_classification =
     source->state.extraction_classification;
-  destination->profile_state.calibration_ready =
-    source->profile_state.calibration_ready;
+  destination->profile_state = source->profile_state;
+  destination->profile_state.setup_refresh_pending = 1;
+  destination->profile_state.setup_not_ready = 0;
 }
 
 gboolean

--- a/drivers/goodix53x5/device/debug.c
+++ b/drivers/goodix53x5/device/debug.c
@@ -713,7 +713,10 @@ goodix_debug_capture_runtime_metadata (GoodixDebugRuntimeMetadata *metadata,
                                         FpiDeviceAction             action,
                                         const guint16              *setup_tx_on,
                                         const guint16              *live_raw,
-                                        guint64 generation_use_index)
+                                        guint64 generation_use_index,
+                                        gboolean setup_initialized,
+                                        gboolean setup_refresh_pending,
+                                        gboolean setup_not_ready)
 {
   g_return_if_fail (metadata != NULL);
   g_return_if_fail (setup_tx_on != NULL);
@@ -722,6 +725,9 @@ goodix_debug_capture_runtime_metadata (GoodixDebugRuntimeMetadata *metadata,
   goodix_debug_clear_runtime_metadata (metadata);
   metadata->action = action;
   metadata->generation_use_index = generation_use_index;
+  metadata->setup_initialized = setup_initialized;
+  metadata->setup_refresh_pending = setup_refresh_pending;
+  metadata->setup_not_ready = setup_not_ready;
   if (!goodix_debug_env_enabled ("GOODIX53X5_DUMP_TEMPLATES") ||
       !goodix_debug_dump_enabled ())
     return;
@@ -834,9 +840,11 @@ goodix_debug_log_runtime_result (FpDevice                         *dev,
   chronology = self->debug_chronology + 1;
   common_prefix = g_strdup_printf (
     "runtime-artifact-%s-%s-%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT
-    "-%u-%" G_GUINT64_FORMAT,
+    "-%u-%" G_GUINT64_FORMAT "-setup-i%u-r%u-n%u",
     self->debug_capture_session_id, action_name, output->action_epoch,
-    output->generation_id, stage, chronology);
+    output->generation_id, stage, chronology,
+    metadata->setup_initialized, metadata->setup_refresh_pending,
+    metadata->setup_not_ready);
   operation_id = g_strdup_printf ("%s/%s/%" G_GUINT64_FORMAT,
                                   self->debug_capture_session_id, action_name,
                                   output->action_epoch);

--- a/drivers/goodix53x5/device/debug.h
+++ b/drivers/goodix53x5/device/debug.h
@@ -26,6 +26,9 @@ typedef struct
 {
   FpiDeviceAction action;
   guint64         generation_use_index;
+  gboolean        setup_initialized;
+  gboolean        setup_refresh_pending;
+  gboolean        setup_not_ready;
   GBytes         *setup_tx_on;
   GBytes         *live_raw;
 } GoodixDebugRuntimeMetadata;
@@ -94,7 +97,10 @@ void goodix_debug_capture_runtime_metadata (
   FpiDeviceAction             action,
   const guint16              *setup_tx_on,
   const guint16              *live_raw,
-  guint64                     generation_use_index);
+  guint64                     generation_use_index,
+  gboolean                    setup_initialized,
+  gboolean                    setup_refresh_pending,
+  gboolean                    setup_not_ready);
 void goodix_debug_clear_runtime_metadata (
   GoodixDebugRuntimeMetadata *metadata);
 void goodix_debug_log_runtime_result (

--- a/drivers/goodix53x5/device/enroll.c
+++ b/drivers/goodix53x5/device/enroll.c
@@ -343,7 +343,10 @@ goodix_enroll_start_task (FpDevice *dev)
     goodix_debug_capture_runtime_metadata (
       &data->debug_metadata, FPI_DEVICE_ACTION_ENROLL,
       self->milan_generation->setup_tx_on, self->captured_raw_image,
-      self->milan_generation->use_count);
+      self->milan_generation->use_count,
+      self->milan_generation->profile_state.setup_initialized,
+      self->milan_generation->profile_state.setup_refresh_pending,
+      self->milan_generation->profile_state.setup_not_ready);
                         )
   data->runtime_input = goodix_milan_runtime_input_new (
     data->action_epoch, data->generation_id, GOODIX_MILAN_PURPOSE_ENROLL,

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -27,6 +27,7 @@
    GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS)
 #define GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION 0x29aa
 #define GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION 0x29bb
+#define GOODIX_MILAN_PREPROCESS_NOT_READY 0x80
 #define GOODIX_MILAN_PREPROCESS_RETRY 0x7531
 #define GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION 0xc351
 #define GOODIX_MILAN_ANTIFAKE_AMBIGUOUS 1
@@ -220,6 +221,9 @@ typedef enum
 typedef struct
 {
   uint32_t calibration_ready;
+  uint32_t setup_initialized;
+  uint32_t setup_refresh_pending;
+  uint32_t setup_not_ready;
 } GoodixMilanProfileState;
 
 typedef enum

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -254,6 +254,36 @@ goodix_milan_runtime_study (const GoodixMilanRuntimeInput *input,
     probe, feature, feature_len, match_result, TRUE, queue, after_study, action);
 }
 
+static gint32
+goodix_milan_runtime_initialize_setup (const GoodixMilanRuntimeInput *input,
+                                       GoodixMilanRuntimeOutput      *output)
+{
+  gboolean setup_required;
+
+  setup_required = !output->profile_state.setup_initialized ||
+                   output->profile_state.setup_refresh_pending;
+  if (!setup_required)
+    return output->profile_state.setup_not_ready ?
+           GOODIX_MILAN_PREPROCESS_NOT_READY : 0;
+
+  output->profile_state.calibration_ready = 0;
+  output->profile_state.setup_refresh_pending = 0;
+  /* Native retries setup once against the same retained frame. */
+  for (guint attempt = 0; attempt < 2; attempt++)
+    if (goodix_milan_preprocess_clamp_and_admit_raw (
+          input->setup_tx_on, GOODIX_MILAN_SENSOR_ROWS,
+          GOODIX_MILAN_SENSOR_COLUMNS, 2, 85))
+      {
+        output->profile_state.setup_initialized = 1;
+        output->profile_state.setup_not_ready = 0;
+        return 0;
+      }
+
+  output->profile_state.setup_not_ready =
+    output->profile_state.setup_initialized;
+  return GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION;
+}
+
 GoodixMilanRuntimeOutput *
 goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
 {
@@ -266,6 +296,7 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   GoodixMilanRuntimeOutput *output;
   GoodixMilanPrintTemplateInfo probe_info;
   gsize winner_position = G_MAXSIZE;
+  gint32 setup_status;
   gint32 preprocess_status;
 
   g_return_val_if_fail (input != NULL, NULL);
@@ -300,6 +331,23 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
 
   output->preprocess_state = input->preprocess_state;
   output->profile_state = input->profile_state;
+  setup_status = goodix_milan_runtime_initialize_setup (input, output);
+  if (setup_status != 0)
+    {
+#ifdef GOODIX53X5_DEBUG
+      output->preprocess_attempted =
+        setup_status == GOODIX_MILAN_PREPROCESS_NOT_READY;
+      output->preprocess_status = setup_status;
+      output->preprocess_status_available = TRUE;
+#endif
+      output->preprocess_state_valid = TRUE;
+      output->status = GOODIX_MILAN_RUNTIME_RETRY;
+      g_set_error_literal (&output->error, GOODIX_MILAN_PRINT_ERROR,
+                           GOODIX_MILAN_PRINT_ERROR_INVALID,
+                           "Native Milan setup initialization failed");
+      return output;
+    }
+
   processed = g_malloc (GOODIX_MILAN_SENSOR_PIXELS);
 #ifdef GOODIX53X5_DEBUG
   output->preprocess_attempted = TRUE;

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -306,8 +306,7 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
   if (setup_status != 0)
     {
 #ifdef GOODIX53X5_DEBUG
-      output->preprocess_attempted =
-        setup_status == GOODIX_MILAN_PREPROCESS_NOT_READY;
+      output->preprocess_attempted = TRUE;
       output->preprocess_status = setup_status;
       output->preprocess_status_available = TRUE;
 #endif

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -254,36 +254,6 @@ goodix_milan_runtime_study (const GoodixMilanRuntimeInput *input,
     probe, feature, feature_len, match_result, TRUE, queue, after_study, action);
 }
 
-static gint32
-goodix_milan_runtime_initialize_setup (const GoodixMilanRuntimeInput *input,
-                                       GoodixMilanRuntimeOutput      *output)
-{
-  gboolean setup_required;
-
-  setup_required = !output->profile_state.setup_initialized ||
-                   output->profile_state.setup_refresh_pending;
-  if (!setup_required)
-    return output->profile_state.setup_not_ready ?
-           GOODIX_MILAN_PREPROCESS_NOT_READY : 0;
-
-  output->profile_state.calibration_ready = 0;
-  output->profile_state.setup_refresh_pending = 0;
-  /* Native retries setup once against the same retained frame. */
-  for (guint attempt = 0; attempt < 2; attempt++)
-    if (goodix_milan_preprocess_clamp_and_admit_raw (
-          input->setup_tx_on, GOODIX_MILAN_SENSOR_ROWS,
-          GOODIX_MILAN_SENSOR_COLUMNS, 2, 85))
-      {
-        output->profile_state.setup_initialized = 1;
-        output->profile_state.setup_not_ready = 0;
-        return 0;
-      }
-
-  output->profile_state.setup_not_ready =
-    output->profile_state.setup_initialized;
-  return GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION;
-}
-
 GoodixMilanRuntimeOutput *
 goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
 {
@@ -331,7 +301,8 @@ goodix_milan_runtime_run (const GoodixMilanRuntimeInput *input)
 
   output->preprocess_state = input->preprocess_state;
   output->profile_state = input->profile_state;
-  setup_status = goodix_milan_runtime_initialize_setup (input, output);
+  setup_status = goodix_milan_runtime_initialize_setup (
+    &output->profile_state, input->setup_tx_on);
   if (setup_status != 0)
     {
 #ifdef GOODIX53X5_DEBUG

--- a/drivers/goodix53x5/milan/runtime.h
+++ b/drivers/goodix53x5/milan/runtime.h
@@ -187,6 +187,38 @@ void goodix_milan_runtime_input_set_cancel_check (
   GoodixMilanRuntimeCancelFunc cancel_func,
   gpointer                     user_data,
   GDestroyNotify               destroy);
+static inline gint32
+goodix_milan_runtime_initialize_setup (GoodixMilanProfileState *profile_state,
+                                       guint16                 *setup_tx_on)
+{
+  gboolean setup_required;
+
+  g_return_val_if_fail (profile_state != NULL,
+                        GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION);
+  g_return_val_if_fail (setup_tx_on != NULL,
+                        GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION);
+  setup_required = !profile_state->setup_initialized ||
+                   profile_state->setup_refresh_pending;
+  if (!setup_required)
+    return profile_state->setup_not_ready ?
+           GOODIX_MILAN_PREPROCESS_NOT_READY : 0;
+
+  profile_state->calibration_ready = 0;
+  profile_state->setup_refresh_pending = 0;
+  /* Native retries setup once against the same retained frame. */
+  for (guint attempt = 0; attempt < 2; attempt++)
+    if (goodix_milan_preprocess_clamp_and_admit_raw (
+          setup_tx_on, GOODIX_MILAN_SENSOR_ROWS,
+          GOODIX_MILAN_SENSOR_COLUMNS, 2, 85))
+      {
+        profile_state->setup_initialized = 1;
+        profile_state->setup_not_ready = 0;
+        return 0;
+      }
+
+  profile_state->setup_not_ready = profile_state->setup_initialized;
+  return GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION;
+}
 void goodix_milan_runtime_input_free (GoodixMilanRuntimeInput *input);
 
 GoodixMilanRuntimeOutput *goodix_milan_runtime_run (

--- a/tools/milan-parity/current-runner
+++ b/tools/milan-parity/current-runner
@@ -100,13 +100,19 @@ def main():
     parser.add_argument("--case")
     parser.add_argument("--expected-source-digest")
     parser.add_argument("--expected-backend-sha256")
+    parser.add_argument("--profile-setup-initialized", action="store_true")
+    parser.add_argument("--profile-setup-refresh-pending", action="store_true")
+    parser.add_argument("--profile-setup-not-ready", action="store_true")
     args = parser.parse_args()
     repo = Path(args.repo).resolve()
     tool = Path(__file__).resolve().parent
     if args.identity:
         if (args.corpus is not None or args.case is not None or
                 args.expected_source_digest is not None or
-                args.expected_backend_sha256 is not None):
+                args.expected_backend_sha256 is not None or
+                args.profile_setup_initialized or
+                args.profile_setup_refresh_pending or
+                args.profile_setup_not_ready):
             parser.error("--identity accepts only --repo")
         sys.stdout.buffer.write(canonical(resolve_backend(repo, tool, build=True)))
         return
@@ -146,6 +152,12 @@ def main():
                "--tcode", str(replay["tcode"]), "--dac-high", str(replay["dac_high"]),
                "--dac-low", str(replay["dac_low"]), "--profile", "9", "--subtype", "12"]
     command.extend(("--prelude-count", str(len(prelude))))
+    if args.profile_setup_initialized:
+        command.append("--profile-setup-initialized")
+    if args.profile_setup_refresh_pending:
+        command.append("--profile-setup-refresh-pending")
+    if args.profile_setup_not_ready:
+        command.append("--profile-setup-not-ready")
     for name, frame_purpose in zip(prelude, prelude_purposes):
         command.extend(("--live", str(artifact_path(root, case, name)),
                         "--live-purpose", str(frame_purpose)))

--- a/tools/milan-parity/current/current-runner.c
+++ b/tools/milan-parity/current/current-runner.c
@@ -29,6 +29,9 @@ static gint dac_low;
 static gint profile_number = GOODIX_MILAN_PRINT_PROFILE;
 static gint subtype = GOODIX_MILAN_PRINT_SENSOR_TYPE;
 static gint prelude_count;
+static gboolean profile_setup_initialized;
+static gboolean profile_setup_refresh_pending;
+static gboolean profile_setup_not_ready;
 
 static GOptionEntry options[] = {
   { "case-id", 0, 0, G_OPTION_ARG_STRING, &case_id, "Opaque case ID", "ID" },
@@ -46,6 +49,12 @@ static GOptionEntry options[] = {
   { "subtype", 0, 0, G_OPTION_ARG_INT, &subtype, "sensor subtype", "U16" },
   { "prelude-count", 0, 0, G_OPTION_ARG_INT, &prelude_count,
     "number of preprocessing-only live frames", "COUNT" },
+  { "profile-setup-initialized", 0, 0, G_OPTION_ARG_NONE,
+    &profile_setup_initialized, "seed initialized setup state", NULL },
+  { "profile-setup-refresh-pending", 0, 0, G_OPTION_ARG_NONE,
+    &profile_setup_refresh_pending, "seed pending refresh setup state", NULL },
+  { "profile-setup-not-ready", 0, 0, G_OPTION_ARG_NONE,
+    &profile_setup_not_ready, "seed not-ready setup state", NULL },
   { NULL }
 };
 
@@ -259,6 +268,9 @@ main (int argc, char **argv)
       goto fail;
     }
   goodix_milan_preprocess_reset (&state);
+  profile.setup_initialized = profile_setup_initialized;
+  profile.setup_refresh_pending = profile_setup_refresh_pending;
+  profile.setup_not_ready = profile_setup_not_ready;
 
   for (gsize stage = 0; live_paths[stage]; stage++)
     {

--- a/tools/milan-parity/current/current-runner.c
+++ b/tools/milan-parity/current/current-runner.c
@@ -298,9 +298,12 @@ main (int argc, char **argv)
 
       if (!load_frame (live_paths[stage], live, &error))
         goto fail;
-      preprocess_status = goodix_milan_preprocess (
-        &phase_state, &phase_profile, setup, live, stage_purpose, processed,
-        &quality, &coverage);
+      preprocess_status = goodix_milan_runtime_initialize_setup (
+        &phase_profile, setup);
+      if (preprocess_status == 0)
+        preprocess_status = goodix_milan_preprocess (
+          &phase_state, &phase_profile, setup, live, stage_purpose, processed,
+          &quality, &coverage);
       if (preprocess_status == 0 ||
           preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION)
         processed_hash = hash_data (processed, GOODIX_MILAN_SENSOR_PIXELS);
@@ -319,7 +322,9 @@ main (int argc, char **argv)
           if (preprocess_status != 0 &&
               preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY &&
               preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION &&
-              preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION)
+              preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION &&
+              preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_SETUP_ADMISSION &&
+              preprocess_status != GOODIX_MILAN_PREPROCESS_NOT_READY)
             {
               g_set_error_literal (&error, G_OPTION_ERROR,
                                    G_OPTION_ERROR_FAILED,

--- a/tools/milan-parity/milan_parity_replay.py
+++ b/tools/milan-parity/milan_parity_replay.py
@@ -61,7 +61,7 @@ def _admit(root: Path, source: Path) -> dict[str, Any]:
 def create_case(state: Path, dump: Path, runtime_path: Path, runtime: dict[str, Any],
                 setup: Path, live: Path, prelude: list[tuple[Path, int]],
                 gallery_inputs: list[Path], dll_sha256: str,
-                wine_prefix: Path) -> dict[str, Any]:
+                wine_prefix: Path, profile_seed: dict[str, bool]) -> dict[str, Any]:
     operation = (runtime["capture_session_id"], runtime["action"],
                  runtime["action_epoch_u64"])
     digest = sha256_file(runtime_path)
@@ -122,7 +122,7 @@ def create_case(state: Path, dump: Path, runtime_path: Path, runtime: dict[str, 
               "modes": {"full": [case_id], "quick": [case_id]},
               "policy": RUNNER_POLICY, "schema": CORPUS_SCHEMA}
     write_atomic(root / "corpus.json", canonical(corpus))
-    return {"case_id": case_id, "root": root}
+    return {"case_id": case_id, "profile_seed": profile_seed, "root": root}
 
 
 def _validate_record(value: Any, case_id: str, label: str) -> dict[str, Any]:
@@ -182,12 +182,16 @@ def current_runner_identity(runner: Path, repo: Path) -> dict[str, str]:
 
 def execute_current(runner: Path, repo: Path, case: dict[str, Any],
                     identity: dict[str, str]) -> dict[str, Any]:
-    process = run((str(runner), "--repo", str(repo), "--corpus", str(case["root"]),
-                   "--case", case["case_id"],
-                   "--expected-source-digest", identity["source_digest"],
-                   "--expected-backend-sha256", identity["backend_sha256"]),
-                  "current runner",
-                  stdout=-1, stderr=-1)
+    command = [str(runner), "--repo", str(repo), "--corpus", str(case["root"]),
+               "--case", case["case_id"],
+               "--expected-source-digest", identity["source_digest"],
+               "--expected-backend-sha256", identity["backend_sha256"]]
+    for field, enabled in case["profile_seed"].items():
+        if enabled:
+            command.append(f"--profile-{field.replace('_', '-')}")
+    process = run(tuple(command),
+                   "current runner",
+                   stdout=-1, stderr=-1)
     return _load_stdout(process, case["case_id"], "current runner")
 
 

--- a/tools/milan-parity/milan_parity_validate.py
+++ b/tools/milan-parity/milan_parity_validate.py
@@ -617,13 +617,24 @@ def _profile_seed(runtimes: list[dict[str, Any]],
     generation.sort(key=lambda item: item["runtime"]["generation_use_index_u64"])
     first = generation[0]["runtime"]
     basename = first["artifacts"]["setup_tx_on"]["basename"]
-    marker = re.search(r"-setup-i([01])-r([01])-n([01])-", basename)
+    prefix = (
+        f"runtime-artifact-{first['capture_session_id']}-{first['action']}-"
+        f"{first['action_epoch_u64']}-{first['generation_id_u64']}-"
+        f"{first['stage_u32']}-{first['chronology_u64']}")
+    stamp_crc = r"-?(?:0|[1-9][0-9]*)-[0-9a-f]{8}\.bin"
+    marker = re.fullmatch(
+        re.escape(prefix) +
+        r"-setup-i([01])-r([01])-n([01])-setup_tx_on-" + stamp_crc,
+        basename)
     if marker:
         return {
             "setup_initialized": marker[1] == "1",
             "setup_not_ready": marker[3] == "1",
             "setup_refresh_pending": marker[2] == "1",
         }
+    if not re.fullmatch(
+            re.escape(prefix) + r"-setup_tx_on-" + stamp_crc, basename):
+        raise HarnessError("setup artifact basename differs from producer grammar")
 
     earlier_generation = any(
         item["runtime"]["capture_session_id"] == runtime["capture_session_id"] and

--- a/tools/milan-parity/milan_parity_validate.py
+++ b/tools/milan-parity/milan_parity_validate.py
@@ -349,7 +349,7 @@ def validate_runtime(value: Any, path: Path, match: re.Match[str],
     preprocess_outputs_present = runtime["coverage_i32"] is not None
     if preprocess_outputs_present is not preprocess["attempted"]:
         raise HarnessError(f"preprocess outputs differ from attempt state: {path.name}")
-    if preprocess_status in {0x29AA, 0x29BB} and (
+    if preprocess_status in {0x80, 0x29AA, 0x29BB} and (
             runtime["coverage_i32"] != 0 or runtime["quality_i32"] != 0):
         raise HarnessError(f"early preprocess retry outputs must be zero: {path.name}")
     if preprocess_status == 0xC351 and (

--- a/tools/milan-parity/milan_parity_validate.py
+++ b/tools/milan-parity/milan_parity_validate.py
@@ -600,7 +600,47 @@ def _chronology(runtimes: list[dict[str, Any]]) -> None:
 
 def _preprocess_state_committed(runtime: dict[str, Any]) -> bool:
     return (not runtime["cancellation"]["runtime_observed"] and
-            runtime["preprocess_status_i32"] in {0, 0x29AA, 0x7531, 0xC351})
+            runtime["preprocess_status_i32"] in {
+                0, 0x80, 0x29AA, 0x29BB, 0x7531, 0xC351})
+
+
+def _profile_seed(runtimes: list[dict[str, Any]],
+                  current: dict[str, Any]) -> dict[str, bool]:
+    runtime = current["runtime"]
+    generation = [
+        item for item in runtimes
+        if item["runtime"]["capture_session_id"] == runtime["capture_session_id"] and
+        item["runtime"]["generation_id_u64"] == runtime["generation_id_u64"] and
+        item["runtime"]["artifacts"]["setup_tx_on"]["sha256"] ==
+        runtime["artifacts"]["setup_tx_on"]["sha256"]
+    ]
+    generation.sort(key=lambda item: item["runtime"]["generation_use_index_u64"])
+    first = generation[0]["runtime"]
+    basename = first["artifacts"]["setup_tx_on"]["basename"]
+    marker = re.search(r"-setup-i([01])-r([01])-n([01])-", basename)
+    if marker:
+        return {
+            "setup_initialized": marker[1] == "1",
+            "setup_not_ready": marker[3] == "1",
+            "setup_refresh_pending": marker[2] == "1",
+        }
+
+    earlier_generation = any(
+        item["runtime"]["capture_session_id"] == runtime["capture_session_id"] and
+        item["runtime"]["chronology_u64"] < first["chronology_u64"] and
+        item["runtime"]["generation_id_u64"] != runtime["generation_id_u64"]
+        for item in runtimes)
+    failed_setup = any(
+        item["runtime"]["preprocess_status_i32"] in {0x80, 0x29BB}
+        for item in generation)
+    if earlier_generation and failed_setup:
+        raise HarnessError(
+            "captured refresh setup state predates the exact setup-state marker")
+    return {
+        "setup_initialized": False,
+        "setup_not_ready": False,
+        "setup_refresh_pending": False,
+    }
 
 
 def _prelude(runtimes: list[dict[str, Any]], current: dict[str, Any]) -> list[tuple[Path, int]]:
@@ -883,7 +923,8 @@ def run_validate_dump(args: argparse.Namespace) -> None:
                 prelude = _prelude(runtimes, item)
                 case = create_case(state, dump, item["path"], runtime,
                                    artifacts["setup_tx_on"][0], artifacts["live_raw"][0],
-                                   prelude, gallery_inputs, dll_sha, prefix)
+                                   prelude, gallery_inputs, dll_sha, prefix,
+                                   _profile_seed(runtimes, item))
                 operation["structural_replay_admissibility"].update({
                     "admissible": True, "status": "pass"})
                 pending.append({"case": case, "expected": _capture_projection(runtime),


### PR DESCRIPTION
## Summary

- Separate hardware reference admission from engine setup admission.
- Publish and retain FDT/image-pair-valid references before applying the strict setup sample gate.
- Apply native setup initialization on the first completed sample, including initial retry and one-shot refresh failure lifetime.
- Share that setup transition with direct parity phase/prelude replay so existing captured data remains usable.

## Native contract

For profile 9/type 12, the approved DLL clamps the retained setup frame and accepts only when `100 * valid_count > 85 * 8736`. The adapter retries the same frame once. At 7,425 valid interior pixels it returns `0x29bb`, keeps the hardware reference, emits no processed image or probe, and reports the completed sample as bad capture. At 7,426 it succeeds. A failed refresh consumes the one-shot marker and the later unmarked call returns `0x80`.

Previously Linux applied the same arithmetic during hardware base acquisition. The 7,425 case therefore published no generation, performed no live capture, and entered reference recovery instead of returning the operation result.

## Verification

- Two independent approved-DLL audits confirmed the exact 85-percent instructions, 7,425/7,426 boundary, caller ownership, initial chronology, and refresh chronology.
- Focused initial and refresh target/control comparisons pass on final source: 7,425 publishes the generation then returns `0x29bb` with no processed image/probe; 7,426 completes normally; failed refresh retains the new generation and later returns `0x80`.
- ASan/UBSan focused runs pass.
- Debug-disabled offline production build passes.
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and focused `fpi-device` suites pass 4/4.
- Independent pre-validation correctness, ownership, ABI, dead-state, boundary, and performance review found no production blocker.
- The PR review finding about stale direct parity replay state was fixed by sharing the setup transition. One explicit saved operation from each standing corpus passes current-vs-native comparison; no dump, manifest, schema, selector, or captured result changed.

The full standing 450/643 identify/verify datasets were not run: they contain no setup-admission failure, hardware reference publication, or FDT acquisition chronology and cannot distinguish the corrected owner from the old one. Focused target/control evidence covers the changed condition; one operation from each corpus verifies reader compatibility.

Durable native documentation: `8263ea84192535ff97b80958eae6f3be157a21fc`.

No tests, persisted schemas, debug schemas, or installed ABI were changed.