### PR TITLE
Name Milan score policy inputs

### DIFF
--- a/drivers/goodix53x5/milan/match/score.c
+++ b/drivers/goodix53x5/milan/match/score.c
@@ -10,6 +10,40 @@
 
 #include "milan/milan.h"
 
+/* Finalizes overlap and candidate scores recovered from FUN_1800717e0,
+ * FUN_1800731d0, FUN_1800740f0, and FUN_1800608b0. */
+enum {
+  OVERLAP_CLASS_ZERO = 0,
+  OVERLAP_CLASS_ONE = 1,
+  OVERLAP_CLASS_TWO = 2,
+  OVERLAP_CLASS_MATCH = 3,
+};
+
+enum {
+  OVERLAP_WEIGHT_HIGH_VALID = 0,
+  OVERLAP_WEIGHT_LOW_VALID = 1,
+  OVERLAP_WEIGHT_QUALITY = 2,
+};
+
+enum {
+  MATCH_METRIC_PRIMARY_COUNT = 0,
+  MATCH_METRIC_RETAINED_COUNT = 1,
+  MATCH_METRIC_OVERLAP_SCORE = 4,
+  MATCH_METRIC_OVERLAP_DETAIL = 5,
+  MATCH_METRIC_LOW_BITMAP_DETAIL = 8,
+  MATCH_METRIC_OVERLAP_COVERAGE = 9,
+  MATCH_METRIC_GEOMETRIC_PERCENT = 11,
+  MATCH_METRIC_SCALE_PENALTY = 12,
+  MATCH_METRIC_ORTHOGONALITY_PENALTY = 13,
+  MATCH_METRIC_STRONG_ORTHOGONALITY_PENALTY = 14,
+};
+
+#define MATCH_Q8_ONE 0x100
+#define OVERLAP_REJECTED_SCORE 128
+#define EXTENDED_DENOMINATOR_TYPE_MASK 0x413000U
+#define FINAL_SCORE_DEFAULT_DENOMINATOR 31
+#define FINAL_SCORE_EXTENDED_DENOMINATOR 42
+
 int32_t
 goodix_milan_match_secondary_result (int32_t primary_score,
                                      int32_t secondary_score,
@@ -37,16 +71,20 @@ goodix_milan_match_overlap_result (
   int32_t quality;
 
   if (coverage)
-    *coverage = (full_count / 2 + valid_count * 0x100) / full_count;
+    *coverage = (full_count / 2 + valid_count * MATCH_Q8_ONE) / full_count;
   if (detail)
     {
-      int32_t non_match_total = classes[0] + classes[1] + classes[2];
+      int32_t non_match_total = classes[OVERLAP_CLASS_ZERO] +
+                                classes[OVERLAP_CLASS_ONE] +
+                                classes[OVERLAP_CLASS_TWO];
       int32_t result = non_match_total > 0 ?
-                       (non_match_total / 2 + classes[0] * 0x100) /
+                       (non_match_total / 2 +
+                        classes[OVERLAP_CLASS_ZERO] * MATCH_Q8_ONE) /
                        (non_match_total + 1) :
                        0;
       int32_t match_fraction =
-        (valid_count / 2 + classes[3] * 0x100) / (valid_count + 1);
+        (valid_count / 2 + classes[OVERLAP_CLASS_MATCH] * MATCH_Q8_ONE) /
+        (valid_count + 1);
 
       if (match_fraction < 15)
         result -= ((15 - match_fraction) >> 1) + 3;
@@ -55,27 +93,40 @@ goodix_milan_match_overlap_result (
   if (mode != 0)
     {
       if (*context_confidence < 0)
-        *context_confidence = classes[3] * 0x100 /
-                              (classes[1] + classes[2] + classes[3] + 1);
+        {
+          *context_confidence = classes[OVERLAP_CLASS_MATCH] * MATCH_Q8_ONE /
+                                (classes[OVERLAP_CLASS_ONE] +
+                                 classes[OVERLAP_CLASS_TWO] +
+                                 classes[OVERLAP_CLASS_MATCH] + 1);
+        }
     }
   if (valid_count == 0)
     {
-      *score = 128;
+      *score = OVERLAP_REJECTED_SCORE;
       return 0;
     }
   if (full_count / 2 < valid_count)
-    raw_score = weights[0] + 38 +
-                (valid_count / 2 + classes[0] * 0x100) / valid_count;
+    {
+      raw_score = weights[OVERLAP_WEIGHT_HIGH_VALID] + 38 +
+                  (valid_count / 2 +
+                   classes[OVERLAP_CLASS_ZERO] * MATCH_Q8_ONE) / valid_count;
+    }
   else
-    raw_score = (valid_count / 2 + classes[0] * 0x100) /
-                (valid_count + 1) +
-                valid_count * 19 / (full_count / 2) + weights[1] + 19;
-  quality = (valid_count / 2 + classes[3] * 0x100) / valid_count + weights[2];
+    {
+      raw_score = (valid_count / 2 +
+                   classes[OVERLAP_CLASS_ZERO] * MATCH_Q8_ONE) /
+                  (valid_count + 1) +
+                  valid_count * 19 / (full_count / 2) +
+                  weights[OVERLAP_WEIGHT_LOW_VALID] + 19;
+    }
+  quality = (valid_count / 2 +
+             classes[OVERLAP_CLASS_MATCH] * MATCH_Q8_ONE) / valid_count +
+            weights[OVERLAP_WEIGHT_QUALITY];
   if (mode == 0)
     {
       *score = quality > 23 || (raw_score > 230 && quality > 16) ?
                raw_score :
-               128;
+               OVERLAP_REJECTED_SCORE;
       return 0;
     }
   *score = quality > 23 ||
@@ -86,7 +137,7 @@ goodix_milan_match_overlap_result (
                              context_count > 8)) ||
            (raw_score > 230 && quality > 16) ?
            raw_score :
-           128;
+           OVERLAP_REJECTED_SCORE;
   return 0;
 }
 
@@ -96,76 +147,87 @@ goodix_milan_match_final_score (const int32_t metrics[15],
                                 int           alternate_policy,
                                 int32_t      *score)
 {
-  int32_t detail;
-  int32_t low_detail;
+  int32_t overlap_detail;
+  int32_t low_bitmap_detail;
   int32_t combined_detail;
-  int32_t filtered_count;
-  int32_t coverage;
-  int32_t denominator = 31;
+  int32_t retained_count;
+  int32_t overlap_coverage;
+  int32_t score_denominator = FINAL_SCORE_DEFAULT_DENOMINATOR;
 
   *score = 0;
   if (template_type < 23 &&
-      ((0x413000U >> (template_type & 31)) & 1) != 0)
-    denominator = 42;
+      ((EXTENDED_DENOMINATOR_TYPE_MASK >> (template_type & 31)) & 1) != 0)
+    score_denominator = FINAL_SCORE_EXTENDED_DENOMINATOR;
 
-  filtered_count = metrics[1];
-  detail = metrics[5];
-  low_detail = metrics[8];
-  coverage = metrics[9];
+  retained_count = metrics[MATCH_METRIC_RETAINED_COUNT];
+  overlap_detail = metrics[MATCH_METRIC_OVERLAP_DETAIL];
+  low_bitmap_detail = metrics[MATCH_METRIC_LOW_BITMAP_DETAIL];
+  overlap_coverage = metrics[MATCH_METRIC_OVERLAP_COVERAGE];
   if (template_type == 21 || template_type == 11)
     {
-      int32_t penalty = metrics[12] + metrics[13] + metrics[14] +
-                        (metrics[0] < 5);
+      int32_t penalty = metrics[MATCH_METRIC_SCALE_PENALTY] +
+                        metrics[MATCH_METRIC_ORTHOGONALITY_PENALTY] +
+                        metrics[MATCH_METRIC_STRONG_ORTHOGONALITY_PENALTY] +
+                        (metrics[MATCH_METRIC_PRIMARY_COUNT] < 5);
 
-      detail -= penalty * 3;
-      low_detail -= penalty * 3;
+      overlap_detail -= penalty * 3;
+      low_bitmap_detail -= penalty * 3;
     }
-  combined_detail = detail + low_detail;
+  combined_detail = overlap_detail + low_bitmap_detail;
 
   if (alternate_policy)
     {
-      if (metrics[0] < filtered_count)
+      if (metrics[MATCH_METRIC_PRIMARY_COUNT] < retained_count)
         {
-          detail -= 2;
-          low_detail -= 2;
+          overlap_detail -= 2;
+          low_bitmap_detail -= 2;
         }
-      if (filtered_count < 8 ||
-          detail + low_detail -
-          (metrics[12] + metrics[13] + metrics[14]) * 4 < 417 ||
-          coverage < 96)
+      if (retained_count < 8 ||
+          overlap_detail + low_bitmap_detail -
+          (metrics[MATCH_METRIC_SCALE_PENALTY] +
+           metrics[MATCH_METRIC_ORTHOGONALITY_PENALTY] +
+           metrics[MATCH_METRIC_STRONG_ORTHOGONALITY_PENALTY]) * 4 < 417 ||
+          overlap_coverage < 96)
         return 0;
     }
   else if (template_type == 21 || template_type == 11)
     {
-      if (((metrics[0] < 5 || filtered_count < 8 || combined_detail < 425 ||
-            metrics[11] < 42) &&
-           (metrics[0] < 3 || metrics[4] < 235 || coverage < 120 ||
+      if (((metrics[MATCH_METRIC_PRIMARY_COUNT] < 5 || retained_count < 8 ||
+            combined_detail < 425 ||
+            metrics[MATCH_METRIC_GEOMETRIC_PERCENT] < 42) &&
+           (metrics[MATCH_METRIC_PRIMARY_COUNT] < 3 ||
+            metrics[MATCH_METRIC_OVERLAP_SCORE] < 235 ||
+            overlap_coverage < 120 ||
             combined_detail < 400)) &&
-          (metrics[0] < 6 || coverage < 61 || combined_detail < 415 ||
-           metrics[11] < 41))
+          (metrics[MATCH_METRIC_PRIMARY_COUNT] < 6 ||
+           overlap_coverage < 61 || combined_detail < 415 ||
+           metrics[MATCH_METRIC_GEOMETRIC_PERCENT] < 41))
         return 0;
-      *score = (((filtered_count * 256 + 15) / 31) * 100) >> 8;
+      *score = (((retained_count * MATCH_Q8_ONE + 15) /
+                 FINAL_SCORE_DEFAULT_DENOMINATOR) * 100) >> 8;
       return 0;
     }
   else
     {
-      int weak_first = detail < 226 || low_detail < 176 ||
-                       coverage < 91;
-      int weak_second = detail < 218 || low_detail < 176 ||
-                        coverage < 121;
-      int weak_seven = filtered_count < 7 || detail < 216 ||
-                       low_detail < 176 || coverage < 121;
-      int weak_eight = filtered_count < 8 || detail < 209 ||
-                       low_detail < 191 || coverage < 106;
-      int weak_nine = filtered_count < 9 || combined_detail < 416 || coverage < 41;
+      int five_strict = retained_count >= 5 && overlap_detail >= 226 &&
+                        low_bitmap_detail >= 176 && overlap_coverage >= 91;
+      int five_balanced = retained_count >= 5 && overlap_detail >= 218 &&
+                          low_bitmap_detail >= 176 && overlap_coverage >= 121;
+      int seven_balanced = retained_count >= 7 && overlap_detail >= 216 &&
+                           low_bitmap_detail >= 176 && overlap_coverage >= 121;
+      int eight_low_detail = retained_count >= 8 && overlap_detail >= 209 &&
+                             low_bitmap_detail >= 191 && overlap_coverage >= 106;
+      int nine_combined = retained_count >= 9 && combined_detail >= 416 &&
+                          overlap_coverage >= 41;
+      int eight_combined = retained_count >= 8 && combined_detail >= 426 &&
+                           overlap_coverage >= 41;
 
-      if ((filtered_count < 5 || (weak_first && weak_second)) &&
-          weak_seven && weak_eight && weak_nine &&
-          (filtered_count < 8 || combined_detail < 426 || coverage < 41))
+      if (!(five_strict || five_balanced || seven_balanced ||
+            eight_low_detail || nine_combined || eight_combined))
         return 0;
     }
 
-  *score = ((((denominator >> 1) + filtered_count * 256) / denominator) *
-            100) >> 8;
+  *score = ((((score_denominator >> 1) + retained_count * MATCH_Q8_ONE) /
+             score_denominator) * 100) >> 8;
   return 0;
 }


### PR DESCRIPTION
## Summary

Make `drivers/goodix53x5/milan/match/score.c` readable without decomposing a small file into helper boilerplate.

- Add a compact native-owner header for `FUN_1800717e0`, `FUN_1800731d0`, `FUN_1800740f0`, and `FUN_1800608b0`.
- Name overlap class and weight slots, the final-score metric slots, Q8 scale, rejected-score sentinel, denominator mask, and denominator values.
- Rename the final-score working values by domain and express the generic policy as six named positive acceptance paths instead of inverted weak predicates.
- Keep the complete two-PR stack four lines smaller than `main`.

No behavioral change is intended.

## Native quirks preserved

- Secondary replacement remains strict: secondary score must be greater and secondary detail must be greater than 195; ties retain primary (`FUN_180071d40`).
- Coverage still divides by full count, while detail and match fraction retain their distinct `+1` denominators (`FUN_1800717e0`).
- Nonzero-mode confidence is initialized only when negative and remains shared across primary/secondary passes (`FUN_1800717e0`).
- Alternate policy still takes precedence over type-11/21 policy; the denominator-42 mask still selects only types 12, 13, 16, and 22 (`FUN_1800608b0`).
- Type-11/21 scoring keeps its special `+15` numerator; all other accepted paths round by half the selected denominator before multiplying by 100 (`FUN_1800608b0`).
- All arithmetic widths, operation order, signed comparisons, strict/equality boundaries, output writes, and short-circuit ordering are unchanged.

## Evidence

- Direct Ghidra revalidation: disassembly/decompilation of `FUN_1800717e0`, `FUN_1800731d0`, `FUN_1800740f0`, `FUN_1800608b0`, and `FUN_180071d40` confirms the ordering, strict predicates, metric slots, mask, denominator selection, and six generic acceptance paths recorded in the existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 600,000 cases against the parent PR, 0 mismatches; optional outputs, modes, zero-valid inputs, reused confidence, template types, both policies, and output aliases covered. ASan/UBSan clean. A generic-policy `>= 226` to `>= 225` mutant was caught in 32 cases.
- Formatting: libfprint `uncrustify` check passes and is idempotent.
- Suites: final debug-disabled build and Milan synthetic/state/runtime suites pass.
- `--compare-current`: 26/26, later durable 119/119, premerge 454/454, readiness 643/643; 1,242/1,242 total, source identity `2abcee17fd13506fe5afc62348ebef8112a60f4c3e209125a4e0b77b9824410c`.

## Follow-ups (not in this PR)

- Broader matcher policy/configuration slot naming remains separate from this file-level refactor.
