### PR TITLE
Name Milan extrema refinement domains

### DIFF
--- a/drivers/goodix53x5/milan/feature/extrema.c
+++ b/drivers/goodix53x5/milan/feature/extrema.c
@@ -14,6 +14,47 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Profile-9 extrema discovery and refinement recovered from FUN_180047c50,
+ * FUN_180048c60, FUN_18004bed0, FUN_18004c5a0, and FUN_18004c100. */
+enum {
+  AXIS_X,
+  AXIS_Y,
+  AXIS_SCALE,
+  AXIS_COUNT,
+};
+
+enum {
+  HESSIAN_XX,
+  HESSIAN_YY,
+  HESSIAN_SCALE_SCALE,
+  HESSIAN_XY,
+  HESSIAN_Y_SCALE,
+  HESSIAN_X_SCALE,
+  HESSIAN_COUNT,
+};
+
+#define EXTREMA_SCAN_BORDER 6
+#define EXTREMA_FIRST_SCALE 1
+#define EXTREMA_SCALE_LIMIT 4
+#define EXTREMA_RESPONSE_THRESHOLD 0x148
+#define DERIVATIVE_LIMIT 0x8000
+#define MIXED_DERIVATIVE_LIMIT 0x2000
+#define REFINEMENT_ATTEMPT_LIMIT 5
+#define REFINEMENT_Q12_SHIFT 12
+#define REFINEMENT_Q12_ONE (1 << REFINEMENT_Q12_SHIFT)
+#define REFINEMENT_Q12_HALF (REFINEMENT_Q12_ONE >> 1)
+#define REFINEMENT_Q12_TO_Q8_SHIFT 4
+#define REFINEMENT_OFFSET_SATURATION 0x00ffffff
+#define REFINEMENT_CONTRAST_SCALE 0x4000
+#define REFINEMENT_CONTRAST_MINIMUM 0x1478000
+#define REFINEMENT_EDGE_RATIO 40
+#define REFINEMENT_EDGE_RATIO_PLUS_ONE 41
+#define REFINEMENT_CURVATURE_SCALE 0x400
+#define REFINEMENT_SCALE_EXPONENT_FACTOR 0x10
+#define REFINEMENT_SCALE_EXPONENT_DIVISOR 3
+#define REFINEMENT_SCALE_FACTOR 0x13333
+#define REFINEMENT_Q16_SHIFT 16
+
 size_t
 goodix_milan_feature_collect_extrema (
   const uint16_t             *scales,
@@ -26,16 +67,22 @@ goodix_milan_feature_collect_extrema (
   size_t result_count = 0;
 
   count = rows * columns;
-  for (size_t scale = 1; scale < 4; scale++)
-    for (size_t row = 6; row + 6 < rows; row++)
-      for (size_t column = 6; column + 6 < columns; column++)
+  for (size_t scale = EXTREMA_FIRST_SCALE;
+       scale < EXTREMA_SCALE_LIMIT;
+       scale++)
+    for (size_t row = EXTREMA_SCAN_BORDER;
+         row + EXTREMA_SCAN_BORDER < rows;
+         row++)
+      for (size_t column = EXTREMA_SCAN_BORDER;
+           column + EXTREMA_SCAN_BORDER < columns;
+           column++)
         {
           size_t pixel = row * columns + column;
           int32_t response = (int16_t) (
             scales[(scale + 1) * count + pixel] -
             scales[scale * count + pixel]);
           int32_t absolute = response < 0 ? -response : response;
-          int extremum = absolute > 0x148;
+          int extremum = absolute > EXTREMA_RESPONSE_THRESHOLD;
 
           for (ptrdiff_t adjacent = -1; extremum && adjacent <= 1; adjacent++)
             for (ptrdiff_t delta_row = -1;
@@ -62,7 +109,7 @@ goodix_milan_feature_collect_extrema (
           if (!extremum)
             continue;
           if (result_count < capacity && extrema)
-            extrema[result_count] = (GoodixMilanFeatureExtremum) {
+            extrema[result_count] = (GoodixMilanFeatureExtremum){
               (int32_t) column, (int32_t) row, (int32_t) scale, response,
             };
           result_count++;
@@ -77,8 +124,8 @@ feature_build_refinement_derivatives (const uint16_t *scales,
                                       int32_t         x,
                                       int32_t         y,
                                       int32_t         scale,
-                                      int16_t         hessian[6],
-                                      int16_t         gradient[3],
+                                      int16_t         hessian[HESSIAN_COUNT],
+                                      int16_t         gradient[AXIS_COUNT],
                                       int16_t        *center)
 {
   size_t count = rows * columns;
@@ -92,60 +139,60 @@ feature_build_refinement_derivatives (const uint16_t *scales,
   *center = (int16_t) (2 * ((int32_t) next[pixel] - current[pixel]));
   value = 2 * (((int32_t) current[pixel - 1] - next[pixel - 1]) -
                current[pixel + 1] + next[pixel + 1]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  gradient[0] = (int16_t) value;
+  gradient[AXIS_X] = (int16_t) value;
   value = 2 * (((int32_t) current[pixel - columns] -
                 next[pixel - columns]) -
                current[pixel + columns] + next[pixel + columns]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  gradient[1] = (int16_t) value;
+  gradient[AXIS_Y] = (int16_t) value;
   value = 2 * (((int32_t) previous[pixel] - current[pixel]) - next[pixel] +
                next2[pixel]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  gradient[2] = (int16_t) value;
+  gradient[AXIS_SCALE] = (int16_t) value;
 
   value = 4 * (((int32_t) next[pixel - 1] - current[pixel - 1]) -
                current[pixel + 1] - *center + next[pixel + 1]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  hessian[0] = (int16_t) value;
+  hessian[HESSIAN_XX] = (int16_t) value;
   value = 4 * (((int32_t) next[pixel - columns] -
                 current[pixel - columns]) -
                *center - current[pixel + columns] + next[pixel + columns]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  hessian[1] = (int16_t) value;
+  hessian[HESSIAN_YY] = (int16_t) value;
   value = 4 * (((int32_t) current[pixel] - previous[pixel]) - next[pixel] -
                *center + next2[pixel]);
-  if (value <= -0x8000 || value >= 0x8000)
+  if (value <= -DERIVATIVE_LIMIT || value >= DERIVATIVE_LIMIT)
     return 0;
-  hessian[2] = (int16_t) value;
+  hessian[HESSIAN_SCALE_SCALE] = (int16_t) value;
 
   value = ((int32_t) current[pixel + columns - 1] -
            next[pixel + columns - 1]) -
           next[pixel - columns + 1] - current[pixel + columns + 1] -
           current[pixel - columns - 1] + current[pixel - columns + 1] +
           next[pixel + columns + 1] + next[pixel - columns - 1];
-  if (value <= -0x2000 || value >= 0x2000)
+  if (value <= -MIXED_DERIVATIVE_LIMIT || value >= MIXED_DERIVATIVE_LIMIT)
     return 0;
-  hessian[3] = (int16_t) value;
+  hessian[HESSIAN_XY] = (int16_t) value;
   value = ((int32_t) previous[pixel + columns] -
            previous[pixel - columns]) -
           next2[pixel - columns] + next2[pixel + columns] -
           next[pixel + columns] - current[pixel + columns] +
           current[pixel - columns] + next[pixel - columns];
-  if (value <= -0x2000 || value >= 0x2000)
+  if (value <= -MIXED_DERIVATIVE_LIMIT || value >= MIXED_DERIVATIVE_LIMIT)
     return 0;
-  hessian[4] = (int16_t) value;
+  hessian[HESSIAN_Y_SCALE] = (int16_t) value;
   value = ((int32_t) previous[pixel + 1] - previous[pixel - 1]) -
           next2[pixel - 1] + next2[pixel + 1] - current[pixel + 1] -
           next[pixel + 1] + next[pixel - 1] + current[pixel - 1];
-  if (value <= -0x2000 || value >= 0x2000)
+  if (value <= -MIXED_DERIVATIVE_LIMIT || value >= MIXED_DERIVATIVE_LIMIT)
     return 0;
-  hessian[5] = (int16_t) value;
+  hessian[HESSIAN_X_SCALE] = (int16_t) value;
   return 1;
 }
 
@@ -164,36 +211,42 @@ feature_signed_bit_length (int64_t value)
 }
 
 static void
-feature_solve_refinement_offset (const int16_t hessian[6],
-                                 const int16_t gradient[3],
-                                 int32_t       offset[3])
+feature_solve_refinement_offset (const int16_t hessian[HESSIAN_COUNT],
+                                 const int16_t gradient[AXIS_COUNT],
+                                 int32_t       offset[AXIS_COUNT])
 {
-  int64_t h00 = hessian[0], h11 = hessian[1], h22 = hessian[2];
-  int64_t h01 = hessian[3], h12 = hessian[4], h02 = hessian[5];
+  int64_t h00 = hessian[HESSIAN_XX];
+  int64_t h11 = hessian[HESSIAN_YY];
+  int64_t h22 = hessian[HESSIAN_SCALE_SCALE];
+  int64_t h01 = hessian[HESSIAN_XY];
+  int64_t h12 = hessian[HESSIAN_Y_SCALE];
+  int64_t h02 = hessian[HESSIAN_X_SCALE];
   int64_t cofactor0 = h11 * h22 - h12 * h12;
   int64_t cofactor1 = h02 * h12 - h01 * h22;
   int64_t cofactor2 = h01 * h12 - h02 * h11;
   int64_t determinant = h00 * cofactor0 + h01 * cofactor1 +
                         h02 * cofactor2;
-  int64_t numerator[3];
+  int64_t numerator[AXIS_COUNT];
   int determinant_bits = feature_signed_bit_length (determinant);
 
   if (determinant == 0)
     {
-      memset (offset, 0, 3 * sizeof(*offset));
+      memset (offset, 0, AXIS_COUNT * sizeof (*offset));
       return;
     }
-  numerator[0] = -((int64_t) gradient[0] * cofactor0 +
-                   (int64_t) gradient[1] * cofactor1 +
-                   (int64_t) gradient[2] * cofactor2);
-  numerator[1] = -((h00 * h22 - h02 * h02) * gradient[1] +
-                   (h01 * h02 - h00 * h12) * gradient[2] +
-                   (int64_t) gradient[0] * cofactor1);
-  numerator[2] = -((h00 * h11 - h01 * h01) * gradient[2] +
-                   (h01 * h02 - h00 * h12) * gradient[1] +
-                   (int64_t) gradient[0] * cofactor2);
+  numerator[AXIS_X] = -((int64_t) gradient[AXIS_X] * cofactor0 +
+                        (int64_t) gradient[AXIS_Y] * cofactor1 +
+                        (int64_t) gradient[AXIS_SCALE] * cofactor2);
+  numerator[AXIS_Y] =
+    -((h00 * h22 - h02 * h02) * gradient[AXIS_Y] +
+      (h01 * h02 - h00 * h12) * gradient[AXIS_SCALE] +
+      (int64_t) gradient[AXIS_X] * cofactor1);
+  numerator[AXIS_SCALE] =
+    -((h00 * h11 - h01 * h01) * gradient[AXIS_SCALE] +
+      (h01 * h02 - h00 * h12) * gradient[AXIS_Y] +
+      (int64_t) gradient[AXIS_X] * cofactor2);
 
-  for (size_t axis = 0; axis < 3; axis++)
+  for (size_t axis = 0; axis < AXIS_COUNT; axis++)
     {
       int numerator_bits = feature_signed_bit_length (numerator[axis]);
       int64_t scaled_numerator = numerator[axis];
@@ -201,17 +254,17 @@ feature_solve_refinement_offset (const int16_t hessian[6],
 
       if (numerator_bits - determinant_bits >= 9)
         {
-          offset[axis] = 0x00ffffff;
+          offset[axis] = REFINEMENT_OFFSET_SATURATION;
           continue;
         }
-      int bits = numerator_bits > determinant_bits ? numerator_bits
-                                                   : determinant_bits;
+      int bits = numerator_bits > determinant_bits ? numerator_bits :
+                 determinant_bits;
       if (bits > 32)
         {
           scaled_numerator >>= bits - 32;
           scaled_determinant >>= bits - 32;
         }
-      offset[axis] = (int32_t) ((scaled_numerator * 0x1000) /
+      offset[axis] = (int32_t) ((scaled_numerator * REFINEMENT_Q12_ONE) /
                                 scaled_determinant);
     }
 }
@@ -222,9 +275,11 @@ feature_round_q12_move (int32_t value)
   if (value < 0)
     {
       uint32_t magnitude = (uint32_t) -value;
-      return -(int32_t) ((magnitude >> 12) + ((magnitude & 0x800) != 0));
+      return -(int32_t) ((magnitude >> REFINEMENT_Q12_SHIFT) +
+                         ((magnitude & REFINEMENT_Q12_HALF) != 0));
     }
-  return (value >> 12) + (((uint32_t) value & 0x800) != 0);
+  return (value >> REFINEMENT_Q12_SHIFT) +
+         (((uint32_t) value & REFINEMENT_Q12_HALF) != 0);
 }
 
 static uint32_t
@@ -235,19 +290,19 @@ feature_exp2_q16 (int32_t value)
     0x00b8, 0x005c, 0x002e, 0x0017, 0x000c, 0x0006, 0x0003, 0x0001,
   };
   uint32_t magnitude = value < 0 ? (uint32_t) -value : (uint32_t) value;
-  uint32_t fraction = magnitude & 0xffff;
-  uint64_t result = UINT64_C(0x10000);
+  uint32_t fraction = magnitude & ((UINT32_C (1) << REFINEMENT_Q16_SHIFT) - 1);
+  uint64_t result = UINT64_C (1) << REFINEMENT_Q16_SHIFT;
 
-  if ((magnitude >> 16) > 0)
-    result <<= magnitude >> 16;
+  if ((magnitude >> REFINEMENT_Q16_SHIFT) > 0)
+    result <<= magnitude >> REFINEMENT_Q16_SHIFT;
   for (size_t bit = 0; bit < 16; bit++)
     if (fraction >= thresholds[bit])
       {
         fraction -= thresholds[bit];
         result += result >> (bit + 1);
       }
-  return value > 0 ? (uint32_t) result
-                   : (uint32_t) (UINT64_C(0x100000000) / result);
+  return value > 0 ? (uint32_t) result :
+         (uint32_t) ((UINT64_C (1) << 32) / result);
 }
 
 int
@@ -258,60 +313,70 @@ goodix_milan_feature_refine_extremum (
   GoodixMilanFeatureCandidate *candidate,
   uint32_t                    *curvature)
 {
-  int16_t hessian[6];
-  int16_t gradient[3];
+  int16_t hessian[HESSIAN_COUNT];
+  int16_t gradient[AXIS_COUNT];
   int16_t center;
-  int32_t offset[3];
+  int32_t offset[AXIS_COUNT];
   int32_t x, y, scale;
 
   x = candidate->x;
   y = candidate->y;
   scale = candidate->scale;
-  for (size_t iteration = 0; iteration < 5; iteration++)
+  for (size_t iteration = 0; iteration < REFINEMENT_ATTEMPT_LIMIT; iteration++)
     {
       if (!feature_build_refinement_derivatives (
             scales, rows, columns, x, y, scale, hessian, gradient, &center))
         return 0;
       feature_solve_refinement_offset (hessian, gradient, offset);
-      if (abs (offset[0]) < 0x800 && abs (offset[1]) < 0x800 &&
-          abs (offset[2]) < 0x800)
+      if (abs (offset[AXIS_X]) < REFINEMENT_Q12_HALF &&
+          abs (offset[AXIS_Y]) < REFINEMENT_Q12_HALF &&
+          abs (offset[AXIS_SCALE]) < REFINEMENT_Q12_HALF)
         {
-          int64_t contrast = (int64_t) center * 0x4000 +
-                             (int64_t) gradient[0] * offset[0] +
-                             (int64_t) gradient[1] * offset[1] +
-                             (int64_t) gradient[2] * offset[2];
+          int64_t contrast = (int64_t) center * REFINEMENT_CONTRAST_SCALE +
+                             (int64_t) gradient[AXIS_X] * offset[AXIS_X] +
+                             (int64_t) gradient[AXIS_Y] * offset[AXIS_Y] +
+                             (int64_t) gradient[AXIS_SCALE] * offset[AXIS_SCALE];
           if (contrast <= 0)
             contrast = -contrast;
-          if (contrast < 0x1478000)
+          if (contrast < REFINEMENT_CONTRAST_MINIMUM)
             return 0;
-          candidate->strength = (int32_t) (contrast >> 12);
-          int32_t trace = (int32_t) hessian[0] + hessian[1];
-          int32_t determinant = (int32_t) hessian[0] * hessian[1] -
-                                (int32_t) hessian[3] * hessian[3];
+          candidate->strength =
+            (int32_t) (contrast >> REFINEMENT_Q12_SHIFT);
+          int32_t trace = (int32_t) hessian[HESSIAN_XX] + hessian[HESSIAN_YY];
+          int32_t determinant =
+            (int32_t) hessian[HESSIAN_XX] * hessian[HESSIAN_YY] -
+            (int32_t) hessian[HESSIAN_XY] * hessian[HESSIAN_XY];
           if (determinant <= 0 ||
-              (int64_t) determinant * 41 * 41 <=
-                (int64_t) 40 * trace * trace)
+              (int64_t) determinant * REFINEMENT_EDGE_RATIO_PLUS_ONE *
+              REFINEMENT_EDGE_RATIO_PLUS_ONE <=
+              (int64_t) REFINEMENT_EDGE_RATIO * trace * trace)
             return 0;
           candidate->refined_x =
-            (int16_t) ((x * 0x1000 + offset[0]) >> 4);
+            (int16_t) ((x * REFINEMENT_Q12_ONE + offset[AXIS_X]) >>
+                       REFINEMENT_Q12_TO_Q8_SHIFT);
           candidate->refined_y =
-            (int16_t) ((y * 0x1000 + offset[1]) >> 4);
-          *curvature = (uint32_t) (((int64_t) trace * trace * 0x400) /
-                                   determinant);
-          int32_t exponent = ((scale * 0x1000 + offset[2]) * 0x10) / 3;
+            (int16_t) ((y * REFINEMENT_Q12_ONE + offset[AXIS_Y]) >>
+                       REFINEMENT_Q12_TO_Q8_SHIFT);
+          *curvature =
+            (uint32_t) (((int64_t) trace * trace *
+                         REFINEMENT_CURVATURE_SCALE) / determinant);
+          int32_t exponent =
+            ((scale * REFINEMENT_Q12_ONE + offset[AXIS_SCALE]) *
+             REFINEMENT_SCALE_EXPONENT_FACTOR) /
+            REFINEMENT_SCALE_EXPONENT_DIVISOR;
           candidate->scale_value =
-            (int32_t) (((uint64_t) feature_exp2_q16 (exponent) * 0x13333) >>
-                       16);
+            (int32_t) (((uint64_t) feature_exp2_q16 (exponent) *
+                        REFINEMENT_SCALE_FACTOR) >> REFINEMENT_Q16_SHIFT);
           return 1;
         }
 
-      x += feature_round_q12_move (offset[0]);
-      y += feature_round_q12_move (offset[1]);
-      scale += feature_round_q12_move (offset[2]);
+      x += feature_round_q12_move (offset[AXIS_X]);
+      y += feature_round_q12_move (offset[AXIS_Y]);
+      scale += feature_round_q12_move (offset[AXIS_SCALE]);
       candidate->x = x;
       candidate->y = y;
       candidate->scale = scale;
-      if (scale < 1 || scale > 3 || x < 1 ||
+      if (scale < EXTREMA_FIRST_SCALE || scale >= EXTREMA_SCALE_LIMIT || x < 1 ||
           x >= (int32_t) columns - 1 || y < 1 || y >= (int32_t) rows - 1)
         return 0;
     }


### PR DESCRIPTION
## Summary

Make Milan extrema discovery and refinement formulas traceable to their native contracts.

- Name the scale-space scan bounds, response threshold, gradient axes, and Hessian slots.
- Name strict derivative limits, refinement-attempt count, Q12/Q16 scales, saturation sentinel, contrast threshold, edge ratio, curvature scale, and scale conversion factors.
- Replace anonymous gradient, Hessian, and offset indices throughout derivative construction, solving, convergence, movement, and accepted-candidate publication.
- Add a compact native-owner header while retaining the existing discovery, derivative, solve, and refinement phase boundaries.

No behavioral change is intended.

## Native quirks preserved

- Derivative order remains gradient `[x,y,scale]` and Hessian `[xx,yy,scale-scale,xy,y-scale,x-scale]` (`FUN_180048c60`).
- Gradient and diagonal Hessian magnitudes must be strictly below `0x8000`; mixed terms must be strictly below `0x2000`. Equality rejects.
- A zero 3x3 determinant writes three zero offsets; numerator bit-length excess of nine or more still saturates to positive `0x00ffffff` regardless of sign (`FUN_18004bed0`).
- Convergence requires every Q12 offset magnitude strictly below half; movement remains half-away-from-zero and the fifth failed convergence publishes its movement before rejection (`FUN_18004c5a0`).
- Contrast equality at `0x1478000` remains accepted. The spatial determinant must be positive and satisfy the strict `determinant * 41^2 > 40 * trace^2` edge test.
- Refined coordinates, curvature, exponent division, threshold-table approximation, and final scale conversion retain their original arithmetic order and widths.

## Evidence

- Direct Ghidra disassembly/decompilation of `FUN_180047c50`, `FUN_180048c60`, `FUN_18004bed0`, `FUN_18004c5a0`, and `FUN_18004c100` confirms every named domain and predicate against existing `milan-dev` notes. No new or corrected native finding resulted.
- Differential harness: 200,000 extremum-collection and 200,000 refinement cases against the parent PR, zero return or mutation mismatches. Production `104x88` controls, fixed-width endpoints, scan ties, capacity truncation, and refinement movement/convergence/rejection were covered.
- ASan/UBSan: all 400,000 comparisons passed without sanitizer or leak findings.
- Mutation controls detected the strict response threshold, neighbor equality, exact Q12 convergence boundary, and exact contrast acceptance boundary.
- Formatting is repeatable without changes; debug-disabled build and existing Milan synthetic/state/runtime suites pass.

## Follow-ups (not in this PR)

- Materialization allocation and count-query ownership remain a separate cross-file refactor scope.
