### PR TITLE
Narrow Milan quality validity contracts

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -1707,14 +1707,13 @@ goodix_milan_preprocess_quality (const uint8_t *frame,
     goto out;
 
   if (goodix_milan_preprocess_quality_coverage_mask (
-        frame, rows, columns, coverage_mask, &raw_coverage) != 0 ||
-      goodix_milan_preprocess_quality_valid_mask (
-        frame, rows, columns, valid_mask, &original_valid_score) != 0)
+        frame, rows, columns, coverage_mask, &raw_coverage) != 0)
     goto out;
+  goodix_milan_preprocess_quality_valid_mask (
+    frame, rows, columns, valid_mask, &original_valid_score);
   propagated_valid_score =
     goodix_milan_preprocess_quality_mask_coverage (valid_mask, count);
-  if (propagated_valid_score < 0 ||
-      quality_patch_score_core (
+  if (quality_patch_score_core (
         frame, valid_mask, rows, columns, 1, refined_mask, &patch_score) != 0 ||
       quality_mask_fraction_core (
         frame, refined_mask, rows, columns, &mask_fraction) != 0 ||

--- a/drivers/goodix53x5/milan/preprocess/validity.c
+++ b/drivers/goodix53x5/milan/preprocess/validity.c
@@ -10,7 +10,6 @@
 
 #include "milan/milan.h"
 
-#include <limits.h>
 #include <stdint.h>
 
 int
@@ -19,8 +18,6 @@ goodix_milan_preprocess_quality_mask_coverage (const uint8_t *mask,
 {
   size_t selected = 0;
 
-  if (!mask || count == 0 || count > INT_MAX)
-    return -1;
   for (size_t i = 0; i < count; i++)
     selected += mask[i] != 0;
   return (int) ((selected * UINT32_C(0x10000)) / count);
@@ -36,14 +33,7 @@ goodix_milan_preprocess_quality_valid_mask (const uint8_t *frame,
   size_t count;
   size_t valid = 0;
 
-  if (!frame || !mask || !valid_score || rows == 0 || columns == 0 ||
-      columns > SIZE_MAX / rows)
-    return -1;
-
   count = rows * columns;
-  if (count > INT_MAX)
-    return -1;
-
   for (size_t row = 0; row < rows; row++)
     {
       for (size_t column = 0; column < columns; column++)


### PR DESCRIPTION
## Summary

Narrow Milan quality-validity helpers to their proven internal contract.

- Remove null, zero-geometry, overflow-geometry, and oversized-count checks absent from native; `goodix_milan_preprocess_quality()` establishes valid allocated planes and dimensions.
- Remove the corresponding impossible error branches from the sole quality caller.
- Retain allocation failure and every later quality-stage status check.

No reachable production behavior change is intended.

## Native quirks preserved

- Only image byte `0xff` is initially invalid; `0xfe` remains valid (`FUN_1800446f0`).
- Original-valid score is computed before radius-two propagation.
- Propagated-mask coverage is counted independently from the original-valid score (`FUN_180044530`).
- Q16 multiplication remains before integer division.

## Evidence

- Caller proof confirms successful allocation and positive bounded geometry before both leaves; their valid-domain results cannot be negative.
- Direct Ghidra validation of `FUN_1800446f0`, `FUN_180073ff0`, and `FUN_180044530` confirms classification, propagation, Q16 arithmetic, and ownership against existing `milan-dev` notes.
- Differential harness and independent oracle: 300,000 coverage cases and 250,000 valid-mask cases against `main`, zero return, score, mask, input, or guard mismatches.
- ASan/UBSan passed all 550,000 cases without findings.
- Six mutation controls detected classification, radius, bounds, and Q16-order changes.
- Debug-disabled build and existing Milan synthetic/state/runtime suites pass.

## Follow-ups (not in this PR)

- The next PR names the validity and propagation domains.
