### PR TITLE
Match Milan separable median filter

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -632,25 +632,15 @@ update_gaussian_core (const uint16_t *source,
 }
 
 static uint16_t
-median9 (const uint16_t *values)
+median3 (uint16_t a,
+         uint16_t b,
+         uint16_t c)
 {
-  uint16_t sorted[9];
+  uint16_t lower = a < b ? a : b;
+  uint16_t upper = a > b ? a : b;
+  uint16_t capped = upper < c ? upper : c;
 
-  memcpy (sorted, values, sizeof(sorted));
-  for (size_t i = 1; i < 9; i++)
-    {
-      uint16_t value = sorted[i];
-      size_t j = i;
-
-      while (j > 0 && sorted[j - 1] > value)
-        {
-          sorted[j] = sorted[j - 1];
-          j--;
-        }
-      sorted[j] = value;
-    }
-
-  return sorted[4];
+  return lower > capped ? lower : capped;
 }
 
 static void
@@ -664,16 +654,18 @@ median3x3_core (const uint16_t *source,
     {
       for (size_t column = 1; column + 1 < columns; column++)
         {
-          uint16_t values[9];
-          size_t index = 0;
+          uint16_t row_medians[3];
 
           for (ptrdiff_t row_offset = -1; row_offset <= 1; row_offset++)
-            for (ptrdiff_t column_offset = -1; column_offset <= 1;
-                 column_offset++)
-              values[index++] =
-                source[(row + row_offset) * columns + column + column_offset];
+            {
+              size_t index = (row + row_offset) * columns + column;
 
-          output[row * columns + column] = median9 (values);
+              row_medians[row_offset + 1] =
+                median3 (source[index - 1], source[index], source[index + 1]);
+            }
+
+          output[row * columns + column] =
+            median3 (row_medians[0], row_medians[1], row_medians[2]);
         }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **All-or-nothing stack, layer 2 of 6.** This PR depends on `milan-profile9-setup-border` and must not be reviewed or merged as an isolated complete fix. Review all six layers and merge bottom-to-top only after the whole stack is approved.

## Summary

Match native `FUN_1800637c0` by computing three horizontal medians and then the median of those three values. The previous implementation selected the median of all nine neighborhood samples, which is not equivalent.

## Native parity

On a producer-valid subtype-12 neighborhood, native's separable median is 12000 while rank-nine gives 9000. Native therefore retains Q13 unity gain 8192 under the strict `> 1800` deviation gate instead of producing 10923. The complete target temporary-gain and divisor maps match native after this layer and its parent.

## Validation

- Focused differing/equal median controls passed, including border preservation and tie behavior.
- Aggregate debug-disabled build and existing suites passed.
- Final aggregate strict parity passed 1,401/1,401 operations.
- Durable native documentation: `426fad5a` on `milan-dev`.

Layers 3-6 are still required to close finalized rendering, classification, metadata, and adaptive-mask output.
