### PR TITLE
Internalize Milan anti-fake boundary scratch storage

### DIFF
--- a/drivers/goodix53x5/milan/antifake/construction.c
+++ b/drivers/goodix53x5/milan/antifake/construction.c
@@ -14,29 +14,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-static int milan_antifake_collect_candidates (
-  GoodixMilanAntifakeBlob *antifake,
-  size_t                   antifake_size,
-  const uint16_t          *source,
-  size_t                   rows,
-  size_t                   columns,
-  int32_t                  x_adjustment);
+static int milan_antifake_collect_candidates (GoodixMilanAntifakeBlob *antifake,
+                                              size_t                   antifake_size,
+                                              const uint16_t          *source,
+                                              size_t                   rows,
+                                              size_t                   columns,
+                                              int32_t                  x_adjustment);
 
-static int milan_antifake_build_class (
-  const uint16_t *calibration,
-  const uint16_t *raw_frame,
-  const uint8_t  *classification_plane,
-  const uint8_t  *feature_mask,
-  size_t          feature_mask_size,
-  size_t          rows,
-  size_t          columns,
-  uint16_t        t_code,
-  uint16_t        dac_high,
-  uint16_t        dac_low,
-  uint16_t        chip_type,
-  int32_t         calibration_scalar,
-  GoodixMilanAntifakeBlob *antifake,
-  size_t                   antifake_size);
+static int milan_antifake_build_class (const uint16_t          *calibration,
+                                       const uint16_t          *raw_frame,
+                                       const uint8_t           *classification_plane,
+                                       const uint8_t           *feature_mask,
+                                       size_t                   feature_mask_size,
+                                       size_t                   rows,
+                                       size_t                   columns,
+                                       uint16_t                 t_code,
+                                       uint16_t                 dac_high,
+                                       uint16_t                 dac_low,
+                                       uint16_t                 chip_type,
+                                       int32_t                  calibration_scalar,
+                                       GoodixMilanAntifakeBlob *antifake,
+                                       size_t                   antifake_size);
 
 static int32_t
 milan_antifake_sensor_offset (uint16_t t_code,
@@ -58,18 +56,18 @@ milan_antifake_sensor_offset (uint16_t t_code,
 
 int
 goodix_milan_antifake_build (
-  const uint16_t *calibration,
-  const uint16_t *raw_frame,
-  const uint8_t  *classification_plane,
-  const uint8_t  *feature_mask,
-  size_t          feature_mask_size,
-  size_t          rows,
-  size_t          columns,
-  uint16_t        t_code,
-  uint16_t        dac_high,
-  uint16_t        dac_low,
-  uint16_t        chip_type,
-  int32_t         calibration_scalar,
+  const uint16_t          *calibration,
+  const uint16_t          *raw_frame,
+  const uint8_t           *classification_plane,
+  const uint8_t           *feature_mask,
+  size_t                   feature_mask_size,
+  size_t                   rows,
+  size_t                   columns,
+  uint16_t                 t_code,
+  uint16_t                 dac_high,
+  uint16_t                 dac_low,
+  uint16_t                 chip_type,
+  int32_t                  calibration_scalar,
   GoodixMilanAntifakeBlob *antifake,
   size_t                   antifake_size)
 {
@@ -81,25 +79,24 @@ goodix_milan_antifake_build (
 
 static int
 milan_antifake_build_class (
-  const uint16_t                   *calibration,
-  const uint16_t                   *raw_frame,
-  const uint8_t                    *classification_plane,
-  const uint8_t                    *feature_mask,
-  size_t                            feature_mask_size,
-  size_t                            rows,
-  size_t                            columns,
-  uint16_t                          t_code,
-  uint16_t                          dac_high,
-  uint16_t                          dac_low,
-  uint16_t                          chip_type,
-  int32_t                           calibration_scalar,
-  GoodixMilanAntifakeBlob          *antifake,
-  size_t                            antifake_size)
+  const uint16_t          *calibration,
+  const uint16_t          *raw_frame,
+  const uint8_t           *classification_plane,
+  const uint8_t           *feature_mask,
+  size_t                   feature_mask_size,
+  size_t                   rows,
+  size_t                   columns,
+  uint16_t                 t_code,
+  uint16_t                 dac_high,
+  uint16_t                 dac_low,
+  uint16_t                 chip_type,
+  int32_t                  calibration_scalar,
+  GoodixMilanAntifakeBlob *antifake,
+  size_t                   antifake_size)
 {
   uint16_t *residual = NULL;
   uint8_t *mask = NULL;
   uint8_t *classes = NULL;
-  uint8_t *thinned = NULL;
   int32_t vector[51];
   int32_t threshold;
   int32_t texture;
@@ -116,16 +113,15 @@ milan_antifake_build_class (
       columns > SIZE_MAX / rows)
     return -1;
   count = rows * columns;
-  if (count > SIZE_MAX / sizeof(*residual))
+  if (count > SIZE_MAX / sizeof (*residual))
     return -1;
-  residual = malloc (count * sizeof(*residual));
+  residual = malloc (count * sizeof (*residual));
   mask = malloc (count);
   classes = malloc (count);
-  thinned = malloc (count);
-  if (!residual || !mask || !classes || !thinned)
+  if (!residual || !mask || !classes)
     goto out;
 
-  memset (goodix_milan_antifake_data (antifake), 0, sizeof(*antifake));
+  memset (goodix_milan_antifake_data (antifake), 0, sizeof (*antifake));
   if (goodix_milan_antifake_residual (
         calibration, raw_frame, rows, columns,
         milan_antifake_sensor_offset (t_code, dac_high, dac_low, chip_type),
@@ -138,7 +134,7 @@ milan_antifake_build_class (
         residual, rows, columns, &threshold) != 0)
     goto out;
   goodix_milan_antifake_set_calibration_scalar (antifake,
-                                                 calibration_scalar);
+                                                calibration_scalar);
   goodix_milan_antifake_set_threshold (antifake, threshold);
 
   if (milan_antifake_collect_candidates (
@@ -153,7 +149,7 @@ milan_antifake_build_class (
       goodix_milan_antifake_class_map (
         classification_plane, mask, rows, columns, classes) != 0 ||
       goodix_milan_antifake_boundary_score (
-        residual, classes, rows, columns, thinned, &boundary) != 0 ||
+        residual, classes, rows, columns, &boundary) != 0 ||
       goodix_milan_antifake_model_vector (
         residual, mask, rows, columns, 2, vector) != 0 ||
       goodix_milan_antifake_model_score (vector, &model) != 0)
@@ -186,7 +182,6 @@ milan_antifake_build_class (
   result = 0;
 
 out:
-  free (thinned);
   free (classes);
   free (mask);
   free (residual);
@@ -195,20 +190,20 @@ out:
 
 int
 goodix_milan_antifake_build_with_boundary (
-  const uint16_t                   *calibration,
-  const uint16_t                   *raw_frame,
-  const uint8_t                    *classification_plane,
-  const uint8_t                    *feature_mask,
-  size_t                            feature_mask_size,
-  size_t                            rows,
-  size_t                            columns,
-  uint16_t                          t_code,
-  uint16_t                          dac_high,
-  uint16_t                          dac_low,
-  uint16_t                          chip_type,
-  int32_t                           calibration_scalar,
-  GoodixMilanAntifakeBlob          *antifake,
-  size_t                            antifake_size,
+  const uint16_t                    *calibration,
+  const uint16_t                    *raw_frame,
+  const uint8_t                     *classification_plane,
+  const uint8_t                     *feature_mask,
+  size_t                             feature_mask_size,
+  size_t                             rows,
+  size_t                             columns,
+  uint16_t                           t_code,
+  uint16_t                           dac_high,
+  uint16_t                           dac_low,
+  uint16_t                           chip_type,
+  int32_t                            calibration_scalar,
+  GoodixMilanAntifakeBlob           *antifake,
+  size_t                             antifake_size,
   GoodixMilanAntifakeBoundaryResult *boundary_result)
 {
   GoodixMilanAntifakeBlob *alternate_antifake = NULL;
@@ -216,7 +211,7 @@ goodix_milan_antifake_build_with_boundary (
   int result;
 
   if (boundary_result)
-    memset (boundary_result, 0, sizeof(*boundary_result));
+    memset (boundary_result, 0, sizeof (*boundary_result));
   result = milan_antifake_build_class (
     calibration, raw_frame, classification_plane, feature_mask,
     feature_mask_size, rows, columns, t_code, dac_high, dac_low, chip_type,
@@ -225,7 +220,7 @@ goodix_milan_antifake_build_with_boundary (
       feature_mask_size != 52 * 44)
     return result;
 
-  alternate_antifake = malloc (sizeof(*alternate_antifake));
+  alternate_antifake = malloc (sizeof (*alternate_antifake));
   alternate_feature_mask = malloc (feature_mask_size + 1);
   if (!alternate_antifake || !alternate_feature_mask)
     {
@@ -244,9 +239,9 @@ goodix_milan_antifake_build_with_boundary (
 
   if (boundary_result)
     {
-      memcpy (&boundary_result->zero_projection, antifake, sizeof(*antifake));
+      memcpy (&boundary_result->zero_projection, antifake, sizeof (*antifake));
       memcpy (&boundary_result->nonzero_projection, alternate_antifake,
-              sizeof(*alternate_antifake));
+              sizeof (*alternate_antifake));
       boundary_result->zero_candidate_count =
         goodix_milan_antifake_candidate_count (antifake);
       boundary_result->nonzero_candidate_count =
@@ -254,7 +249,7 @@ goodix_milan_antifake_build_with_boundary (
     }
   if (memcmp (goodix_milan_antifake_const_data (antifake),
               goodix_milan_antifake_const_data (alternate_antifake),
-              sizeof(*antifake)) != 0)
+              sizeof (*antifake)) != 0)
     {
       if (boundary_result)
         boundary_result->classification =
@@ -281,21 +276,22 @@ milan_antifake_collect_candidates (
   int32_t                  x_adjustment)
 {
   static const int8_t offsets[44][2] = {
-    { 1, 0 }, { 1, 1 }, { 0, 1 }, {-1, 1 }, {-1, 0 }, {-1,-1 },
-    { 0,-1 }, { 1,-1 }, { 2, 0 }, { 2, 1 }, { 1, 2 }, { 0, 2 },
-    {-1, 2 }, {-2, 1 }, {-2, 0 }, {-2,-1 }, {-1,-2 }, { 0,-2 },
-    { 1,-2 }, { 2,-1 }, { 3, 0 }, { 3, 1 }, { 3, 2 }, { 2, 2 },
+    { 1, 0 }, { 1, 1 }, { 0, 1 }, {-1, 1 }, {-1, 0 }, {-1, -1 },
+    { 0, -1 }, { 1, -1 }, { 2, 0 }, { 2, 1 }, { 1, 2 }, { 0, 2 },
+    {-1, 2 }, {-2, 1 }, {-2, 0 }, {-2, -1 }, {-1, -2 }, { 0, -2 },
+    { 1, -2 }, { 2, -1 }, { 3, 0 }, { 3, 1 }, { 3, 2 }, { 2, 2 },
     { 2, 3 }, { 1, 3 }, { 0, 3 }, {-1, 3 }, {-2, 3 }, {-2, 2 },
-    {-3, 2 }, {-3, 1 }, {-3, 0 }, {-3,-1 }, {-3,-2 }, {-2,-2 },
-    {-2,-3 }, {-1,-3 }, { 0,-3 }, { 1,-3 }, { 2,-3 }, { 2,-2 },
-    { 3,-2 }, { 3,-1 },
+    {-3, 2 }, {-3, 1 }, {-3, 0 }, {-3, -1 }, {-3, -2 }, {-2, -2 },
+    {-2, -3 }, {-1, -3 }, { 0, -3 }, { 1, -3 }, { 2, -3 }, { 2, -2 },
+    { 3, -2 }, { 3, -1 },
   };
+
   typedef struct
   {
     int32_t x;
     int32_t y;
     int32_t metric;
-    int invalid;
+    int     invalid;
   } AntifakeCandidate;
   AntifakeCandidate candidates[400];
   size_t candidate_count = 0;
@@ -333,7 +329,7 @@ milan_antifake_collect_candidates (
             metric += center - neighbor;
           }
         if (accepted && candidate_count < 400)
-          candidates[candidate_count++] = (AntifakeCandidate) {
+          candidates[candidate_count++] = (AntifakeCandidate){
             (int32_t) x, (int32_t) y, metric, 0,
           };
       }
@@ -375,7 +371,7 @@ milan_antifake_collect_candidates (
         goodix_milan_antifake_set_record_y (record, candidates[i].y);
         memcpy (record + GOODIX_MILAN_ANTIFAKE_RECORD_DATA_24_OFFSET,
                 &candidates[i].metric,
-                sizeof(candidates[i].metric));
+                sizeof (candidates[i].metric));
         output_count++;
       }
   for (size_t i = 0; i < output_count; i++)

--- a/drivers/goodix53x5/milan/antifake/construction.c
+++ b/drivers/goodix53x5/milan/antifake/construction.c
@@ -14,27 +14,29 @@
 #include <stdlib.h>
 #include <string.h>
 
-static int milan_antifake_collect_candidates (GoodixMilanAntifakeBlob *antifake,
-                                              size_t                   antifake_size,
-                                              const uint16_t          *source,
-                                              size_t                   rows,
-                                              size_t                   columns,
-                                              int32_t                  x_adjustment);
+static int milan_antifake_collect_candidates (
+  GoodixMilanAntifakeBlob *antifake,
+  size_t                   antifake_size,
+  const uint16_t          *source,
+  size_t                   rows,
+  size_t                   columns,
+  int32_t                  x_adjustment);
 
-static int milan_antifake_build_class (const uint16_t          *calibration,
-                                       const uint16_t          *raw_frame,
-                                       const uint8_t           *classification_plane,
-                                       const uint8_t           *feature_mask,
-                                       size_t                   feature_mask_size,
-                                       size_t                   rows,
-                                       size_t                   columns,
-                                       uint16_t                 t_code,
-                                       uint16_t                 dac_high,
-                                       uint16_t                 dac_low,
-                                       uint16_t                 chip_type,
-                                       int32_t                  calibration_scalar,
-                                       GoodixMilanAntifakeBlob *antifake,
-                                       size_t                   antifake_size);
+static int milan_antifake_build_class (
+  const uint16_t *calibration,
+  const uint16_t *raw_frame,
+  const uint8_t  *classification_plane,
+  const uint8_t  *feature_mask,
+  size_t          feature_mask_size,
+  size_t          rows,
+  size_t          columns,
+  uint16_t        t_code,
+  uint16_t        dac_high,
+  uint16_t        dac_low,
+  uint16_t        chip_type,
+  int32_t         calibration_scalar,
+  GoodixMilanAntifakeBlob *antifake,
+  size_t                   antifake_size);
 
 static int32_t
 milan_antifake_sensor_offset (uint16_t t_code,
@@ -56,18 +58,18 @@ milan_antifake_sensor_offset (uint16_t t_code,
 
 int
 goodix_milan_antifake_build (
-  const uint16_t          *calibration,
-  const uint16_t          *raw_frame,
-  const uint8_t           *classification_plane,
-  const uint8_t           *feature_mask,
-  size_t                   feature_mask_size,
-  size_t                   rows,
-  size_t                   columns,
-  uint16_t                 t_code,
-  uint16_t                 dac_high,
-  uint16_t                 dac_low,
-  uint16_t                 chip_type,
-  int32_t                  calibration_scalar,
+  const uint16_t *calibration,
+  const uint16_t *raw_frame,
+  const uint8_t  *classification_plane,
+  const uint8_t  *feature_mask,
+  size_t          feature_mask_size,
+  size_t          rows,
+  size_t          columns,
+  uint16_t        t_code,
+  uint16_t        dac_high,
+  uint16_t        dac_low,
+  uint16_t        chip_type,
+  int32_t         calibration_scalar,
   GoodixMilanAntifakeBlob *antifake,
   size_t                   antifake_size)
 {
@@ -79,20 +81,20 @@ goodix_milan_antifake_build (
 
 static int
 milan_antifake_build_class (
-  const uint16_t          *calibration,
-  const uint16_t          *raw_frame,
-  const uint8_t           *classification_plane,
-  const uint8_t           *feature_mask,
-  size_t                   feature_mask_size,
-  size_t                   rows,
-  size_t                   columns,
-  uint16_t                 t_code,
-  uint16_t                 dac_high,
-  uint16_t                 dac_low,
-  uint16_t                 chip_type,
-  int32_t                  calibration_scalar,
-  GoodixMilanAntifakeBlob *antifake,
-  size_t                   antifake_size)
+  const uint16_t                   *calibration,
+  const uint16_t                   *raw_frame,
+  const uint8_t                    *classification_plane,
+  const uint8_t                    *feature_mask,
+  size_t                            feature_mask_size,
+  size_t                            rows,
+  size_t                            columns,
+  uint16_t                          t_code,
+  uint16_t                          dac_high,
+  uint16_t                          dac_low,
+  uint16_t                          chip_type,
+  int32_t                           calibration_scalar,
+  GoodixMilanAntifakeBlob          *antifake,
+  size_t                            antifake_size)
 {
   uint16_t *residual = NULL;
   uint8_t *mask = NULL;
@@ -113,15 +115,15 @@ milan_antifake_build_class (
       columns > SIZE_MAX / rows)
     return -1;
   count = rows * columns;
-  if (count > SIZE_MAX / sizeof (*residual))
+  if (count > SIZE_MAX / sizeof(*residual))
     return -1;
-  residual = malloc (count * sizeof (*residual));
+  residual = malloc (count * sizeof(*residual));
   mask = malloc (count);
   classes = malloc (count);
   if (!residual || !mask || !classes)
     goto out;
 
-  memset (goodix_milan_antifake_data (antifake), 0, sizeof (*antifake));
+  memset (goodix_milan_antifake_data (antifake), 0, sizeof(*antifake));
   if (goodix_milan_antifake_residual (
         calibration, raw_frame, rows, columns,
         milan_antifake_sensor_offset (t_code, dac_high, dac_low, chip_type),
@@ -134,7 +136,7 @@ milan_antifake_build_class (
         residual, rows, columns, &threshold) != 0)
     goto out;
   goodix_milan_antifake_set_calibration_scalar (antifake,
-                                                calibration_scalar);
+                                                 calibration_scalar);
   goodix_milan_antifake_set_threshold (antifake, threshold);
 
   if (milan_antifake_collect_candidates (
@@ -190,20 +192,20 @@ out:
 
 int
 goodix_milan_antifake_build_with_boundary (
-  const uint16_t                    *calibration,
-  const uint16_t                    *raw_frame,
-  const uint8_t                     *classification_plane,
-  const uint8_t                     *feature_mask,
-  size_t                             feature_mask_size,
-  size_t                             rows,
-  size_t                             columns,
-  uint16_t                           t_code,
-  uint16_t                           dac_high,
-  uint16_t                           dac_low,
-  uint16_t                           chip_type,
-  int32_t                            calibration_scalar,
-  GoodixMilanAntifakeBlob           *antifake,
-  size_t                             antifake_size,
+  const uint16_t                   *calibration,
+  const uint16_t                   *raw_frame,
+  const uint8_t                    *classification_plane,
+  const uint8_t                    *feature_mask,
+  size_t                            feature_mask_size,
+  size_t                            rows,
+  size_t                            columns,
+  uint16_t                          t_code,
+  uint16_t                          dac_high,
+  uint16_t                          dac_low,
+  uint16_t                          chip_type,
+  int32_t                           calibration_scalar,
+  GoodixMilanAntifakeBlob          *antifake,
+  size_t                            antifake_size,
   GoodixMilanAntifakeBoundaryResult *boundary_result)
 {
   GoodixMilanAntifakeBlob *alternate_antifake = NULL;
@@ -211,7 +213,7 @@ goodix_milan_antifake_build_with_boundary (
   int result;
 
   if (boundary_result)
-    memset (boundary_result, 0, sizeof (*boundary_result));
+    memset (boundary_result, 0, sizeof(*boundary_result));
   result = milan_antifake_build_class (
     calibration, raw_frame, classification_plane, feature_mask,
     feature_mask_size, rows, columns, t_code, dac_high, dac_low, chip_type,
@@ -220,7 +222,7 @@ goodix_milan_antifake_build_with_boundary (
       feature_mask_size != 52 * 44)
     return result;
 
-  alternate_antifake = malloc (sizeof (*alternate_antifake));
+  alternate_antifake = malloc (sizeof(*alternate_antifake));
   alternate_feature_mask = malloc (feature_mask_size + 1);
   if (!alternate_antifake || !alternate_feature_mask)
     {
@@ -239,9 +241,9 @@ goodix_milan_antifake_build_with_boundary (
 
   if (boundary_result)
     {
-      memcpy (&boundary_result->zero_projection, antifake, sizeof (*antifake));
+      memcpy (&boundary_result->zero_projection, antifake, sizeof(*antifake));
       memcpy (&boundary_result->nonzero_projection, alternate_antifake,
-              sizeof (*alternate_antifake));
+              sizeof(*alternate_antifake));
       boundary_result->zero_candidate_count =
         goodix_milan_antifake_candidate_count (antifake);
       boundary_result->nonzero_candidate_count =
@@ -249,7 +251,7 @@ goodix_milan_antifake_build_with_boundary (
     }
   if (memcmp (goodix_milan_antifake_const_data (antifake),
               goodix_milan_antifake_const_data (alternate_antifake),
-              sizeof (*antifake)) != 0)
+              sizeof(*antifake)) != 0)
     {
       if (boundary_result)
         boundary_result->classification =
@@ -276,22 +278,21 @@ milan_antifake_collect_candidates (
   int32_t                  x_adjustment)
 {
   static const int8_t offsets[44][2] = {
-    { 1, 0 }, { 1, 1 }, { 0, 1 }, {-1, 1 }, {-1, 0 }, {-1, -1 },
-    { 0, -1 }, { 1, -1 }, { 2, 0 }, { 2, 1 }, { 1, 2 }, { 0, 2 },
-    {-1, 2 }, {-2, 1 }, {-2, 0 }, {-2, -1 }, {-1, -2 }, { 0, -2 },
-    { 1, -2 }, { 2, -1 }, { 3, 0 }, { 3, 1 }, { 3, 2 }, { 2, 2 },
+    { 1, 0 }, { 1, 1 }, { 0, 1 }, {-1, 1 }, {-1, 0 }, {-1,-1 },
+    { 0,-1 }, { 1,-1 }, { 2, 0 }, { 2, 1 }, { 1, 2 }, { 0, 2 },
+    {-1, 2 }, {-2, 1 }, {-2, 0 }, {-2,-1 }, {-1,-2 }, { 0,-2 },
+    { 1,-2 }, { 2,-1 }, { 3, 0 }, { 3, 1 }, { 3, 2 }, { 2, 2 },
     { 2, 3 }, { 1, 3 }, { 0, 3 }, {-1, 3 }, {-2, 3 }, {-2, 2 },
-    {-3, 2 }, {-3, 1 }, {-3, 0 }, {-3, -1 }, {-3, -2 }, {-2, -2 },
-    {-2, -3 }, {-1, -3 }, { 0, -3 }, { 1, -3 }, { 2, -3 }, { 2, -2 },
-    { 3, -2 }, { 3, -1 },
+    {-3, 2 }, {-3, 1 }, {-3, 0 }, {-3,-1 }, {-3,-2 }, {-2,-2 },
+    {-2,-3 }, {-1,-3 }, { 0,-3 }, { 1,-3 }, { 2,-3 }, { 2,-2 },
+    { 3,-2 }, { 3,-1 },
   };
-
   typedef struct
   {
     int32_t x;
     int32_t y;
     int32_t metric;
-    int     invalid;
+    int invalid;
   } AntifakeCandidate;
   AntifakeCandidate candidates[400];
   size_t candidate_count = 0;
@@ -329,7 +330,7 @@ milan_antifake_collect_candidates (
             metric += center - neighbor;
           }
         if (accepted && candidate_count < 400)
-          candidates[candidate_count++] = (AntifakeCandidate){
+          candidates[candidate_count++] = (AntifakeCandidate) {
             (int32_t) x, (int32_t) y, metric, 0,
           };
       }
@@ -371,7 +372,7 @@ milan_antifake_collect_candidates (
         goodix_milan_antifake_set_record_y (record, candidates[i].y);
         memcpy (record + GOODIX_MILAN_ANTIFAKE_RECORD_DATA_24_OFFSET,
                 &candidates[i].metric,
-                sizeof (candidates[i].metric));
+                sizeof(candidates[i].metric));
         output_count++;
       }
   for (size_t i = 0; i < output_count; i++)

--- a/drivers/goodix53x5/milan/antifake/morphology.c
+++ b/drivers/goodix53x5/milan/antifake/morphology.c
@@ -457,25 +457,33 @@ goodix_milan_antifake_boundary_score (
   const uint8_t  *classes,
   size_t          rows,
   size_t          columns,
-  uint8_t        *thinned,
   int32_t        *score)
 {
+  uint8_t *thinned;
   uint32_t maximum;
   uint32_t difference_sum;
   uint32_t adjacent_count;
+  int result = -1;
 
-  if (!residual || !classes || !thinned || !score || rows < 7 ||
+  if (!residual || !classes || !score || rows < 7 ||
       columns < 7 || columns > SIZE_MAX / rows)
     return -1;
 
+  thinned = malloc (rows * columns);
+  if (!thinned)
+    return -1;
   for (size_t i = 0; i < rows * columns; i++)
     thinned[i] = classes[i] == ANTIFAKE_CLASS_DARK ? ANTIFAKE_CLASS_DARK : 0;
 
   maximum = boundary_maximum_residual (residual, classes, rows, columns);
   if (zhang_suen_thin (thinned, rows, columns, THINNING_MAX_ITERATIONS) != 0)
-    return -1;
+    goto out;
   boundary_adjacent_differences (residual, thinned, rows, columns,
                                  &difference_sum, &adjacent_count);
-  return boundary_rounded_ratio (difference_sum, adjacent_count, maximum,
-                                 score);
+  result = boundary_rounded_ratio (difference_sum, adjacent_count, maximum,
+                                   score);
+
+out:
+  free (thinned);
+  return result;
 }

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -1228,7 +1228,6 @@ int goodix_milan_antifake_boundary_score (
   const uint8_t  *classes,
   size_t          rows,
   size_t          columns,
-  uint8_t        *thinned,
   int32_t        *score);
 
 int goodix_milan_antifake_build (


### PR DESCRIPTION
## Summary

Internalize the thinning scratch buffer owned by `goodix_milan_antifake_boundary_score()`, removing caller-only allocation and its public parameter. No reachable behavior change is intended.

## Contracts Preserved

- Input and geometry validation remain at the boundary-score owner.
- Allocation failure still returns `-1`.
- Thinning, adjacent-difference accumulation, and rounded-ratio order are unchanged.

## Evidence

- 100,000 valid-geometry differential cases matched exactly.
- ASan/UBSan and leak checks passed; thinning and ratio mutations were detected.
- Release/debug builds and Milan suites pass in the validated integration.

## Stack

Item 1 of the 13-PR Milan refactor stack; based on `main`.
