### PR TITLE
Narrow Milan preprocess selection contracts

### DIFF
--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -518,17 +518,6 @@ int goodix_milan_preprocess_refine (const uint16_t *source,
                                 size_t          columns,
                                 uint8_t         *output);
 
-int goodix_milan_preprocess_selection_metric (const uint8_t *frame,
-                                           const uint8_t *mask,
-                                           size_t         rows,
-                                           size_t         columns);
-
-int goodix_milan_preprocess_masked_correlation (const uint8_t *first,
-                                             const uint8_t *second,
-                                             const uint8_t *mask,
-                                             size_t         rows,
-                                             size_t         columns);
-
 int goodix_milan_preprocess_select_output (const uint8_t *contrast,
                                        const uint8_t *refined,
                                        const uint8_t *mask,

--- a/drivers/goodix53x5/milan/preprocess/selection.c
+++ b/drivers/goodix53x5/milan/preprocess/selection.c
@@ -13,11 +13,11 @@
 #include <limits.h>
 #include <string.h>
 
-int
-goodix_milan_preprocess_selection_metric (const uint8_t *frame,
-                                       const uint8_t *mask,
-                                       size_t         rows,
-                                       size_t         columns)
+static int
+milan_selection_metric (const uint8_t *frame,
+                        const uint8_t *mask,
+                        size_t         rows,
+                        size_t         columns)
 {
   size_t count;
   uint64_t valid_sum = 0;
@@ -27,10 +27,6 @@ goodix_milan_preprocess_selection_metric (const uint8_t *frame,
   int found_first = 0;
   int previous_average = 0;
   uint64_t difference_sum = 0;
-
-  if (!frame || !mask || rows == 0 || columns == 0 ||
-      columns > SIZE_MAX / rows || rows > INT_MAX || columns > INT_MAX)
-    return -1;
 
   count = rows * columns;
   for (size_t i = 0; i < count; i++)
@@ -65,23 +61,23 @@ goodix_milan_preprocess_selection_metric (const uint8_t *frame,
 
       int average = (int) ((row_sum << 8) / columns);
       if (row != first_row)
-        difference_sum += average > previous_average
-                            ? (uint32_t) (average - previous_average)
-                            : (uint32_t) (previous_average - average);
+        difference_sum += average > previous_average ?
+                          (uint32_t) (average - previous_average) :
+                          (uint32_t) (previous_average - average);
       previous_average = average;
     }
 
   if (last_row == first_row)
     return (int) difference_sum;
   return (int) ((((rows - 1) * difference_sum) /
-                  (last_row - first_row)) >> 8);
+                 (last_row - first_row)) >> 8);
 }
 
 static uint32_t
 integer_square_root (uint64_t value)
 {
   uint32_t root = 0;
-  uint32_t bit = UINT32_C(0x80000000);
+  uint32_t bit = UINT32_C (0x80000000);
 
   if (value < 2)
     return (uint32_t) value;
@@ -98,12 +94,12 @@ integer_square_root (uint64_t value)
   return root;
 }
 
-int
-goodix_milan_preprocess_masked_correlation (const uint8_t *first,
-                                         const uint8_t *second,
-                                         const uint8_t *mask,
-                                         size_t         rows,
-                                         size_t         columns)
+static int
+milan_masked_correlation (const uint8_t *first,
+                          const uint8_t *second,
+                          const uint8_t *mask,
+                          size_t         rows,
+                          size_t         columns)
 {
   size_t count;
   uint64_t first_sum = 0;
@@ -111,10 +107,6 @@ goodix_milan_preprocess_masked_correlation (const uint8_t *first,
   int64_t covariance = 0;
   uint64_t first_variance = 0;
   uint64_t second_variance = 0;
-
-  if (!first || !second || !mask || rows == 0 || columns == 0 ||
-      columns > SIZE_MAX / rows)
-    return -1;
 
   count = rows * columns;
   for (size_t i = 0; i < count; i++)
@@ -146,13 +138,13 @@ goodix_milan_preprocess_masked_correlation (const uint8_t *first,
 
 int
 goodix_milan_preprocess_select_output (const uint8_t *contrast,
-                                   const uint8_t *refined,
-                                   const uint8_t *mask,
-                                   size_t         rows,
-                                   size_t         columns,
-                                   int            threshold,
-                                   uint8_t       *output,
-                                   int           *selected_refined)
+                                       const uint8_t *refined,
+                                       const uint8_t *mask,
+                                       size_t         rows,
+                                       size_t         columns,
+                                       int            threshold,
+                                       uint8_t       *output,
+                                       int           *selected_refined)
 {
   size_t count;
   int contrast_metric;
@@ -160,28 +152,17 @@ goodix_milan_preprocess_select_output (const uint8_t *contrast,
   int correlation;
   int required_metric;
 
-  if (!contrast || !refined || !mask || !output || !selected_refined ||
-      threshold < 0 || rows == 0 || columns == 0 ||
-      columns > SIZE_MAX / rows)
-    return -1;
-
   count = rows * columns;
-  contrast_metric = goodix_milan_preprocess_selection_metric (
-    contrast, mask, rows, columns);
-  if (contrast_metric < 0)
-    return -1;
+  contrast_metric = milan_selection_metric (contrast, mask, rows, columns);
 
   memmove (output, contrast, count);
   *selected_refined = 0;
   if (contrast_metric < threshold)
     return 0;
 
-  refined_metric = goodix_milan_preprocess_selection_metric (
-    refined, mask, rows, columns);
-  correlation = goodix_milan_preprocess_masked_correlation (
+  refined_metric = milan_selection_metric (refined, mask, rows, columns);
+  correlation = milan_masked_correlation (
     contrast, refined, mask, rows, columns);
-  if (refined_metric < 0)
-    return -1;
 
   if (contrast_metric < 1800)
     required_metric = threshold * 205 >> 8;


### PR DESCRIPTION
## Summary

Narrow the internal contracts in Milan preprocessing candidate selection before the policy readability layer above it.

- Make the row-transition metric and masked-correlation helpers file-local; their sole caller is `goodix_milan_preprocess_select_output()`.
- Remove null, zero-dimension, overflow-dimension, and negative-threshold checks that are absent from native and unreachable from the sole production caller, which always supplies nonnull `88x108` planes and threshold `800`.
- Remove now-impossible internal negative-result propagation and the two dead declarations from `milan.h`.

No reachable production behavior change is intended. Malformed direct calls outside the proven internal contract no longer return `-1`.

## Native quirks preserved

- Every nonzero mask byte admits a sample; excluded row-metric pixels use `valid_sum / (valid_count + 1)` (`FUN_180069150`).
- Empty and single-active-row masks still return zero, and row-transition normalization still divides before its final Q8 shift.
- Masked correlation still bitwise-intersects noncanonical mask bytes and replaces only zero-mask pixels with `122` (`FUN_180081d30`).
- Primary output and selected index zero are still published before the refinement threshold gate (`FUN_18006e7f0`).
- Allocation-free metric/correlation behavior, publication order, and overlap-safe candidate copies are unchanged.

## Evidence

- Caller proof: complete repository reference search found one fixed production selector call in `core.c`; the two leaf metrics have no caller outside `selection.c`.
- Direct Ghidra revalidation of `FUN_180069150`, `FUN_180081d30`, and `FUN_18006e7f0` confirms the trusted inputs, arithmetic, mask semantics, strict policy boundaries, and publication order recorded in existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 265,000 cases each for row metric, masked correlation, and output selection; 795,000 total valid-domain comparisons against the original `main`, with zero return, output, or mutation mismatches. This includes 25,000 explicit `88x108` production-geometry cases per function, plus varied positive dimensions, sparse/full/noncanonical masks, exact policy boundaries, zero denominators, and ten output alias layouts.
- ASan/UBSan: all 795,000 comparisons passed without sanitizer or leak findings.
- Mutation controls detected 5,707 refined-equality mismatches, one exact-correlation-boundary mismatch, and 2,486 row-arithmetic mismatches.
- Debug-disabled production build and existing Milan synthetic/state/runtime suites pass after rebase.
- Rebase provenance: pre/post-rebase stable patch ID is identical (`94866d71d715ed2438b913f44c5e875c72c0c818`).

## Follow-ups (not in this PR)

- The next PR names and isolates the profile-9/type-12 refined-candidate policy.
