### PR TITLE
Clarify Milan transform proximity

### DIFF
--- a/drivers/goodix53x5/milan/match/admission.c
+++ b/drivers/goodix53x5/milan/match/admission.c
@@ -12,6 +12,21 @@
 
 #include <string.h>
 
+enum
+{
+  AFFINE_XX,
+  AFFINE_XY,
+  AFFINE_X_OFFSET,
+  AFFINE_YX,
+  AFFINE_YY,
+  AFFINE_Y_OFFSET,
+  AFFINE_WORDS,
+};
+
+#define AFFINE_Q8_ONE 0x100
+#define PROXIMITY_PRIMARY_SENSOR_MASK UINT32_C (0x472010)
+#define PROXIMITY_ALTERNATE_SENSOR_MASK UINT64_C (0xc000000000001ec5)
+
 int
 goodix_milan_match_fallback_candidate_eligible (
   int32_t composite_score,
@@ -23,51 +38,58 @@ goodix_milan_match_fallback_candidate_eligible (
 
 int
 goodix_milan_match_transform_proximity (const int32_t transform[6],
-                                                int32_t       mode,
-                                                uint32_t      sensor_type)
+                                        int32_t       mode,
+                                        uint32_t      sensor_type)
 {
-  static const int32_t identity[6] = { 0x100, 0, 0, 0, 0x100, 0 };
-  int32_t thresholds[6] = { 15, 11, 0x400, 11, 15, 0x400 };
+  static const int32_t identity[AFFINE_WORDS] = {
+    [AFFINE_XX] = AFFINE_Q8_ONE,
+    [AFFINE_YY] = AFFINE_Q8_ONE,
+  };
+  static const int32_t default_limits[AFFINE_WORDS] = {
+    15, 11, 0x400, 11, 15, 0x400,
+  };
+  static const int32_t mode4_limits[AFFINE_WORDS] = {
+    38, 38, 0xc00, 38, 38, 0xc00,
+  };
+  static const int32_t mode5_limits[AFFINE_WORDS] = {
+    45, 40, 0xf00, 40, 45, 0xf00,
+  };
+  static const int32_t alternate_sensor_limits[AFFINE_WORDS] = {
+    25, 21, 0x700, 21, 25, 0x700,
+  };
+  int32_t limits[AFFINE_WORDS];
   int32_t multiplier = 1;
 
-  if (!transform || mode < 1 || mode > 5)
+  if (mode < 1 || mode > 5)
     return 0;
+  memcpy (limits, default_limits, sizeof (limits));
   if (mode == 3)
     multiplier = 2;
   else if (mode == 4)
-    {
-      const int32_t values[6] = { 38, 38, 0xc00, 38, 38, 0xc00 };
-
-      memcpy (thresholds, values, sizeof (thresholds));
-    }
+    memcpy (limits, mode4_limits, sizeof (limits));
   else if (mode == 5)
-    {
-      const int32_t values[6] = { 45, 40, 0xf00, 40, 45, 0xf00 };
-
-      memcpy (thresholds, values, sizeof (thresholds));
-    }
-  if (sensor_type < 23 && ((UINT32_C (0x472010) >> sensor_type) & 1) != 0)
+    memcpy (limits, mode5_limits, sizeof (limits));
+  if (sensor_type < 23 &&
+      ((PROXIMITY_PRIMARY_SENSOR_MASK >> sensor_type) & 1) != 0)
     {
       if (mode == 2)
         multiplier = 2;
     }
   else
     {
-      static const int32_t alternate[6] = {
-        25, 21, 0x700, 21, 25, 0x700,
-      };
-
       if (sensor_type >= 64 ||
-          ((UINT64_C (0xc000000000001ec5) >> sensor_type) & 1) == 0)
+          ((PROXIMITY_ALTERNATE_SENSOR_MASK >> sensor_type) & 1) == 0)
         return 0;
-      memcpy (thresholds, alternate, sizeof (thresholds));
+      /* Preserve current mode-1 limits for alternate-family modes 4/5. Native
+       * uses their wider tables, but profile-9/type-12 cannot reach them. */
+      memcpy (limits, alternate_sensor_limits, sizeof (limits));
       multiplier = 1;
     }
-  for (size_t i = 0; i < 6; i++)
+  for (size_t i = 0; i < AFFINE_WORDS; i++)
     {
       int32_t delta = transform[i] - identity[i];
 
-      if ((delta < 0 ? -delta : delta) > thresholds[i] * multiplier)
+      if ((delta < 0 ? -delta : delta) > limits[i] * multiplier)
         return 0;
     }
   return 1;


### PR DESCRIPTION
## Summary

Make Milan transform-proximity admission readable without changing its existing behavior.

- Name the six affine slots, Q8 identity, and both sensor-family masks.
- Name the default, mode-4, mode-5, and alternate-family component-limit tables.
- Replace branch-local anonymous arrays with one explicit selected limit vector.
- Remove the non-native null guard from this internal helper; all production callers provide a transform.

No reachable production behavior change is intended.

## Native quirks preserved

- Modes outside `1..5` return false before reading the transform (`FUN_1800624c0`).
- Component limits are inclusive; equality passes and limit plus one fails.
- Mode 3 doubles the selected limits, and mode 2 doubles limits only for the primary sensor family.
- Unsupported sensor types return false without reading transform components.
- The current alternate-family mode-4/5 table override remains unchanged and is explicitly documented. It differs from native but is unreachable for profile-9/type-12, whose production proximity modes are `0..3`.

## Evidence

- Direct Ghidra disassembly/decompilation of `FUN_1800624c0` confirms mode dispatch, sensor masks, component order, inclusive limits, and native table selection against the existing `milan-dev` note.
- Caller review confirms every production invocation supplies a nonnull six-word transform; profile-9/type-12 cannot reach the preserved mode-4/5 deviation.
- Differential harness: 624,300 proximity cases and 600,512 fallback-eligibility cases against `main`, zero mismatches. Every mode, sensor type `0..80`, mask boundary, affine component, exact limit, and full signed-dword inputs within defined arithmetic were covered.
- ASan/UBSan passed the complete corpus without findings.
- Mutation controls detected inclusive-boundary, mode-3 multiplier, and alternate-family table changes.
- Debug-disabled build and existing Milan synthetic/state/runtime suites pass.

## Follow-ups (not in this PR)

- The next PR names the initial candidate classifier's metric and configuration domains.
