### PR TITLE
Trim Milan score helper contracts

### DIFF
--- a/drivers/goodix53x5/milan/match/score.c
+++ b/drivers/goodix53x5/milan/match/score.c
@@ -12,12 +12,12 @@
 
 int32_t
 goodix_milan_match_secondary_result (int32_t primary_score,
-                                             int32_t secondary_score,
-                                             int32_t secondary_detail)
+                                     int32_t secondary_score,
+                                     int32_t secondary_detail)
 {
-  return secondary_score > primary_score && secondary_detail > 195
-           ? secondary_score
-           : primary_score;
+  return secondary_score > primary_score && secondary_detail > 195 ?
+         secondary_score :
+         primary_score;
 }
 
 int
@@ -36,20 +36,15 @@ goodix_milan_match_overlap_result (
   int32_t raw_score;
   int32_t quality;
 
-  if (!classes || !weights || !score || valid_count < 0 || full_count <= 0 ||
-      classes[0] < 0 || classes[1] < 0 || classes[2] < 0 || classes[3] < 0 ||
-      (int64_t) classes[0] + classes[1] + classes[2] + classes[3] !=
-        valid_count)
-    return -1;
   if (coverage)
     *coverage = (full_count / 2 + valid_count * 0x100) / full_count;
   if (detail)
     {
       int32_t non_match_total = classes[0] + classes[1] + classes[2];
-      int32_t result = non_match_total > 0
-                         ? (non_match_total / 2 + classes[0] * 0x100) /
-                             (non_match_total + 1)
-                         : 0;
+      int32_t result = non_match_total > 0 ?
+                       (non_match_total / 2 + classes[0] * 0x100) /
+                       (non_match_total + 1) :
+                       0;
       int32_t match_fraction =
         (valid_count / 2 + classes[3] * 0x100) / (valid_count + 1);
 
@@ -59,8 +54,6 @@ goodix_milan_match_overlap_result (
     }
   if (mode != 0)
     {
-      if (!context_confidence)
-        return -1;
       if (*context_confidence < 0)
         *context_confidence = classes[3] * 0x100 /
                               (classes[1] + classes[2] + classes[3] + 1);
@@ -75,33 +68,33 @@ goodix_milan_match_overlap_result (
                 (valid_count / 2 + classes[0] * 0x100) / valid_count;
   else
     raw_score = (valid_count / 2 + classes[0] * 0x100) /
-                  (valid_count + 1) +
+                (valid_count + 1) +
                 valid_count * 19 / (full_count / 2) + weights[1] + 19;
   quality = (valid_count / 2 + classes[3] * 0x100) / valid_count + weights[2];
   if (mode == 0)
     {
-      *score = quality > 23 || (raw_score > 230 && quality > 16)
-                 ? raw_score
-                 : 128;
+      *score = quality > 23 || (raw_score > 230 && quality > 16) ?
+               raw_score :
+               128;
       return 0;
     }
   *score = quality > 23 ||
-             (quality > 18 && *context_confidence > 62) ||
-             (quality > 19 && *context_confidence > 50) ||
-             (quality > 17 && ((*context_confidence > 40 &&
-                                 context_count > 7) ||
-                                context_count > 8)) ||
-             (raw_score > 230 && quality > 16)
-             ? raw_score
-             : 128;
+           (quality > 18 && *context_confidence > 62) ||
+           (quality > 19 && *context_confidence > 50) ||
+           (quality > 17 && ((*context_confidence > 40 &&
+                              context_count > 7) ||
+                             context_count > 8)) ||
+           (raw_score > 230 && quality > 16) ?
+           raw_score :
+           128;
   return 0;
 }
 
 int
 goodix_milan_match_final_score (const int32_t metrics[15],
-                                       uint32_t      template_type,
-                                       int           alternate_policy,
-                                       int32_t      *score)
+                                uint32_t      template_type,
+                                int           alternate_policy,
+                                int32_t      *score)
 {
   int32_t detail;
   int32_t low_detail;
@@ -110,8 +103,6 @@ goodix_milan_match_final_score (const int32_t metrics[15],
   int32_t coverage;
   int32_t denominator = 31;
 
-  if (!metrics || !score)
-    return -1;
   *score = 0;
   if (template_type < 23 &&
       ((0x413000U >> (template_type & 31)) & 1) != 0)
@@ -140,7 +131,7 @@ goodix_milan_match_final_score (const int32_t metrics[15],
         }
       if (filtered_count < 8 ||
           detail + low_detail -
-            (metrics[12] + metrics[13] + metrics[14]) * 4 < 417 ||
+          (metrics[12] + metrics[13] + metrics[14]) * 4 < 417 ||
           coverage < 96)
         return 0;
     }
@@ -176,27 +167,5 @@ goodix_milan_match_final_score (const int32_t metrics[15],
 
   *score = ((((denominator >> 1) + filtered_count * 256) / denominator) *
             100) >> 8;
-  return 0;
-}
-
-int
-goodix_milan_match_select_first_positive (const int32_t *scores,
-                                            size_t         score_count,
-                                            size_t        *matched_index,
-                                            int32_t       *selected_score)
-{
-  if (!scores || score_count == 0 || !matched_index || !selected_score)
-    return -1;
-
-  *matched_index = SIZE_MAX;
-  for (size_t i = 0; i < score_count; i++)
-    {
-      *selected_score = scores[i];
-      if (scores[i] > 0)
-        {
-          *matched_index = i;
-          break;
-        }
-    }
   return 0;
 }

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -1031,12 +1031,6 @@ int goodix_milan_match_final_score (
   int           alternate_policy,
   int32_t      *score);
 
-int goodix_milan_match_select_first_positive (
-  const int32_t *scores,
-  size_t         score_count,
-  size_t        *matched_index,
-  int32_t       *selected_score);
-
 typedef struct
 {
   uint32_t sensor_type;

--- a/tests/test-goodix53x5-milan-synthetic.c
+++ b/tests/test-goodix53x5-milan-synthetic.c
@@ -260,34 +260,6 @@ test_preprocess_post_render_retry (void)
   g_assert_cmpstr (digest, ==, post_render_retry_sha256);
 }
 
-static void
-test_first_positive (void)
-{
-  static const struct
-  {
-    int32_t scores[4];
-    size_t count;
-    size_t index;
-    int32_t score;
-  } cases[] = {
-    { { 23, -1, 45, 0 }, 3, 0, 23 },
-    { { -4, 0, 17, 99 }, 4, 2, 17 },
-    { { -4, 0, -7, 0 }, 3, SIZE_MAX, -7 },
-  };
-
-  for (size_t i = 0; i < G_N_ELEMENTS (cases); i++)
-    {
-      size_t index = 0;
-      int32_t score = 0;
-
-      g_assert_cmpint (goodix_milan_match_select_first_positive (
-                         cases[i].scores, cases[i].count, &index, &score),
-                       ==, 0);
-      g_assert_cmpuint (index, ==, cases[i].index);
-      g_assert_cmpint (score, ==, cases[i].score);
-    }
-}
-
 typedef struct
 {
   const char *name;
@@ -1182,7 +1154,6 @@ main (int argc,
                     test_preprocess_classification_retry);
   g_test_add_func ("/goodix53x5/milan/preprocess-post-render-retry",
                    test_preprocess_post_render_retry);
-  g_test_add_func ("/goodix53x5/milan/first-positive", test_first_positive);
   g_test_add_func ("/goodix53x5/milan/selection", test_selection_rows);
   g_test_add_func ("/goodix53x5/milan/gain-tail", test_gain_tail);
   g_test_add_func ("/goodix53x5/milan/generated-extraction",


### PR DESCRIPTION
## Summary

Trim the internal Milan score surface before the readability refactor above it.

- Remove fail-closed pointer, count, and class-total checks from two internal score helpers. Every production caller supplies nonnull outputs, fixed positive geometry, and classifier-produced nonnegative classes whose sum is the valid count; native trusts the same inputs.
- Remove `goodix_milan_match_select_first_positive()`, which had no production caller and only duplicated the ordered arbitration already implemented and exercised through the runtime path.
- Reduce the stack's base by 66 net lines across `score.c`, `milan.h`, and the redundant synthetic helper test.

No reachable production behavior change is intended. Malformed direct calls to these internal helpers no longer return `-1`; like native, they may fault or consume malformed values.

## Native quirks preserved

- Optional overlap coverage and detail are still published before nonzero-mode confidence and score (`FUN_1800717e0`).
- A zero-valid overlap still initializes a negative confidence to zero, publishes score 128, and avoids reading weights (`FUN_1800717e0`, `FUN_1800731d0`).
- Gallery arbitration still stops at the first signed positive score, while an all-nonpositive result retains the final score (`identifyImage`); the production runtime test continues to cover this path.

## Evidence

- Caller proof: all repository callers enumerated; overlap inputs come directly from `goodix_milan_match_bitmap_classes()` with fixed `44 * 52` area and nonnull stack/output storage; final-score callers pass live 15/77-word vectors and nonnull score storage.
- Direct Ghidra revalidation: `FUN_1800717e0`, `FUN_1800731d0`, `FUN_1800740f0`, `FUN_1800608b0`, `FUN_180071d40`, and `identifyImage` confirm the trusted internal inputs, output ordering, strict secondary selector, final-score policy, and ordered gallery arbitration recorded in the existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 600,000 valid-domain cases against `origin/main`, 0 mismatches; optional outputs, modes, zero-valid inputs, reused confidence, template types, both policies, and output aliases covered. ASan/UBSan clean. A `> 195` to `>= 195` mutant was caught in 444 cases.
- Suites: debug-disabled build and Milan synthetic/state/runtime suites pass.
- Final stack `--compare-current`: 26/26, later durable 119/119, premerge 454/454, readiness 643/643; 1,242/1,242 total, source identity `2abcee17fd13506fe5afc62348ebef8112a60f4c3e209125a4e0b77b9824410c`.

## Follow-ups (not in this PR)

- The next PR names the retained metric slots, Q8 scale, score sentinels, and final-policy paths in `score.c`.
