### PR TITLE
Match Milan positive severe seeds

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -1614,11 +1614,14 @@ goodix_milan_profile9_build_broken_mask (
     grow_threshold = 350;
 
   memset (broken_mask, 0, count);
-  for (size_t i = 0; i < count; i++)
-    broken_mask[i] = scores[i] >= seed_threshold ? UINT8_MAX : 0;
-  milan_profile9_flood (
-    (const int16_t *) scores, (int16_t) grow_threshold,
-    rows, columns, broken_mask);
+  if (score_count != 0)
+    {
+      for (size_t i = 0; i < count; i++)
+        broken_mask[i] = scores[i] >= seed_threshold ? UINT8_MAX : 0;
+      milan_profile9_flood (
+        (const int16_t *) scores, (int16_t) grow_threshold,
+        rows, columns, broken_mask);
+    }
   size_t selected = 0;
   for (size_t i = 0; i < count; i++)
     selected += broken_mask[i] != 0;

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -27,7 +27,7 @@
 #define PIXELS GOODIX_MILAN_SENSOR_PIXELS
 
 static const char accepted_preprocess_sha256[] =
-  "3d70fb014ec834a23c51e6838ac56b0aec9683152be93e175d4db73aebb3475c";
+  "4882d43dd7208d554362fa832c7f6a5f9b3f79b382099d3d81efc702120c6b5e";
 static const char post_render_retry_sha256[] =
   "8b9629cb2aa7bf3d44a13c9ab087b961e02adf29644c237032597bf24401d943";
 static const char feature_extraction_sha256[] =
@@ -162,7 +162,7 @@ test_preprocess_accepted (void)
     state->profile9_class_counts.profile9_class3_count,
     state->primary_contrast_valid, digest);
 
-  g_assert_cmpint (status, ==, GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION);
+  g_assert_cmpint (status, ==, 0);
   g_assert_cmpint (quality, ==, 0);
   g_assert_cmpint (coverage, ==, 0);
   g_assert_cmpint (state->selected_refined, ==, 0);
@@ -172,10 +172,10 @@ test_preprocess_accepted (void)
   g_assert_cmpuint (state->auxiliary_sample_count, ==, 1);
   g_assert_cmpuint (state->profile9_history_count, ==, 1);
   g_assert_cmpuint (state->profile9_history_update_count, ==, 1);
-  g_assert_cmpuint (state->profile9_class_counts.profile9_class1_count, ==, 0);
-  g_assert_cmpuint (state->profile9_class_counts.profile9_class2_count, ==, 0);
-  g_assert_cmpuint (state->profile9_class_counts.profile9_class3_count, ==,
+  g_assert_cmpuint (state->profile9_class_counts.profile9_class1_count, ==,
                     PIXELS);
+  g_assert_cmpuint (state->profile9_class_counts.profile9_class2_count, ==, 0);
+  g_assert_cmpuint (state->profile9_class_counts.profile9_class3_count, ==, 0);
   g_assert_cmpint (state->primary_contrast_valid, ==, 1);
   g_assert_cmpstr (digest, ==, accepted_preprocess_sha256);
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **All-or-nothing stack, layer 4 of 6.** This layer depends on the three lower preprocessing corrections and is not a complete standalone fix. Review all six PRs together and merge only bottom-to-top after full-stack approval.

## Summary

Match native's severe class-3 seed behavior when no positive score is below the configured ceiling. Native clears the seed mask and skips seed assignment/flooding; the previous zero threshold selected every zero score.

## Native parity

The 1,311 target now starts with zero seeds and produces native class counts `2324/0/0/7180` and exact class-plane SHA-256 `e7dada410f8ca6b4521396f6e6a2d6af683ce5df71bbb4a53ef56190617d6da0`. The 1,312 control produces 7,179 class-3 pixels; the 1,310 admission control remains unchanged.

## Validation

- Focused seed, component-input, class-plane, and adjacent-control proof passed.
- Aggregate debug-disabled build and existing suites passed.
- Final aggregate strict parity passed 1,401/1,401 operations.
- Durable native documentation: `426fad5a` on `milan-dev`.

Ordered metadata and the independently owned adaptive empty-population path remain in layers 5 and 6.
