### PR TITLE
Clarify Milan preprocess candidate policy

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/selection.c
+++ b/drivers/goodix53x5/milan/preprocess/selection.c
@@ -13,6 +13,20 @@
 #include <limits.h>
 #include <string.h>
 
+/* Profile-9 candidate selection recovered from FUN_180069150,
+ * FUN_180081d30, and FUN_18006e7f0. */
+#define SELECTION_Q8_SHIFT 8
+#define SELECTION_Q8_ONE (1 << SELECTION_Q8_SHIFT)
+#define SELECTION_EXCLUDED_PIXEL 122
+#define SELECTION_FIRST_BOUNDARY 1800
+#define SELECTION_SECOND_BOUNDARY 3600
+#define SELECTION_FINAL_BOUNDARY 5400
+#define SELECTION_LOW_RATIO 205
+#define SELECTION_MIDDLE_SLOPE 179
+#define SELECTION_HIGH_SLOPE 2
+#define SELECTION_HIGH_RATIO 384
+#define SELECTION_MAX_CORRELATION 235
+
 static int
 milan_selection_metric (const uint8_t *frame,
                         const uint8_t *mask,
@@ -59,7 +73,7 @@ milan_selection_metric (const uint8_t *frame,
           row_sum += mask[index] != 0 ? frame[index] : fallback;
         }
 
-      int average = (int) ((row_sum << 8) / columns);
+      int average = (int) ((row_sum << SELECTION_Q8_SHIFT) / columns);
       if (row != first_row)
         difference_sum += average > previous_average ?
                           (uint32_t) (average - previous_average) :
@@ -70,7 +84,7 @@ milan_selection_metric (const uint8_t *frame,
   if (last_row == first_row)
     return (int) difference_sum;
   return (int) ((((rows - 1) * difference_sum) /
-                 (last_row - first_row)) >> 8);
+                 (last_row - first_row)) >> SELECTION_Q8_SHIFT);
 }
 
 static uint32_t
@@ -111,18 +125,22 @@ milan_masked_correlation (const uint8_t *first,
   count = rows * columns;
   for (size_t i = 0; i < count; i++)
     {
-      first_sum += mask[i] != 0 ? first[i] & mask[i] : 122;
-      second_sum += mask[i] != 0 ? second[i] & mask[i] : 122;
+      first_sum += mask[i] != 0 ? first[i] & mask[i] :
+                   SELECTION_EXCLUDED_PIXEL;
+      second_sum += mask[i] != 0 ? second[i] & mask[i] :
+                    SELECTION_EXCLUDED_PIXEL;
     }
 
   int first_mean = (int) (first_sum / count);
   int second_mean = (int) (second_sum / count);
   for (size_t i = 0; i < count; i++)
     {
-      int first_value = (mask[i] != 0 ? first[i] & mask[i] : 122) -
-                        first_mean;
-      int second_value = (mask[i] != 0 ? second[i] & mask[i] : 122) -
-                         second_mean;
+      int first_value =
+        (mask[i] != 0 ? first[i] & mask[i] : SELECTION_EXCLUDED_PIXEL) -
+        first_mean;
+      int second_value =
+        (mask[i] != 0 ? second[i] & mask[i] : SELECTION_EXCLUDED_PIXEL) -
+        second_mean;
 
       covariance += first_value * second_value;
       first_variance += (uint32_t) (first_value * first_value);
@@ -133,7 +151,46 @@ milan_masked_correlation (const uint8_t *first,
     integer_square_root (first_variance * second_variance);
   if (denominator == 0)
     return 0;
-  return (int) ((covariance * 256) / denominator);
+  return (int) ((covariance * SELECTION_Q8_ONE) / denominator);
+}
+
+/* Ties at the required metric or correlation ceiling keep primary. */
+static int
+milan_refined_candidate_wins (int primary_metric,
+                              int refined_metric,
+                              int correlation,
+                              int threshold)
+{
+  int required_metric;
+
+  if (primary_metric < SELECTION_FIRST_BOUNDARY)
+    {
+      required_metric = threshold * SELECTION_LOW_RATIO >> SELECTION_Q8_SHIFT;
+    }
+  else if (primary_metric < SELECTION_SECOND_BOUNDARY)
+    {
+      required_metric =
+        (((primary_metric - SELECTION_FIRST_BOUNDARY) * threshold *
+          SELECTION_MIDDLE_SLOPE) /
+         (SELECTION_SECOND_BOUNDARY - SELECTION_FIRST_BOUNDARY) +
+         threshold * SELECTION_LOW_RATIO) >> SELECTION_Q8_SHIFT;
+    }
+  else if (primary_metric < SELECTION_FINAL_BOUNDARY)
+    {
+      required_metric =
+        ((primary_metric - SELECTION_SECOND_BOUNDARY) * threshold *
+         SELECTION_HIGH_SLOPE) /
+        (SELECTION_SECOND_BOUNDARY - SELECTION_FIRST_BOUNDARY) +
+        (threshold * SELECTION_HIGH_RATIO >> SELECTION_Q8_SHIFT);
+    }
+  else
+    {
+      required_metric = INT_MAX;
+    }
+
+  return refined_metric < required_metric &&
+         (primary_metric >= SELECTION_FIRST_BOUNDARY ||
+          correlation < SELECTION_MAX_CORRELATION);
 }
 
 int
@@ -147,36 +204,24 @@ goodix_milan_preprocess_select_output (const uint8_t *contrast,
                                        int           *selected_refined)
 {
   size_t count;
-  int contrast_metric;
+  int primary_metric;
   int refined_metric;
   int correlation;
-  int required_metric;
 
   count = rows * columns;
-  contrast_metric = milan_selection_metric (contrast, mask, rows, columns);
+  primary_metric = milan_selection_metric (contrast, mask, rows, columns);
 
   memmove (output, contrast, count);
   *selected_refined = 0;
-  if (contrast_metric < threshold)
+  if (primary_metric < threshold)
     return 0;
 
   refined_metric = milan_selection_metric (refined, mask, rows, columns);
   correlation = milan_masked_correlation (
     contrast, refined, mask, rows, columns);
 
-  if (contrast_metric < 1800)
-    required_metric = threshold * 205 >> 8;
-  else if (contrast_metric < 3600)
-    required_metric = (((contrast_metric - 1800) * threshold * 179) / 1800 +
-                       threshold * 205) >> 8;
-  else if (contrast_metric < 5400)
-    required_metric = ((contrast_metric - 3600) * threshold * 2) / 1800 +
-                      (threshold * 384 >> 8);
-  else
-    required_metric = INT_MAX;
-
-  if (refined_metric >= required_metric ||
-      (contrast_metric < 1800 && correlation >= 235))
+  if (!milan_refined_candidate_wins (
+        primary_metric, refined_metric, correlation, threshold))
     return 0;
 
   memmove (output, refined, count);


### PR DESCRIPTION
## Summary

Make the profile-9 processed-image candidate policy readable without changing its fixed-width behavior.

- Name Q8 scaling, excluded-pixel fill, type-12 transition boundaries, interpolation factors, and the strict correlation ceiling.
- Extract the four-region required-metric calculation and strict tie policy into `milan_refined_candidate_wins()`.
- Rename the primary metric at the selection site and leave the orchestration as: publish primary, gate refinement, score refined, replace only when refined wins.
- Add a compact native-owner header and one tie-behavior comment rather than narrating each arithmetic line.

No behavioral change is intended.

## Native quirks preserved

- Primary metrics below caller threshold `800` return before refined rendering/scoring.
- Exact primary boundaries `800`, `1800`, and `3600` enter the next region; `5400` enters the final replacement region (`FUN_18006e7f0`).
- The three required-metric formulas retain signed 32-bit multiplication, division, addition, and Q8 shifts in native order.
- Refined metric equality keeps primary; correlation exactly `235` keeps primary in the first region.
- Correlation gates only the first `800 <= primary < 1800` region.
- Primary is copied and selection zero is written before any refinement decision; refined is copied before selection one is published.

## Evidence

- Direct Ghidra disassembly/decompilation of `FUN_180069150`, `FUN_180081d30`, and `FUN_18006e7f0` confirms the constants, ordered regions, arithmetic, strict predicates, and publication sequence recorded in existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 265,000 cases each for row metric, masked correlation, and output selection; 795,000 total against the parent PR with zero return, output, or mutation mismatches. This includes 25,000 explicit `88x108` production-geometry cases per function and exact `1799/1800/1801`, `3599/3600/3601`, `5399/5400/5401`, and correlation `234/235` cases.
- ASan/UBSan: all 795,000 comparisons passed without sanitizer or leak findings.
- Mutation controls detected 5,707 refined-equality mismatches, one exact-correlation-boundary mismatch, and 127 middle-interpolation mismatches.
- Formatting is repeatable without changes; debug-disabled build and existing Milan synthetic/state/runtime suites pass after rebase.
- Rebase provenance: pre/post-rebase stable patch ID is identical (`1f830534467c2c458efafd6ad712a37a4a446664`).

## Follow-ups (not in this PR)

- Other preprocessing stages remain independent refactor scopes.
