### PR TITLE
Clarify Milan affine transforms

### DIFF
--- a/drivers/goodix53x5/milan/relations.h
+++ b/drivers/goodix53x5/milan/relations.h
@@ -43,9 +43,9 @@ void
 goodix_milan_transform_normalize (int32_t transform[6]);
 
 void
-goodix_milan_transform_compose (const int32_t first[6],
-                                      const int32_t second[6],
-                                      int32_t       output[6]);
+goodix_milan_transform_compose (const int32_t after[6],
+                                const int32_t before[6],
+                                int32_t       output[6]);
 
 int
 goodix_milan_transform_invert (const int32_t transform[6],

--- a/drivers/goodix53x5/milan/transform.c
+++ b/drivers/goodix53x5/milan/transform.c
@@ -13,11 +13,39 @@
 #include "milan/relations.h"
 #include "milan/transform-private.h"
 
+/* Q8 affine primitives recovered from FUN_1800687c0, FUN_180068860, and
+ * FUN_1800689a0. */
+enum {
+  AFFINE_XX,
+  AFFINE_XY,
+  AFFINE_X_OFFSET,
+  AFFINE_YX,
+  AFFINE_YY,
+  AFFINE_Y_OFFSET,
+  AFFINE_WORDS,
+};
+
+#define AFFINE_Q8_SHIFT 8
+#define AFFINE_Q16_SHIFT (2 * AFFINE_Q8_SHIFT)
+#define AFFINE_Q8_ONE (1 << AFFINE_Q8_SHIFT)
+
 static inline int32_t
-goodix_milan_transform_sar64_narrow (uint64_t value,
-                                           unsigned int shift)
+goodix_milan_transform_sar64_narrow (uint64_t     value,
+                                     unsigned int shift)
 {
   return goodix_milan_transform_s32 ((uint32_t) (value >> shift));
+}
+
+static inline int32_t
+goodix_milan_transform_dot_q8 (int32_t left_first,
+                               int32_t right_first,
+                               int32_t left_second,
+                               int32_t right_second)
+{
+  return goodix_milan_transform_sar64_narrow (
+    (uint64_t) (int64_t) left_first * (uint64_t) (int64_t) right_first +
+    (uint64_t) (int64_t) left_second * (uint64_t) (int64_t) right_second,
+    AFFINE_Q8_SHIFT);
 }
 
 static inline uint32_t
@@ -44,133 +72,148 @@ void
 goodix_milan_transform_normalize (int32_t transform[6])
 {
   int32_t average = goodix_milan_transform_sar32 (
-    (uint32_t) transform[0] + (uint32_t) transform[4], 1);
+    (uint32_t) transform[AFFINE_XX] + (uint32_t) transform[AFFINE_YY], 1);
   int32_t rotation = goodix_milan_transform_sar32 (
-    (uint32_t) transform[3] - (uint32_t) transform[1], 1);
+    (uint32_t) transform[AFFINE_YX] - (uint32_t) transform[AFFINE_XY], 1);
   uint32_t norm = goodix_milan_transform_integer_sqrt (
     (uint32_t) rotation * (uint32_t) rotation +
     (uint32_t) average * (uint32_t) average);
 
   if (norm == 0)
     {
-      transform[0] = 0x100;
-      transform[1] = 0;
-      transform[3] = 0;
-      transform[4] = 0x100;
+      transform[AFFINE_XX] = AFFINE_Q8_ONE;
+      transform[AFFINE_XY] = 0;
+      transform[AFFINE_YX] = 0;
+      transform[AFFINE_YY] = AFFINE_Q8_ONE;
       return;
     }
-  transform[0] = goodix_milan_transform_divide (
+  transform[AFFINE_XX] = goodix_milan_transform_divide (
     (uint64_t) (int64_t) goodix_milan_transform_s32 (
-      (uint32_t) (norm >> 1) + ((uint32_t) average << 8)),
+      (uint32_t) (norm >> 1) +
+      ((uint32_t) average << AFFINE_Q8_SHIFT)),
     (int32_t) norm);
-  transform[4] = transform[0];
-  transform[1] = goodix_milan_transform_divide (
+  transform[AFFINE_YY] = transform[AFFINE_XX];
+  transform[AFFINE_XY] = goodix_milan_transform_divide (
     (uint64_t) (int64_t) goodix_milan_transform_s32 (
-      (uint32_t) (norm >> 1) - ((uint32_t) rotation << 8)),
+      (uint32_t) (norm >> 1) -
+      ((uint32_t) rotation << AFFINE_Q8_SHIFT)),
     (int32_t) norm);
-  transform[3] = goodix_milan_transform_s32 (
-    UINT32_C (0) - (uint32_t) transform[1]);
+  transform[AFFINE_YX] = goodix_milan_transform_s32 (
+    UINT32_C (0) - (uint32_t) transform[AFFINE_XY]);
 }
 
+/* Compose Q8 matrices as output = after * before. Each array encodes
+ * [xx xy x_offset; yx yy y_offset; 0 0 256]. Inputs are copied because output
+ * may alias either one, and native normalizes the linear part after the product. */
 void
-goodix_milan_transform_compose (const int32_t first[6],
-                                      const int32_t second[6],
-                                      int32_t       output[6])
+goodix_milan_transform_compose (const int32_t after[6],
+                                const int32_t before[6],
+                                int32_t       output[6])
 {
-  int32_t a[6];
-  int32_t b[6];
-  int32_t result[6];
+  int32_t after_copy[AFFINE_WORDS];
+  int32_t before_copy[AFFINE_WORDS];
+  int32_t result[AFFINE_WORDS];
 
-  if (!first || !second || !output)
+  if (!after || !before || !output)
     return;
-  memcpy (a, first, sizeof(a));
-  memcpy (b, second, sizeof(b));
-  result[0] = goodix_milan_transform_sar64_narrow (
-    (uint64_t) (int64_t) b[0] * (uint64_t) (int64_t) a[0] +
-    (uint64_t) (int64_t) b[3] * (uint64_t) (int64_t) a[1], 8);
-  result[1] = goodix_milan_transform_sar64_narrow (
-    (uint64_t) (int64_t) a[0] * (uint64_t) (int64_t) b[1] +
-    (uint64_t) (int64_t) b[4] * (uint64_t) (int64_t) a[1], 8);
-  result[2] = goodix_milan_transform_s32 (
-    (uint32_t) goodix_milan_transform_sar64_narrow (
-      (uint64_t) (int64_t) b[2] * (uint64_t) (int64_t) a[0] +
-      (uint64_t) (int64_t) b[5] * (uint64_t) (int64_t) a[1], 8) +
-    (uint32_t) a[2]);
-  result[3] = goodix_milan_transform_sar64_narrow (
-    (uint64_t) (int64_t) b[0] * (uint64_t) (int64_t) a[3] +
-    (uint64_t) (int64_t) b[3] * (uint64_t) (int64_t) a[4], 8);
-  result[4] = goodix_milan_transform_sar64_narrow (
-    (uint64_t) (int64_t) a[3] * (uint64_t) (int64_t) b[1] +
-    (uint64_t) (int64_t) a[4] * (uint64_t) (int64_t) b[4], 8);
-  result[5] = goodix_milan_transform_s32 (
-    (uint32_t) goodix_milan_transform_sar64_narrow (
-      (uint64_t) (int64_t) a[3] * (uint64_t) (int64_t) b[2] +
-      (uint64_t) (int64_t) a[4] * (uint64_t) (int64_t) b[5], 8) +
-    (uint32_t) a[5]);
+  memcpy (after_copy, after, sizeof (after_copy));
+  memcpy (before_copy, before, sizeof (before_copy));
+  result[AFFINE_XX] = goodix_milan_transform_dot_q8 (
+    before_copy[AFFINE_XX], after_copy[AFFINE_XX],
+    before_copy[AFFINE_YX], after_copy[AFFINE_XY]);
+  result[AFFINE_XY] = goodix_milan_transform_dot_q8 (
+    after_copy[AFFINE_XX], before_copy[AFFINE_XY],
+    before_copy[AFFINE_YY], after_copy[AFFINE_XY]);
+  result[AFFINE_X_OFFSET] = goodix_milan_transform_s32 (
+    (uint32_t) goodix_milan_transform_dot_q8 (
+      before_copy[AFFINE_X_OFFSET], after_copy[AFFINE_XX],
+      before_copy[AFFINE_Y_OFFSET], after_copy[AFFINE_XY]) +
+    (uint32_t) after_copy[AFFINE_X_OFFSET]);
+  result[AFFINE_YX] = goodix_milan_transform_dot_q8 (
+    before_copy[AFFINE_XX], after_copy[AFFINE_YX],
+    before_copy[AFFINE_YX], after_copy[AFFINE_YY]);
+  result[AFFINE_YY] = goodix_milan_transform_dot_q8 (
+    after_copy[AFFINE_YX], before_copy[AFFINE_XY],
+    after_copy[AFFINE_YY], before_copy[AFFINE_YY]);
+  result[AFFINE_Y_OFFSET] = goodix_milan_transform_s32 (
+    (uint32_t) goodix_milan_transform_dot_q8 (
+      after_copy[AFFINE_YX], before_copy[AFFINE_X_OFFSET],
+      after_copy[AFFINE_YY], before_copy[AFFINE_Y_OFFSET]) +
+    (uint32_t) after_copy[AFFINE_Y_OFFSET]);
   goodix_milan_transform_normalize (result);
-  memcpy (output, result, sizeof(result));
+  memcpy (output, result, sizeof (result));
 }
 
+/* Native wraps the determinant at 32 bits and copies wrapped-singular input.
+ * Snapshotting all words also permits inversion in place. */
 int
 goodix_milan_transform_invert (const int32_t transform[6],
-                                     int32_t       inverse[6])
+                               int32_t       inverse[6])
 {
-  int32_t input[6];
-  int32_t result[6];
+  int32_t input[AFFINE_WORDS];
+  int32_t result[AFFINE_WORDS];
   int32_t determinant;
   uint64_t numerator;
 
   if (!transform || !inverse)
     return -1;
-  memcpy (input, transform, sizeof(input));
+  memcpy (input, transform, sizeof (input));
   determinant = goodix_milan_transform_s32 (
-    (uint32_t) input[0] * (uint32_t) input[4] -
-    (uint32_t) input[1] * (uint32_t) input[3]);
+    (uint32_t) input[AFFINE_XX] * (uint32_t) input[AFFINE_YY] -
+    (uint32_t) input[AFFINE_XY] * (uint32_t) input[AFFINE_YX]);
   if (determinant == 0)
     {
-      memcpy (inverse, input, sizeof(input));
+      memcpy (inverse, input, sizeof (input));
       return 0;
     }
-  result[0] = goodix_milan_transform_divide (
-    (uint64_t) (int64_t) input[4] << 16, determinant);
-  result[1] = goodix_milan_transform_divide (
-    (UINT64_C (0) - (uint64_t) (int64_t) input[1]) << 16, determinant);
-  numerator = (uint64_t) (int64_t) input[5] *
-                (uint64_t) (int64_t) input[1] -
-              (uint64_t) (int64_t) input[4] *
-                (uint64_t) (int64_t) input[2];
-  result[2] = goodix_milan_transform_divide (numerator << 8,
-                                                    determinant);
-  result[3] = goodix_milan_transform_divide (
-    (UINT64_C (0) - (uint64_t) (int64_t) input[3]) << 16, determinant);
-  result[4] = goodix_milan_transform_divide (
-    (uint64_t) (int64_t) input[0] << 16, determinant);
-  numerator = (uint64_t) (int64_t) input[3] *
-                (uint64_t) (int64_t) input[2] -
-              (uint64_t) (int64_t) input[5] *
-                (uint64_t) (int64_t) input[0];
-  result[5] = goodix_milan_transform_divide (numerator << 8,
-                                                    determinant);
-  memcpy (inverse, result, sizeof(result));
+  result[AFFINE_XX] = goodix_milan_transform_divide (
+    (uint64_t) (int64_t) input[AFFINE_YY] << AFFINE_Q16_SHIFT,
+      determinant);
+  result[AFFINE_XY] = goodix_milan_transform_divide (
+    (UINT64_C (0) - (uint64_t) (int64_t) input[AFFINE_XY]) <<
+      AFFINE_Q16_SHIFT, determinant);
+  numerator = (uint64_t) (int64_t) input[AFFINE_Y_OFFSET] *
+              (uint64_t) (int64_t) input[AFFINE_XY] -
+              (uint64_t) (int64_t) input[AFFINE_YY] *
+              (uint64_t) (int64_t) input[AFFINE_X_OFFSET];
+  result[AFFINE_X_OFFSET] = goodix_milan_transform_divide (
+    numerator << AFFINE_Q8_SHIFT, determinant);
+  result[AFFINE_YX] = goodix_milan_transform_divide (
+    (UINT64_C (0) - (uint64_t) (int64_t) input[AFFINE_YX]) <<
+      AFFINE_Q16_SHIFT, determinant);
+  result[AFFINE_YY] = goodix_milan_transform_divide (
+    (uint64_t) (int64_t) input[AFFINE_XX] << AFFINE_Q16_SHIFT,
+      determinant);
+  numerator = (uint64_t) (int64_t) input[AFFINE_YX] *
+              (uint64_t) (int64_t) input[AFFINE_X_OFFSET] -
+              (uint64_t) (int64_t) input[AFFINE_Y_OFFSET] *
+              (uint64_t) (int64_t) input[AFFINE_XX];
+  result[AFFINE_Y_OFFSET] = goodix_milan_transform_divide (
+    numerator << AFFINE_Q8_SHIFT, determinant);
+  memcpy (inverse, result, sizeof (result));
   return 0;
 }
 
 void
 goodix_milan_transform_route (const int32_t stored[6],
-                                    const int32_t direct[6],
-                                    int32_t       feature,
-                                    int32_t       reference,
-                                    int32_t       routed[6])
+                              const int32_t direct[6],
+                              int32_t       feature,
+                              int32_t       reference,
+                              int32_t       routed[6])
 {
   int32_t inverse[6];
 
   if (feature > reference)
-    goodix_milan_transform_compose (stored, direct, routed);
+    {
+      goodix_milan_transform_compose (stored, direct, routed);
+    }
   else if (feature < reference)
     {
       goodix_milan_transform_invert (stored, inverse);
       goodix_milan_transform_compose (inverse, direct, routed);
     }
   else
-    memmove (routed, direct, 6 * sizeof(*routed));
+    {
+      memmove (routed, direct, AFFINE_WORDS * sizeof (*routed));
+    }
 }


### PR DESCRIPTION
## Summary

Make Milan affine composition, normalization, inversion, and routing readable without changing their fixed-width behavior.

- Name the six transform slots as `[xx, xy, x_offset, yx, yy, y_offset]` and name the Q8/Q16 shifts and identity scale.
- Rename composition arguments by direction and document `output = after * before` with the full matrix representation.
- Extract the repeated wrapping Q8 two-product sum into one focused helper.
- Name every slot used by normalization and inversion, and document singular-copy and in-place inversion behavior.

No behavioral change is intended.

## Native quirks preserved

- `FUN_180068860` loads both source transforms before writing output, so output may alias either input; null input or output remains a no-op.
- Composition is `after * before`, uses signed 64-bit products and wrapping pairwise addition, arithmetic-shifts by eight, narrows to signed dwords, wraps translation addition at 32 bits, then normalizes the four linear words.
- `FUN_1800687c0` derives the diagonal average and antisymmetric rotation with signed dword arithmetic; a zero norm writes identity only to the linear words and leaves translations unchanged.
- `FUN_1800689a0` wraps the determinant at 32 bits, copies all six words when that wrapped determinant is zero, does not normalize, and supports in-place inversion.
- Routing still composes stored after direct for feature above reference, composes inverted stored after direct for feature below reference, and copies the unnormalized direct transform for equal indices (`FUN_1800619a0`).
- The pre-existing clean-room null/error return and extreme division behavior are unchanged.

## Evidence

- Direct Ghidra disassembly/decompilation of `FUN_1800687c0`, `FUN_180068860`, `FUN_1800689a0`, and `FUN_1800619a0` confirms the representation, argument direction, widths, aliasing, null behavior, singular copy, normalization timing, and route branches recorded in existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 250,000 cases each for normalize, compose, invert, and route; 1,000,000 total against the parent PR with zero mismatches. Full signed-dword patterns, Q8 transforms, wrapped intermediates, determinant-wrap singulars, every route branch, all valid aliases, returns, and mutations were compared.
- ASan/UBSan: the same 1,000,000-case comparison passed without sanitizer or leak findings.
- Mutation controls: a composition-operand mutation produced 651,042 mismatches; a route-order mutation produced 249,999 mismatches.
- Formatting: libfprint `uncrustify` check passes and is repeatable without changes.
- Debug-disabled production build and existing Milan synthetic/state/runtime suites pass.
- `--compare-current`: 26/26, later durable 119/119, premerge 454/454, readiness 643/643; 1,242/1,242 total, source identity `1669a65a37087dc50a7aae84d73b5b104474267f5d9ef3a8743b2120d0468ad8`.

## Follow-ups (not in this PR)

- The checked inversion primitive used by matcher and anti-fake consumers remains separate because it owns a different extreme-input failure contract.
