### PR TITLE
Narrow Milan extrema helper contracts

### DIFF
--- a/drivers/goodix53x5/milan/feature/extrema.c
+++ b/drivers/goodix53x5/milan/feature/extrema.c
@@ -25,8 +25,6 @@ goodix_milan_feature_collect_extrema (
   size_t count;
   size_t result_count = 0;
 
-  if (!scales || rows < 13 || columns < 13 || columns > SIZE_MAX / rows)
-    return 0;
   count = rows * columns;
   for (size_t scale = 1; scale < 4; scale++)
     for (size_t row = 6; row + 6 < rows; row++)
@@ -37,7 +35,7 @@ goodix_milan_feature_collect_extrema (
             scales[(scale + 1) * count + pixel] -
             scales[scale * count + pixel]);
           int32_t absolute = response < 0 ? -response : response;
-          int extremum = absolute > 0x148 && response != 0;
+          int extremum = absolute > 0x148;
 
           for (ptrdiff_t adjacent = -1; extremum && adjacent <= 1; adjacent++)
             for (ptrdiff_t delta_row = -1;
@@ -266,8 +264,6 @@ goodix_milan_feature_refine_extremum (
   int32_t offset[3];
   int32_t x, y, scale;
 
-  if (!scales || !candidate || !curvature || rows < 3 || columns < 3)
-    return 0;
   x = candidate->x;
   y = candidate->y;
   scale = candidate->scale;


### PR DESCRIPTION
## Summary

Narrow Milan extrema helpers to their proven internal production contract before the readability layer above it.

- Remove null, undersized-geometry, and overflow-geometry checks absent from native; the sole materialization caller supplies six valid `104x88` scale planes, valid outputs, and in-bounds candidates.
- Remove `response != 0` from extremum eligibility because the strict `abs(response) > 0x148` predicate already proves it.

No reachable production behavior change is intended. Malformed direct calls outside the internal contract are no longer handled defensively.

## Native quirks preserved

- The center response remains a wrapping signed-16 difference while all 26 neighbor responses remain signed 32-bit differences (`FUN_180047c50`).
- Extremum magnitude remains strictly greater than `0x148`; equal neighbor responses remain eligible.
- Scale/row/column scan order and six-pixel border remain unchanged.
- Refinement still trusts the discovered candidate's scale and coordinates before its first derivative read (`FUN_18004c5a0`).
- Count-query behavior remains source-specific: null extrema output with capacity zero still returns the total qualifying count.

## Evidence

- Caller proof: complete repository reference search found only `goodix_milan_feature_collect_materialized()`, which first queries/counts extrema and then refines discovered in-bounds candidates at fixed production geometry.
- Direct Ghidra revalidation of `FUN_180047c50`, `FUN_180048c60`, `FUN_18004bed0`, `FUN_18004c5a0`, and `FUN_18004c100` confirms the trusted inputs, scan domain, widths, strict thresholds, equality handling, and refinement bounds recorded in existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 200,000 extremum-collection and 200,000 refinement cases against `main`, zero mismatches. Production geometry, threshold boundaries, signed/tied neighbors, all capacity modes, in-bounds movement/convergence/rejection, return values, and complete output mutations were covered.
- ASan/UBSan: all 400,000 comparisons passed without sanitizer or leak findings.
- Mutation controls detected changes to the response threshold, neighbor equality, and contrast acceptance boundary.
- Debug-disabled build and existing Milan synthetic/state/runtime suites pass.

## Follow-ups (not in this PR)

- The next PR names the scan, derivative, solver, and refinement domains without changing phase structure.
