### PR TITLE
Match Milan finalized mask coverage

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -170,8 +170,9 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
   uint32_t rounded_mean;
   uint16_t threshold;
   uint16_t valid_percent;
-  uint16_t admitted_percent;
+  uint16_t refined_percent;
   size_t admitted_pixels = 0;
+  size_t refined_pixels = 0;
   uint32_t auxiliary_samples;
   int selected_refined;
   int metadata_mode;
@@ -285,7 +286,9 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
                                         combined_gain);
         }
     }
-  admitted_percent = (uint16_t) (admitted_pixels * 100 / count);
+  for (size_t i = 0; i < count; i++)
+    refined_pixels += contrast_mask[i] != 0;
+  refined_percent = (uint16_t) (refined_pixels * 100 / count);
 
   classification_status = goodix_milan_profile9_build_broken_mask (
     state, difference, setup_map, normalized_live, contrast_mask,
@@ -302,7 +305,7 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
         contrast, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS,
         selection_mask) != 0 ||
       goodix_milan_preprocess_refine (
-        working, contrast_mask, admitted_percent, GOODIX_MILAN_SENSOR_ROWS,
+        working, contrast_mask, refined_percent, GOODIX_MILAN_SENSOR_ROWS,
         GOODIX_MILAN_SENSOR_COLUMNS, refined) != 0 ||
       goodix_milan_preprocess_select_output (
         contrast, refined, selection_mask, GOODIX_MILAN_SENSOR_ROWS,


### PR DESCRIPTION
> [!IMPORTANT]
> **All-or-nothing stack, layer 3 of 6.** This PR depends on both lower layers. It intentionally leaves later native differences unresolved and must not be merged independently. Review and merge the complete stack bottom-to-top.

## Summary

Keep native's two mask counts separate: the pre-finalization count remains the gain-update admission input, while refined rendering uses a fresh count of the finalized contrast mask.

## Native parity

The severe target transitions from pre-finalization count 9504 to finalized count 1311, so refined rendering receives 13%, not 100%. The adjacent rendered control transitions to 1312 and also receives 13%. This restores native's refined-render bytes without changing gain-update admission.

## Validation

- Focused 1,311 target, 1,312 rendered control, and 1,310 admission control passed.
- Aggregate debug-disabled build and existing suites passed.
- Final aggregate strict parity passed 1,401/1,401 operations.
- Added cost is one fixed 9,504-byte mask scan; aggregate review found no performance blocker.
- Durable native documentation: `426fad5a` on `milan-dev`.

Layers 4-6 remain required for exact class and metadata output.
