### PR TITLE
Clarify Milan quality validity masks

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/validity.c
+++ b/drivers/goodix53x5/milan/preprocess/validity.c
@@ -12,26 +12,32 @@
 
 #include <stdint.h>
 
+/* Profile-9 validity masks recovered from FUN_1800446f0 and FUN_180073ff0;
+ * propagated-mask coverage is consumed by FUN_180044530. */
+#define VALIDITY_Q16_ONE UINT32_C (0x10000)
+#define VALIDITY_INVALID_SAMPLE UINT8_MAX
+#define VALIDITY_MASK_SELECTED UINT8_MAX
+
 int
 goodix_milan_preprocess_quality_mask_coverage (const uint8_t *mask,
-                                           size_t         count)
+                                               size_t         count)
 {
-  size_t selected = 0;
+  size_t propagated_valid = 0;
 
   for (size_t i = 0; i < count; i++)
-    selected += mask[i] != 0;
-  return (int) ((selected * UINT32_C(0x10000)) / count);
+    propagated_valid += mask[i] != 0;
+  return (int) ((propagated_valid * VALIDITY_Q16_ONE) / count);
 }
 
 int
 goodix_milan_preprocess_quality_valid_mask (const uint8_t *frame,
-                                        size_t         rows,
-                                        size_t         columns,
-                                        uint8_t       *mask,
-                                        int           *valid_score)
+                                            size_t         rows,
+                                            size_t         columns,
+                                            uint8_t       *mask,
+                                            int           *valid_score)
 {
   size_t count;
-  size_t valid = 0;
+  size_t original_valid = 0;
 
   count = rows * columns;
   for (size_t row = 0; row < rows; row++)
@@ -39,24 +45,31 @@ goodix_milan_preprocess_quality_valid_mask (const uint8_t *frame,
       for (size_t column = 0; column < columns; column++)
         {
           size_t index = row * columns + column;
-          int invalid = frame[index] == UINT8_MAX;
+          int invalid = frame[index] == VALIDITY_INVALID_SAMPLE;
 
-          valid += !invalid;
+          original_valid += !invalid;
+          /* A byte remains excluded only when the center and every in-bounds
+           * axial neighbor at distance one or two are invalid. */
           if (invalid &&
-              (column < 1 || frame[index - 1] == UINT8_MAX) &&
-              (column + 1 >= columns || frame[index + 1] == UINT8_MAX) &&
-              (row < 1 || frame[index - columns] == UINT8_MAX) &&
-              (row + 1 >= rows || frame[index + columns] == UINT8_MAX) &&
-              (column < 2 || frame[index - 2] == UINT8_MAX) &&
-              (column + 2 >= columns || frame[index + 2] == UINT8_MAX) &&
-              (row < 2 || frame[index - columns * 2] == UINT8_MAX) &&
-              (row + 2 >= rows || frame[index + columns * 2] == UINT8_MAX))
+              (column < 1 || frame[index - 1] == VALIDITY_INVALID_SAMPLE) &&
+              (column + 1 >= columns ||
+               frame[index + 1] == VALIDITY_INVALID_SAMPLE) &&
+              (row < 1 || frame[index - columns] == VALIDITY_INVALID_SAMPLE) &&
+              (row + 1 >= rows ||
+               frame[index + columns] == VALIDITY_INVALID_SAMPLE) &&
+              (column < 2 || frame[index - 2] == VALIDITY_INVALID_SAMPLE) &&
+              (column + 2 >= columns ||
+               frame[index + 2] == VALIDITY_INVALID_SAMPLE) &&
+              (row < 2 ||
+               frame[index - columns * 2] == VALIDITY_INVALID_SAMPLE) &&
+              (row + 2 >= rows ||
+               frame[index + columns * 2] == VALIDITY_INVALID_SAMPLE))
             mask[index] = 0;
           else
-            mask[index] = UINT8_MAX;
+            mask[index] = VALIDITY_MASK_SELECTED;
         }
     }
 
-  *valid_score = (int) ((valid * UINT32_C(0x10000)) / count);
+  *valid_score = (int) ((original_valid * VALIDITY_Q16_ONE) / count);
   return 0;
 }


### PR DESCRIPTION
## Summary

Make Milan quality-validity mask semantics explicit.

- Name the Q16 scale, exact invalid sample, and selected-mask byte.
- Distinguish original-valid and propagated-valid counts.
- Document the nine-position radius-two cross directly above its expanded boundary predicate.
- Retain the expanded checks so ignored out-of-plane positions remain visible.

No behavioral change is intended.

## Native quirks preserved

- A byte remains excluded only when its center and every in-bounds axial neighbor at distance one or two are `0xff` (`FUN_1800446f0`, `FUN_180073ff0`).
- Out-of-plane positions are ignored, so corners and interior pixels propagate to different support counts.
- An all-`0xff` frame produces an all-zero mask; any other byte can propagate validity.
- The returned score remains the original pre-propagation Q16 valid fraction.

## Evidence

- Direct Ghidra validation confirms exact byte classification, cross geometry, bounds behavior, and score timing against existing `milan-dev` notes.
- Differential harness and independent oracle: 550,000 valid-domain comparisons against the parent PR, zero mismatches, including production `88x108`, corners, interiors, distances one through three, noncanonical masks, and Q16 boundaries.
- ASan/UBSan passed the complete corpus without findings.
- All six classification, radius, bounds, and arithmetic mutation controls were detected.
- Formatting is repeatable without changes; debug-disabled build and existing Milan synthetic/state/runtime suites pass.

## Follow-ups (not in this PR)

- Quality patch scoring and final combination remain separate refactor scopes.
