### PR TITLE
Consolidate Milan transform API

### DIFF
--- a/drivers/goodix53x5/milan/match/geometry.c
+++ b/drivers/goodix53x5/milan/match/geometry.c
@@ -11,6 +11,7 @@
 #include "milan/match/geometry.h"
 #include "milan/match/correspondence.h"
 #include "milan/private.h"
+#include "milan/relations.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -1010,7 +1011,7 @@ goodix_milan_refine_record_similarity (
 
   if (enrolled_partition > enrolled_record_count ||
       probe_partition > probe_record_count || search_radius < 0 ||
-      milan_invert_transform (transform, inverse) != 0)
+      goodix_milan_transform_invert (transform, inverse) != 0)
     return -1;
   for (size_t partition = 0; partition < 2; partition++)
     {

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -1414,7 +1414,7 @@ milan_match_prepared_probe (
             {
               diagnostics->descriptor_score = reverse_descriptor_score;
               diagnostics->filtered_count = (int32_t) reverse_filtered_count;
-              if (milan_invert_transform (
+               if (goodix_milan_transform_invert (
                     reverse_transform, reverse_forward_transform) == 0)
                 memcpy (diagnostics->transform, reverse_forward_transform,
                         sizeof(diagnostics->transform));
@@ -1445,7 +1445,7 @@ milan_match_prepared_probe (
                 {
                   memcpy (diagnostics->feature_metrics[feature_index][1],
                           reverse_metrics, 15 * sizeof(*reverse_metrics));
-                  if (milan_invert_transform (
+                   if (goodix_milan_transform_invert (
                         reverse_transform, reverse_forward_transform) == 0)
                     memcpy (diagnostics->feature_transforms[feature_index][1],
                             reverse_forward_transform,
@@ -1456,7 +1456,7 @@ milan_match_prepared_probe (
                     reverse_metrics, feature.fields.tagged_values[3],
                     feature.fields.tagged_values[4], matcher_policy.configuration,
                     &reverse_match_flag, &reverse_candidate_flag, NULL) == 0 &&
-                  milan_invert_transform (
+                   goodix_milan_transform_invert (
                     reverse_transform, reverse_forward_transform) == 0)
                 {
 #ifdef GOODIX53X5_DEBUG

--- a/drivers/goodix53x5/milan/private.h
+++ b/drivers/goodix53x5/milan/private.h
@@ -69,11 +69,6 @@ int goodix_milan_feature_extract_records_mode_masked (
   const uint8_t            *broken_mask,
   uint8_t                  *validity_mask,
   int                       high_class);
-void milan_compose_transform (const int32_t first[6],
-                              const int32_t second[6],
-                              int32_t       output[6]);
-int milan_invert_transform (const int32_t transform[6],
-                            int32_t       inverse[6]);
 int goodix_milan_template_patch_feature_scalar (uint8_t *feature_element,
                                 size_t   feature_element_size,
                                 uint8_t  tag,

--- a/drivers/goodix53x5/milan/relations.c
+++ b/drivers/goodix53x5/milan/relations.c
@@ -58,7 +58,7 @@ goodix_milan_template_reference_transform (
   milan_template_relation_transform (
     unpacked, feature_index, reference, relation);
   if ((feature_index > reference) == reverse_above_reference)
-    return milan_invert_transform (relation, transform);
+    return goodix_milan_transform_invert (relation, transform);
   memcpy (transform, relation, sizeof(relation));
   return 0;
 }

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -690,7 +690,7 @@ milan_study_policy_derive (
           if (other == i || input->features[other].active == 0 ||
               input->features[other].state == 5)
             continue;
-          milan_compose_transform (
+          goodix_milan_transform_compose (
             reference_to_features[other], relation_transform, footprint);
           footprint[2] >>= 1;
           footprint[5] >>= 1;
@@ -702,7 +702,7 @@ milan_study_policy_derive (
       if (feature->uncovered_probe_residual < 20)
         feature->uncovered_probe_residual = 0;
 
-      milan_compose_transform (
+      goodix_milan_transform_compose (
         reference_to_features[i], relation_transform, candidate_transform);
       candidate_transform[2] >>= 1;
       candidate_transform[5] >>= 1;

--- a/drivers/goodix53x5/milan/template/lifecycle.c
+++ b/drivers/goodix53x5/milan/template/lifecycle.c
@@ -10,6 +10,7 @@
 
 #include "milan/milan.h"
 #include "milan/private.h"
+#include "milan/relations.h"
 #include "milan/template/codec-private.h"
 #include "milan/template/normalization.h"
 
@@ -252,7 +253,7 @@ goodix_milan_template_normalize_unpacked (
               if (goodix_milan_template_reference_transform (
                     unpacked, other_index, 1, other_transform) != 0)
                 return -1;
-              milan_compose_transform (
+              goodix_milan_transform_compose (
                 other_transform, current_transform, footprint_transform);
               footprint_transform[2] = goodix_milan_template_normalization_sar1 (
                 footprint_transform[2]);

--- a/drivers/goodix53x5/milan/transform.c
+++ b/drivers/goodix53x5/milan/transform.c
@@ -174,17 +174,3 @@ goodix_milan_transform_route (const int32_t stored[6],
   else
     memmove (routed, direct, 6 * sizeof(*routed));
 }
-
-void
-milan_compose_transform (const int32_t first[6],
-                          const int32_t second[6],
-                          int32_t       output[6])
-{
-  goodix_milan_transform_compose (first, second, output);
-}
-
-int
-milan_invert_transform (const int32_t transform[6], int32_t inverse[6])
-{
-  return goodix_milan_transform_invert (transform, inverse);
-}


### PR DESCRIPTION
## Summary

Consolidate Milan affine callers on the canonical transform API before the readability refactor above it.

- Replace the duplicate `milan_compose_transform()` and `milan_invert_transform()` forwarding names with `goodix_milan_transform_compose()` and `goodix_milan_transform_invert()` at every caller.
- Move the two affected translation units to the owning `relations.h` declaration rather than exposing transform declarations through generic `private.h`.
- Delete the two forwarding implementations and their duplicate prototypes.

No transform arithmetic, routing decision, return handling, or safety behavior changes.

## Contracts preserved

- Every former inversion status check still checks the canonical inversion result.
- Composition argument order is unchanged at every call site.
- Callers that deliberately ignore inversion status continue to do so.
- The transform implementation remains the sole owner of alias handling, singular copies, normalization, and fixed-width arithmetic.

## Evidence

- All repository references to the duplicate transform names were enumerated before removal; no references remain.
- Debug-disabled production build passes.
- Existing Milan synthetic, state, and runtime suites pass.
- The final stack was revalidated in Ghidra against `FUN_1800687c0`, `FUN_180068860`, `FUN_1800689a0`, and `FUN_1800619a0`; maintained profile-9 notes remain exact and required no update.
- Final stack `--compare-current`: 26/26, later durable 119/119, premerge 454/454, readiness 643/643; 1,242/1,242 total, source identity `1669a65a37087dc50a7aae84d73b5b104474267f5d9ef3a8743b2120d0468ad8`.

## Follow-ups (not in this PR)

- The next PR makes the retained Q8 affine implementation and composition direction explicit.
