### PR TITLE
Narrow Milan feature record contracts

### DIFF
--- a/drivers/goodix53x5/milan/feature/record.c
+++ b/drivers/goodix53x5/milan/feature/record.c
@@ -40,8 +40,6 @@ goodix_milan_feature_transform_record (uint8_t *record,
   uint8_t first[8];
   uint8_t second[8];
 
-  if (!record)
-    return;
   for (size_t i = 0; i < 8; i++)
     {
       uint8_t left = record[16 + i * 2];
@@ -67,7 +65,7 @@ goodix_milan_feature_partition_records (uint8_t *records,
   size_t left = 0;
   size_t right;
 
-  if (!records || record_count == 0)
+  if (record_count == 0)
     return 0;
   right = record_count - 1;
   while (left < right)


### PR DESCRIPTION
## Summary

- remove non-native null handling from positive-count internal feature-record operations
- retain the zero-count partition return before any record access
- preserve all valid production behavior

Malformed positive-count null calls now fault like native rather than returning quietly. No reachable behavior change is intended.

## Native Quirks Preserved

- mode zero still performs the common nibble transform without tail expansion
- any nonzero mode selects bit reversal and tail expansion
- empty partition input returns boundary zero without dereferencing records
- the partition remains limited to producer-supplied low classes zero and one

## Evidence

- directly revalidated `FUN_180047ae0` and `FUN_180037480` in Ghidra
- 600,604 differential cases, zero mismatches
- ASan/UBSan/LeakSanitizer clean
- 17/17 mutation controls killed across the stack
- Milan synthetic, state, and runtime suites pass

## Follow-Ups

- The next layer names the 56-byte record layout and partition domains.
