### PR TITLE
Name Milan feature record layout

### DIFF
--- a/drivers/goodix53x5/milan/feature/record.c
+++ b/drivers/goodix53x5/milan/feature/record.c
@@ -12,55 +12,78 @@
 
 #include <string.h>
 
+/* In-place 56-byte descriptor transform recovered from FUN_180047ae0. */
+enum {
+  MILAN_FEATURE_RECORD_SIZE = 56,
+  MILAN_FEATURE_PAIR_COUNT = 8,
+  MILAN_FEATURE_PAIR_OFFSET = 16,
+  MILAN_FEATURE_SOURCE_WORD_OFFSET = 32,
+  MILAN_FEATURE_REVERSED_WORD_OFFSET = 36,
+  MILAN_FEATURE_TAIL_OFFSET = 40,
+  MILAN_FEATURE_EXPANDED_TAIL_OFFSET = 48,
+  MILAN_FEATURE_PARTITION_MASK = 3,
+  MILAN_FEATURE_LEFT_CLASS = 0,
+  MILAN_FEATURE_RIGHT_CLASS = 1,
+};
+
 static void
 milan_feature_expand_record (uint8_t *record)
 {
   uint32_t bits;
   uint32_t reversed = 0;
 
-  memcpy (&bits, record + 32, sizeof(bits));
+  memcpy (&bits, record + MILAN_FEATURE_SOURCE_WORD_OFFSET, sizeof (bits));
   for (size_t i = 0; i < 32; i++)
     reversed |= ((bits >> i) & 1U) << (31 - i);
-  memcpy (record + 36, &reversed, sizeof(reversed));
-  record[48] = record[40];
-  record[49] = (uint8_t) ~record[41];
-  record[50] = (uint8_t) ~record[42];
-  record[51] = record[43];
-  record[52] = record[47];
-  record[53] = record[46];
-  record[54] = record[45];
-  record[55] = record[44];
+  memcpy (record + MILAN_FEATURE_REVERSED_WORD_OFFSET,
+          &reversed, sizeof (reversed));
+  record[MILAN_FEATURE_EXPANDED_TAIL_OFFSET] =
+    record[MILAN_FEATURE_TAIL_OFFSET];
+  record[MILAN_FEATURE_EXPANDED_TAIL_OFFSET + 1] =
+    (uint8_t) ~record[MILAN_FEATURE_TAIL_OFFSET + 1];
+  record[MILAN_FEATURE_EXPANDED_TAIL_OFFSET + 2] =
+    (uint8_t) ~record[MILAN_FEATURE_TAIL_OFFSET + 2];
+  record[MILAN_FEATURE_EXPANDED_TAIL_OFFSET + 3] =
+    record[MILAN_FEATURE_TAIL_OFFSET + 3];
+  for (size_t i = 0; i < 4; i++)
+    record[MILAN_FEATURE_EXPANDED_TAIL_OFFSET + 4 + i] =
+      record[MILAN_FEATURE_TAIL_OFFSET + 7 - i];
 }
 
 void
 goodix_milan_feature_transform_record (uint8_t *record,
                                        int      reverse_bits)
 {
-  static const uint8_t swap_order[8] = { 0, 1, 1, 0, 1, 0, 0, 1 };
-  uint8_t first[8];
-  uint8_t second[8];
+  static const uint8_t swap_order[MILAN_FEATURE_PAIR_COUNT] = {
+    0, 1, 1, 0, 1, 0, 0, 1,
+  };
+  uint8_t first[MILAN_FEATURE_PAIR_COUNT];
+  uint8_t second[MILAN_FEATURE_PAIR_COUNT];
 
-  for (size_t i = 0; i < 8; i++)
+  for (size_t i = 0; i < MILAN_FEATURE_PAIR_COUNT; i++)
     {
-      uint8_t left = record[16 + i * 2];
-      uint8_t right = record[17 + i * 2];
+      uint8_t left = record[MILAN_FEATURE_PAIR_OFFSET + i * 2];
+      uint8_t right = record[MILAN_FEATURE_PAIR_OFFSET + i * 2 + 1];
       uint8_t high_left = ((left ^ right) & 0x0f) ^ left;
       uint8_t high_right = ((left ^ right) & 0x0f) ^ right;
 
       first[i] = swap_order[i] == 0 ? high_right : high_left;
       second[i] = swap_order[i] == 0 ? high_left : high_right;
     }
-  memcpy (record + 16, first, sizeof(first));
-  memcpy (record + 24, second, sizeof(second));
-  memset (record + 36, 0, 4);
+  memcpy (record + MILAN_FEATURE_PAIR_OFFSET, first, sizeof (first));
+  memcpy (record + MILAN_FEATURE_PAIR_OFFSET + MILAN_FEATURE_PAIR_COUNT,
+          second, sizeof (second));
+  memset (record + MILAN_FEATURE_REVERSED_WORD_OFFSET, 0, sizeof (uint32_t));
 
   if (reverse_bits)
     milan_feature_expand_record (record);
 }
 
+/* Partition Boolean low classes in place. End swaps make this deliberately
+ * unstable; low classes 2/3 are outside the producer contract. */
 size_t
 goodix_milan_feature_partition_records (uint8_t *records,
-                                         size_t   record_count)
+                                        size_t   record_count)
 {
   size_t left = 0;
   size_t right;
@@ -70,19 +93,28 @@ goodix_milan_feature_partition_records (uint8_t *records,
   right = record_count - 1;
   while (left < right)
     {
-      while (left < right && (records[left * 56] & 3) == 0)
+      while (left < right &&
+             (records[left * MILAN_FEATURE_RECORD_SIZE] &
+              MILAN_FEATURE_PARTITION_MASK) == MILAN_FEATURE_LEFT_CLASS)
         left++;
-      while (left < right && (records[right * 56] & 3) == 1)
+      while (left < right &&
+             (records[right * MILAN_FEATURE_RECORD_SIZE] &
+              MILAN_FEATURE_PARTITION_MASK) == MILAN_FEATURE_RIGHT_CLASS)
         right--;
       if (left < right)
         {
-          uint8_t temporary[56];
+          uint8_t temporary[MILAN_FEATURE_RECORD_SIZE];
 
-          memcpy (temporary, records + left * 56, sizeof(temporary));
-          memcpy (records + left * 56, records + right * 56,
-                  sizeof(temporary));
-          memcpy (records + right * 56, temporary, sizeof(temporary));
+          memcpy (temporary, records + left * MILAN_FEATURE_RECORD_SIZE,
+                  sizeof (temporary));
+          memcpy (records + left * MILAN_FEATURE_RECORD_SIZE,
+                  records + right * MILAN_FEATURE_RECORD_SIZE,
+                  sizeof (temporary));
+          memcpy (records + right * MILAN_FEATURE_RECORD_SIZE,
+                  temporary, sizeof (temporary));
         }
     }
-  return left + ((records[left * 56] & 3) == 0);
+  return left +
+         ((records[left * MILAN_FEATURE_RECORD_SIZE] &
+           MILAN_FEATURE_PARTITION_MASK) == MILAN_FEATURE_LEFT_CLASS);
 }


### PR DESCRIPTION
## Summary

- name feature-record size, descriptor spans, source/reversed words, and tail offsets
- name descriptor pair count, nibble transform placement, and partition classes
- document the deliberately unstable two-ended partition

No behavioral change is intended.

## Native Quirks Preserved

- low nibbles exchange while high nibbles remain attached to their source bytes
- mode expansion reverses the source dword and writes the exact transformed tail order
- the intermediate reversed-word destination is always cleared before optional expansion
- whole 56-byte records are swapped, making the Boolean partition unstable
- upper record flag bits are preserved and ignored by the low-two-bit classifier

## Evidence

- directly revalidated `FUN_180047ae0`, `FUN_18004c9f0`, and `FUN_180037480` in Ghidra
- 600,604 differential cases, zero mismatches including exact partition permutations
- ASan/UBSan/LeakSanitizer clean
- 17/17 mutation controls killed across transform and partition domains
- formatting is repeatable; Milan synthetic, state, and runtime suites pass

## Follow-Ups

- Feature mask expansion remains an independent, very small leaf.
