### PR TITLE
Match Milan mode-one overlap margin

### DIFF
--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -1084,7 +1084,7 @@ goodix_milan_matcher_late_context_derive (
 
 static int32_t
 overlap_margin_type12 (int32_t       accumulated_high_class,
-                       int32_t       probe_low_class,
+                       int32_t       primary_histogram_class,
                        const int32_t metrics[77],
                        int32_t       context_record_count,
                        int32_t       image_quality)
@@ -1097,11 +1097,11 @@ overlap_margin_type12 (int32_t       accumulated_high_class,
     {
       if (metrics[5] < 197 && metrics[8] < 195)
         margin = 20;
-      else if (probe_low_class > 1)
+      else if (primary_histogram_class > 1)
         margin = 15;
+      else if (primary_histogram_class == 1)
+        margin = 13;
       else
-        /* Profile 9 decodes probe_low_class as 0, 2, or 3, so class 1 is
-         * excluded by the caller contract. */
         margin = 10;
     }
   else


### PR DESCRIPTION
## Summary

- Map primary histogram state one to native overlap margin 13.
- Preserve margin 10 for state zero, margin 15 above one, and the existing metric-margin-20 arm.
- Rename the private helper parameter to reflect its actual primary-histogram ownership.

## Native contract

For profile 9/type 12 with accumulated high class two or three and the metric-margin-20 arm false, native `FUN_180058700` maps primary histogram state zero/one/greater-than-one to margins 10/13/15. State one is ordinary producer-reachable through mode-one extraction; it is not the packed probe low class.

Current grouped state one with zero at margin 10. A producer-valid mode-one target reaches state `[2,1,2]` and affine area 8060. Native margin 13 returns policy status one while old current margin 10 returns zero, changing score, study action, candidate publication, after-match gallery, and persisted output.

## Verification

- Two independent approved-DLL agents reproduced the native contract and complete target/control outputs.
- Focused target: corrected current matches native at score 50, study action 4, after-match `bc2f7cf2...`, and candidate `76e09879...`.
- Adjacent area-7840 control remains exact at score 52, study action zero, and no persistence advance.
- Debug-disabled offline production build passes.
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites pass 4/4.
- `git diff --check` passes; no tests or schemas changed.

The standing 450/643 datasets were not run because every frozen probe has primary histogram summary zero and cannot enter the corrected state-one margin arm. The focused target/control exercise the distinguishing condition.

Durable native documentation: `ca3637b20f41291420bf781e7790f97cc512ab48`.