### PR TITLE
Match Milan mode-one classifier boundary

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -319,7 +319,7 @@ milan_profile9_primary_histogram_state (
   int32_t box[256];
   uint8_t state = 0;
 
-  if (clipped->sample_count < 10 || clipped->range <= 0)
+  if (clipped->mode_bin < 10 || clipped->range <= 0)
     return 0;
   milan_profile9_smooth_histogram (
     clipped->histogram, 4, smooth, box);
@@ -330,7 +330,7 @@ milan_profile9_primary_histogram_state (
 
   while (upper < 246 && smooth[upper] >= width_floor)
     upper++;
-  while (lower > 9 && smooth[lower] >= width_floor)
+  while (lower > 10 && smooth[lower] >= width_floor)
     lower--;
   int width = upper - lower;
   if ((width > 180 && clipped->range > 1200) ||


### PR DESCRIPTION
## Summary

- Guard the profile-9 primary histogram classifier with native mode-bin ownership.
- Clamp the lower width search at native bin 10 instead of allowing bin 9.
- Preserve the upper scan and all strict width/range predicates.

## Native contract

Native `FUN_18004e0e0` returns zero when signed `mode_bin < 10` or signed range is nonpositive. Its lower histogram-width scan tests through bin 10 and never returns bin 9.

At a producer-valid strict boundary, native computes lower/upper/width `10/240/230` and summary zero. The previous current code computed `9/240/231` and false summary one. Processed bytes, records, packed class, and serialized probe remain identical, but the summary is separately consumed by matcher policy.

## Observable result

This layer depends on PR #92 for native-correct state-one margin 13. With the false current summary, the target enters area policy at area 8099 while native summary zero returns before area. Old complete outputs differ at policy status, score 50/40, after-match gallery, and persistent candidate.

The adjacent area-7905 control remains status zero and complete-output exact at score 54.

## Verification

- Two independent approved-DLL agents reproduced the classifier instructions, target/control, and complete outputs.
- Corrected target matches native at score 50, study action 4, after-match `e747e998...`, and candidate `4ce0cac9...`.
- Adjacent control remains exact at score 54, study action zero, and no candidate.
- Debug-disabled offline production build passes.
- Existing `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device` suites pass 4/4.
- `git diff --check` passes; no tests or schemas changed.

The standing 450/643 datasets were not run because their maintained frozen producer coverage does not include this strict width-230 mode boundary. Focused target/control evidence exercises the distinguishing condition.

Durable native documentation: `76f6395c71597839d634ab47f031f9e04972fab0`.

Stack parent: #92.