### PR TITLE
Narrow Milan feature helper contracts

### DIFF
--- a/drivers/goodix53x5/milan/feature/extraction.c
+++ b/drivers/goodix53x5/milan/feature/extraction.c
@@ -179,8 +179,7 @@ feature_build_scale_space_pass (const uint8_t *blurred,
   const MilanFeatureKernel *kernels;
   size_t count;
 
-  if (!blurred || !scales || rows == 0 || columns == 0 ||
-      columns > SIZE_MAX / rows ||
+  if ((rows != 0 && columns > SIZE_MAX / rows) ||
       (pass_marker != 0 && pass_marker != 100))
     return -1;
   kernels = milan_feature_kernels[pass_marker == 100];
@@ -220,8 +219,7 @@ feature_build_gradients_pass (const uint8_t *enhanced,
   uint16_t *second = NULL;
   int result = -1;
 
-  if (!enhanced || !gradient_input || !magnitude || !orientation || rows < 2 ||
-      columns < 2 || columns > SIZE_MAX / rows ||
+  if ((rows != 0 && columns > SIZE_MAX / rows) ||
       (pass_marker != 0 && pass_marker != 100))
     return -1;
   kernels = milan_feature_kernels[pass_marker == 100];

--- a/drivers/goodix53x5/milan/feature/materialization.c
+++ b/drivers/goodix53x5/milan/feature/materialization.c
@@ -200,8 +200,7 @@ goodix_milan_feature_collect_materialized (
   uint8_t *visited = calloc (rows * columns, 1);
   size_t count = 0;
 
-  if (!feature_source || !scales || !magnitude || !orientation ||
-      !records || !ranks || !auxiliary || !extrema || !visited)
+  if (!extrema || !visited)
     {
       free (visited);
       free (extrema);


### PR DESCRIPTION
## Summary

Remove redundant pointer and minimum-geometry checks from internal feature helpers after proving every caller establishes those preconditions. No successful-path behavior change is intended.

## Contracts Preserved

- Pass-marker, arithmetic-overflow, allocation, and capacity failures remain checked.
- Scale-space and materialization traversal/output order is unchanged.
- Invalid direct calls outside the internal contract are no longer handled defensively, matching native ownership.

## Evidence

- Caller enumeration covered every repository call site.
- 206,000 valid-domain differential cases matched; invalid-surface checks confirmed the intentional contract change.
- ASan/UBSan, mutations, release/debug builds, current runner, and Milan suites pass.

## Stack

Item 8 of the 13-PR Milan refactor stack; depends on the vocabulary-normalization PR.
