### PR TITLE
Isolate Milan runtime debug instrumentation

### DIFF
--- a/drivers/goodix53x5/meson.build
+++ b/drivers/goodix53x5/meson.build
@@ -37,6 +37,7 @@ goodix53x5_sources = files(
     'milan/match/study.c',
     'milan/match/match.c',
     'milan/core.c',
+    'milan/debug-hooks.c',
     'milan/preprocess/classification.c',
     'milan/preprocess/gain.c',
     'milan/preprocess/selection.c',

--- a/drivers/goodix53x5/milan/debug-hooks.c
+++ b/drivers/goodix53x5/milan/debug-hooks.c
@@ -1,0 +1,222 @@
+/*
+ * Goodix 53x5 driver for libfprint - Milan algorithm debug hooks
+ * Copyright (C) 2026 goodix-fp-linux-dev contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "milan/debug-hooks.h"
+
+#include "milan/antifake/antifake.h"
+
+#include <string.h>
+
+#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
+static void
+goodix_milan_debug_hash_bytes (GBytes *bytes,
+                               gchar   digest[65])
+{
+  gconstpointer data;
+  gsize size;
+  g_autofree gchar *checksum = NULL;
+
+  digest[0] = '\0';
+  if (!bytes)
+    return;
+  data = g_bytes_get_data (bytes, &size);
+  checksum = g_compute_checksum_for_data (G_CHECKSUM_SHA256, data, size);
+  g_strlcpy (digest, checksum ? checksum : "", 65);
+}
+
+void
+goodix_milan_debug_runtime_hash_after_match (
+  GoodixMilanRuntimeGalleryResult *result,
+  GBytes                          *after_match)
+{
+  goodix_milan_debug_hash_bytes (after_match, result->after_match_sha256);
+}
+#endif
+
+#ifdef GOODIX53X5_DEBUG
+static void
+goodix_milan_debug_hash_projection (
+  const GoodixMilanAntifakeBlob *projection,
+  gchar                          digest[GOODIX_MILAN_EXTRACTION_SHA256_SIZE])
+{
+  g_autofree gchar *checksum = g_compute_checksum_for_data (
+    G_CHECKSUM_SHA256, goodix_milan_antifake_const_data (projection),
+    GOODIX_MILAN_ANTIFAKE_DEFINED_MATERIAL_SIZE);
+
+  g_strlcpy (digest, checksum ? checksum : "",
+             GOODIX_MILAN_EXTRACTION_SHA256_SIZE);
+}
+
+void
+goodix_milan_debug_extraction_antifake (
+  GoodixMilanExtractionDiagnostics *diagnostics,
+  const guint16                    *calibration,
+  const guint16                    *raw_frame,
+  const guint8                     *primary_contrast_plane,
+  const guint8                     *feature_mask,
+  guint16                           t_code,
+  guint16                           dac_high,
+  guint16                           dac_low,
+  guint16                           sensor_subtype,
+  gint32                            calibration_scalar)
+{
+  g_autofree GoodixMilanAntifakeBlob *diagnostic_antifake = NULL;
+
+  if (diagnostics && calibration && raw_frame &&
+      (diagnostic_antifake = g_try_malloc0 (
+         sizeof (*diagnostic_antifake))) != NULL)
+    {
+      GoodixMilanAntifakeBoundaryResult boundary = { 0 };
+      int status = goodix_milan_antifake_build_with_boundary (
+        calibration, raw_frame, primary_contrast_plane, feature_mask, 52 * 44,
+        GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, t_code,
+        dac_high, dac_low, sensor_subtype, calibration_scalar,
+        diagnostic_antifake, sizeof (*diagnostic_antifake), &boundary);
+
+      if (status == 0 || status == GOODIX_MILAN_ANTIFAKE_AMBIGUOUS)
+        {
+          diagnostics->boundary_classification = boundary.classification;
+          diagnostics->zero_candidate_count = boundary.zero_candidate_count;
+          diagnostics->nonzero_candidate_count = boundary.nonzero_candidate_count;
+          goodix_milan_debug_hash_projection (
+            &boundary.zero_projection, diagnostics->zero_projection_sha256);
+          goodix_milan_debug_hash_projection (
+            &boundary.nonzero_projection,
+            diagnostics->nonzero_projection_sha256);
+        }
+    }
+}
+
+void
+goodix_milan_debug_runtime_gallery_result_free (
+  GoodixMilanRuntimeGalleryResult *result)
+{
+  g_clear_pointer (&result->input_template, g_bytes_unref);
+  g_clear_pointer (&result->after_match_template, g_bytes_unref);
+}
+
+void
+goodix_milan_debug_runtime_setup_failed (GoodixMilanRuntimeOutput *output,
+                                         gint32                    status)
+{
+  output->preprocess_attempted = TRUE;
+  output->preprocess_status = status;
+  output->preprocess_status_available = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_preprocess_started (GoodixMilanRuntimeOutput *output)
+{
+  output->preprocess_attempted = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_preprocess_status (GoodixMilanRuntimeOutput *output,
+                                              gint32                    status)
+{
+  output->preprocess_status = status;
+  output->preprocess_status_available = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_preprocess_finished (GoodixMilanRuntimeOutput *output,
+                                                gint32                    status,
+                                                const guint8             *processed)
+{
+  output->preprocess_completed = status == 0;
+  if (output->preprocess_completed ||
+      status == GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION)
+    output->processed_image = g_bytes_new (processed,
+                                           GOODIX_MILAN_SENSOR_PIXELS);
+}
+
+void
+goodix_milan_debug_runtime_extraction_started (GoodixMilanRuntimeOutput *output)
+{
+  output->extraction_attempted = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_extraction_finished (GoodixMilanRuntimeOutput *output)
+{
+  output->extraction_completed = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_gallery_input (GoodixMilanRuntimeGalleryResult *result,
+                                          GBytes                          *input_template)
+{
+  result->input_template = g_bytes_ref (input_template);
+  goodix_milan_debug_hash_bytes (input_template, result->input_template_sha256);
+}
+
+void
+goodix_milan_debug_runtime_gallery_validated (GoodixMilanRuntimeGalleryResult *result)
+{
+  result->validation_observed = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_queue_before_match (GoodixMilanRuntimeGalleryResult *result,
+                                               const GoodixStudyQueue          *queue)
+{
+  result->queue_before_match_observed = TRUE;
+  result->queue_state_before_match = queue->enabled_state;
+  result->queue_counter_before_match = queue->transaction_counter;
+  result->queue_occupied_before_match = goodix_milan_study_queue_occupied (queue);
+}
+
+void
+goodix_milan_debug_runtime_queue_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                              const GoodixStudyQueue          *queue)
+{
+  result->queue_after_match_observed = TRUE;
+  result->queue_occupied_after_match = goodix_milan_study_queue_occupied (queue);
+}
+
+void
+goodix_milan_debug_runtime_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                        GBytes                          *after_match)
+{
+  result->after_match_template = g_bytes_ref (after_match);
+}
+
+void
+goodix_milan_debug_runtime_study_started (GoodixMilanRuntimeOutput *output)
+{
+  output->study_attempted = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_queue_after_study (GoodixMilanRuntimeOutput *output,
+                                              gsize                     winner_position,
+                                              const GoodixStudyQueue   *queue)
+{
+  GoodixMilanRuntimeGalleryResult *result =
+    g_ptr_array_index (output->gallery_results, winner_position);
+
+  result->queue_after_study_observed = TRUE;
+  result->queue_state_after_study = queue->enabled_state;
+  result->queue_counter_after_study = queue->transaction_counter;
+  result->queue_occupied_after_study = goodix_milan_study_queue_occupied (queue);
+}
+
+void
+goodix_milan_debug_runtime_study_finished (GoodixMilanRuntimeOutput *output)
+{
+  output->study_completed = TRUE;
+}
+
+void
+goodix_milan_debug_runtime_output_free (GoodixMilanRuntimeOutput *output)
+{
+  g_clear_pointer (&output->processed_image, g_bytes_unref);
+}
+#endif

--- a/drivers/goodix53x5/milan/debug-hooks.h
+++ b/drivers/goodix53x5/milan/debug-hooks.h
@@ -1,0 +1,226 @@
+/*
+ * Goodix 53x5 driver for libfprint - Milan algorithm debug hooks
+ * Copyright (C) 2026 goodix-fp-linux-dev contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "milan/runtime.h"
+#include "milan/study/queue.h"
+
+#ifdef GOODIX53X5_DEBUG
+void goodix_milan_debug_runtime_gallery_result_free (
+  GoodixMilanRuntimeGalleryResult *result);
+void goodix_milan_debug_runtime_setup_failed (
+  GoodixMilanRuntimeOutput *output,
+  gint32                    status);
+void goodix_milan_debug_runtime_preprocess_started (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_preprocess_status (
+  GoodixMilanRuntimeOutput *output,
+  gint32                    status);
+void goodix_milan_debug_runtime_preprocess_finished (
+  GoodixMilanRuntimeOutput *output,
+  gint32                    status,
+  const guint8             *processed);
+void goodix_milan_debug_runtime_extraction_started (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_extraction_finished (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_gallery_input (
+  GoodixMilanRuntimeGalleryResult *result,
+  GBytes                          *input_template);
+void goodix_milan_debug_runtime_gallery_validated (
+  GoodixMilanRuntimeGalleryResult *result);
+void goodix_milan_debug_runtime_queue_before_match (
+  GoodixMilanRuntimeGalleryResult *result,
+  const GoodixStudyQueue          *queue);
+void goodix_milan_debug_runtime_queue_after_match (
+  GoodixMilanRuntimeGalleryResult *result,
+  const GoodixStudyQueue          *queue);
+void goodix_milan_debug_runtime_after_match (
+  GoodixMilanRuntimeGalleryResult *result,
+  GBytes                          *after_match);
+void goodix_milan_debug_runtime_study_started (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_queue_after_study (
+  GoodixMilanRuntimeOutput *output,
+  gsize                     winner_position,
+  const GoodixStudyQueue   *queue);
+void goodix_milan_debug_runtime_study_finished (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_output_free (
+  GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_extraction_antifake (
+  GoodixMilanExtractionDiagnostics *diagnostics,
+  const guint16                    *calibration,
+  const guint16                    *raw_frame,
+  const guint8                     *primary_contrast_plane,
+  const guint8                     *feature_mask,
+  guint16                           t_code,
+  guint16                           dac_high,
+  guint16                           dac_low,
+  guint16                           sensor_subtype,
+  gint32                            calibration_scalar);
+#else
+static inline void
+goodix_milan_debug_runtime_gallery_result_free (
+  GoodixMilanRuntimeGalleryResult *result)
+{
+  (void) result;
+}
+
+static inline void
+goodix_milan_debug_runtime_setup_failed (GoodixMilanRuntimeOutput *output,
+                                         gint32                    status)
+{
+  (void) output;
+  (void) status;
+}
+
+static inline void
+goodix_milan_debug_runtime_preprocess_started (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_runtime_preprocess_status (GoodixMilanRuntimeOutput *output,
+                                              gint32                    status)
+{
+  (void) output;
+  (void) status;
+}
+
+static inline void
+goodix_milan_debug_runtime_preprocess_finished (GoodixMilanRuntimeOutput *output,
+                                                gint32                    status,
+                                                const guint8             *processed)
+{
+  (void) output;
+  (void) status;
+  (void) processed;
+}
+
+static inline void
+goodix_milan_debug_runtime_extraction_started (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_runtime_extraction_finished (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_runtime_gallery_input (GoodixMilanRuntimeGalleryResult *result,
+                                          GBytes                          *input_template)
+{
+  (void) result;
+  (void) input_template;
+}
+
+static inline void
+goodix_milan_debug_runtime_gallery_validated (GoodixMilanRuntimeGalleryResult *result)
+{
+  (void) result;
+}
+
+static inline void
+goodix_milan_debug_runtime_queue_before_match (GoodixMilanRuntimeGalleryResult *result,
+                                               const GoodixStudyQueue          *queue)
+{
+  (void) result;
+  (void) queue;
+}
+
+static inline void
+goodix_milan_debug_runtime_queue_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                              const GoodixStudyQueue          *queue)
+{
+  (void) result;
+  (void) queue;
+}
+
+static inline void
+goodix_milan_debug_runtime_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                        GBytes                          *after_match)
+{
+  (void) result;
+  (void) after_match;
+}
+
+static inline void
+goodix_milan_debug_runtime_study_started (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_runtime_queue_after_study (GoodixMilanRuntimeOutput *output,
+                                              gsize                     winner_position,
+                                              const GoodixStudyQueue   *queue)
+{
+  (void) output;
+  (void) winner_position;
+  (void) queue;
+}
+
+static inline void
+goodix_milan_debug_runtime_study_finished (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_runtime_output_free (GoodixMilanRuntimeOutput *output)
+{
+  (void) output;
+}
+
+static inline void
+goodix_milan_debug_extraction_antifake (
+  GoodixMilanExtractionDiagnostics *diagnostics,
+  const guint16                    *calibration,
+  const guint16                    *raw_frame,
+  const guint8                     *primary_contrast_plane,
+  const guint8                     *feature_mask,
+  guint16                           t_code,
+  guint16                           dac_high,
+  guint16                           dac_low,
+  guint16                           sensor_subtype,
+  gint32                            calibration_scalar)
+{
+  (void) diagnostics;
+  (void) calibration;
+  (void) raw_frame;
+  (void) primary_contrast_plane;
+  (void) feature_mask;
+  (void) t_code;
+  (void) dac_high;
+  (void) dac_low;
+  (void) sensor_subtype;
+  (void) calibration_scalar;
+}
+#endif
+
+#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
+void goodix_milan_debug_runtime_hash_after_match (
+  GoodixMilanRuntimeGalleryResult *result,
+  GBytes                          *after_match);
+#else
+static inline void
+goodix_milan_debug_runtime_hash_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                             GBytes                          *after_match)
+{
+  (void) result;
+  (void) after_match;
+}
+#endif

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -11,6 +11,7 @@
 #define FP_COMPONENT "goodix53x5"
 
 #include "drivers_api.h"
+#include "milan/debug-hooks.h"
 #include "milan/match/match.h"
 #include "milan/match/info-private.h"
 #include "milan/match/rescue.h"
@@ -328,26 +329,8 @@ static GoodixMilanExtractionStatus goodix_milan_match_extract_planes (
   guint16        dac_low,
   guint16        sensor_subtype,
   gint32         calibration_scalar,
-  GoodixMatchInfo **result
-#ifdef GOODIX53X5_DEBUG
-  , GoodixMilanExtractionDiagnostics *diagnostics
-#endif
-  );
-
-#ifdef GOODIX53X5_DEBUG
-static void
-goodix_milan_match_hash_projection (
-  const GoodixMilanAntifakeBlob *projection,
-  gchar                          digest[GOODIX_MILAN_EXTRACTION_SHA256_SIZE])
-{
-  g_autofree gchar *checksum = g_compute_checksum_for_data (
-    G_CHECKSUM_SHA256, goodix_milan_antifake_const_data (projection),
-    GOODIX_MILAN_ANTIFAKE_DEFINED_MATERIAL_SIZE);
-
-  g_strlcpy (digest, checksum ? checksum : "",
-             GOODIX_MILAN_EXTRACTION_SHA256_SIZE);
-}
-#endif
+  GoodixMatchInfo **result,
+  GoodixMilanExtractionDiagnostics *diagnostics);
 
 GoodixMatchInfo *
 goodix_milan_match_extract_native (const guint8               *image,
@@ -391,11 +374,7 @@ goodix_milan_match_extract_native_result (
     &preprocess_state->extraction_classification,
     &preprocess_state->extraction_auxiliary, preprocess_state->setup_map,
     raw_frame, t_code, dac_high, dac_low, sensor_subtype,
-    preprocess_state->selected_refined, info
-#ifdef GOODIX53X5_DEBUG
-    , NULL
-#endif
-    );
+    preprocess_state->selected_refined, info, NULL);
 }
 
 #ifdef GOODIX53X5_DEBUG
@@ -442,17 +421,11 @@ goodix_milan_match_extract_planes (const guint8  *image,
                              guint16        dac_high,
                              guint16        dac_low,
                              guint16        sensor_subtype,
-                             gint32         calibration_scalar,
-                             GoodixMatchInfo **result
-#ifdef GOODIX53X5_DEBUG
-                             , GoodixMilanExtractionDiagnostics *diagnostics
-#endif
-                             )
+                              gint32         calibration_scalar,
+                              GoodixMatchInfo **result,
+                              GoodixMilanExtractionDiagnostics *diagnostics)
 {
   GoodixMatchInfo *info = NULL;
-#ifdef GOODIX53X5_DEBUG
-  g_autofree GoodixMilanAntifakeBlob *diagnostic_antifake = NULL;
-#endif
   guint8 *cropped = NULL;
   guint8 *high = NULL;
   guint8 *low = NULL;
@@ -559,32 +532,9 @@ goodix_milan_match_extract_planes (const guint8  *image,
         dac_low,
         sensor_subtype, calibration_scalar, antifake, sizeof(*antifake)) != 0)
     goto out;
-#ifdef GOODIX53X5_DEBUG
-  if (diagnostics && calibration && raw_frame &&
-      (diagnostic_antifake = g_try_malloc0 (
-         sizeof(*diagnostic_antifake))) != NULL)
-    {
-      GoodixMilanAntifakeBoundaryResult boundary = { 0 };
-      int diagnostic_status = goodix_milan_antifake_build_with_boundary (
-        calibration, raw_frame, primary_contrast_plane, feature_mask,
-        52 * 44, GOODIX_MILAN_SENSOR_ROWS, GOODIX_MILAN_SENSOR_COLUMNS, t_code,
-        dac_high, dac_low, sensor_subtype, calibration_scalar, diagnostic_antifake,
-        sizeof(*diagnostic_antifake), &boundary);
-
-      if (diagnostic_status == 0 ||
-          diagnostic_status == GOODIX_MILAN_ANTIFAKE_AMBIGUOUS)
-        {
-          diagnostics->boundary_classification = boundary.classification;
-          diagnostics->zero_candidate_count = boundary.zero_candidate_count;
-          diagnostics->nonzero_candidate_count = boundary.nonzero_candidate_count;
-          goodix_milan_match_hash_projection (
-            &boundary.zero_projection, diagnostics->zero_projection_sha256);
-          goodix_milan_match_hash_projection (
-            &boundary.nonzero_projection,
-            diagnostics->nonzero_projection_sha256);
-        }
-    }
-#endif
+  goodix_milan_debug_extraction_antifake (
+    diagnostics, calibration, raw_frame, primary_contrast_plane, feature_mask,
+    t_code, dac_high, dac_low, sensor_subtype, calibration_scalar);
   goodix_milan_feature_mask_expand (inline_mask, feature_mask);
   if (calibration && raw_frame &&
       goodix_milan_template_initialize_tail (

--- a/drivers/goodix53x5/milan/match/match.h
+++ b/drivers/goodix53x5/milan/match/match.h
@@ -90,7 +90,6 @@ typedef enum {
   GOODIX_MILAN_EXTRACTION_INVALID,
 } GoodixMilanExtractionStatus;
 
-#ifdef GOODIX53X5_DEBUG
 #define GOODIX_MILAN_EXTRACTION_SHA256_SIZE 65
 
 typedef struct
@@ -103,7 +102,6 @@ typedef struct
   gchar                            nonzero_projection_sha256[
     GOODIX_MILAN_EXTRACTION_SHA256_SIZE];
 } GoodixMilanExtractionDiagnostics;
-#endif
 
 typedef enum {
   GOODIX_SIGFM_TEMPLATE_OK,

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -10,27 +10,10 @@
 
 #include "milan/runtime.h"
 
+#include "milan/debug-hooks.h"
 #include "milan/study/queue.h"
 
 #include <string.h>
-
-#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
-static void
-goodix_milan_runtime_hash_bytes (GBytes *bytes,
-                                 gchar   digest[65])
-{
-  gconstpointer data;
-  gsize size;
-  g_autofree gchar *checksum = NULL;
-
-  digest[0] = '\0';
-  if (!bytes)
-    return;
-  data = g_bytes_get_data (bytes, &size);
-  checksum = g_compute_checksum_for_data (G_CHECKSUM_SHA256, data, size);
-  g_strlcpy (digest, checksum ? checksum : "", 65);
-}
-#endif
 
 struct _GoodixMilanRuntimeGalleryInput
 {
@@ -63,10 +46,7 @@ goodix_milan_runtime_gallery_result_free (
 {
   if (!result)
     return;
-#ifdef GOODIX53X5_DEBUG
-  g_clear_pointer (&result->input_template, g_bytes_unref);
-  g_clear_pointer (&result->after_match_template, g_bytes_unref);
-#endif
+  goodix_milan_debug_runtime_gallery_result_free (result);
   g_clear_error (&result->validation_error);
   g_free (result);
 }
@@ -305,11 +285,7 @@ goodix_milan_runtime_preprocess_input (const GoodixMilanRuntimeInput *input,
     &output->profile_state, input->setup_tx_on);
   if (setup_status != 0)
     {
-#ifdef GOODIX53X5_DEBUG
-      output->preprocess_attempted = TRUE;
-      output->preprocess_status = setup_status;
-      output->preprocess_status_available = TRUE;
-#endif
+      goodix_milan_debug_runtime_setup_failed (output, setup_status);
       output->preprocess_state_valid = TRUE;
       output->status = GOODIX_MILAN_RUNTIME_RETRY;
       g_set_error_literal (&output->error, GOODIX_MILAN_PRINT_ERROR,
@@ -319,17 +295,12 @@ goodix_milan_runtime_preprocess_input (const GoodixMilanRuntimeInput *input,
     }
 
   *processed = g_malloc (GOODIX_MILAN_SENSOR_PIXELS);
-#ifdef GOODIX53X5_DEBUG
-  output->preprocess_attempted = TRUE;
-#endif
+  goodix_milan_debug_runtime_preprocess_started (output);
   preprocess_status = goodix_milan_preprocess (
     &output->preprocess_state, &output->profile_state,
     input->setup_tx_on, input->live_raw,
     input->purpose, *processed, &output->quality, &output->coverage);
-#ifdef GOODIX53X5_DEBUG
-  output->preprocess_status = preprocess_status;
-  output->preprocess_status_available = TRUE;
-#endif
+  goodix_milan_debug_runtime_preprocess_status (output, preprocess_status);
   if (preprocess_status != 0 &&
       preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY &&
       preprocess_status != GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION &&
@@ -341,13 +312,8 @@ goodix_milan_runtime_preprocess_input (const GoodixMilanRuntimeInput *input,
                            "Native Milan preprocessing failed");
       return FALSE;
     }
-#ifdef GOODIX53X5_DEBUG
-  output->preprocess_completed = preprocess_status == 0;
-  if (output->preprocess_completed ||
-      preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION)
-    output->processed_image = g_bytes_new (*processed,
-                                           GOODIX_MILAN_SENSOR_PIXELS);
-#endif
+  goodix_milan_debug_runtime_preprocess_finished (
+    output, preprocess_status, *processed);
   output->preprocess_state_valid = TRUE;
   if (preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY ||
       preprocess_status == GOODIX_MILAN_PREPROCESS_RETRY_RAW_ADMISSION ||
@@ -371,9 +337,7 @@ goodix_milan_runtime_build_probe (const GoodixMilanRuntimeInput *input,
 {
   GoodixMilanPrintTemplateInfo probe_info;
 
-#ifdef GOODIX53X5_DEBUG
-  output->extraction_attempted = TRUE;
-#endif
+  goodix_milan_debug_runtime_extraction_started (output);
   *probe = goodix_milan_match_extract_native (
     processed, &output->preprocess_state, input->live_raw, input->tcode,
     input->dac_high, input->dac_low, input->sensor_subtype);
@@ -389,9 +353,7 @@ goodix_milan_runtime_build_probe (const GoodixMilanRuntimeInput *input,
       *probe = NULL;
       return FALSE;
     }
-#ifdef GOODIX53X5_DEBUG
-  output->extraction_completed = TRUE;
-#endif
+  goodix_milan_debug_runtime_extraction_finished (output);
   output->probe_template = g_bytes_ref (*probe_template);
   output->probe_record_count = probe_info.partition0_count +
                                probe_info.partition1_count;
@@ -423,11 +385,8 @@ goodix_milan_runtime_match_gallery (const GoodixMilanRuntimeInput *input,
 
       result->gallery_position = position;
       result->gallery_index = gallery->gallery_index;
-#ifdef GOODIX53X5_DEBUG
-      result->input_template = g_bytes_ref (gallery->template_bytes);
-      goodix_milan_runtime_hash_bytes (
-        gallery->template_bytes, result->input_template_sha256);
-#endif
+      goodix_milan_debug_runtime_gallery_input (
+        result, gallery->template_bytes);
       g_ptr_array_add (output->gallery_results, result);
       if (goodix_milan_runtime_cancelled (
             input, output, GOODIX_MILAN_RUNTIME_CHECKPOINT_BEFORE_GALLERY,
@@ -437,9 +396,7 @@ goodix_milan_runtime_match_gallery (const GoodixMilanRuntimeInput *input,
       template_valid = goodix_milan_print_validate_template (
         gallery->template_bytes, &result->template_info,
         &result->validation_error);
-#ifdef GOODIX53X5_DEBUG
-      result->validation_observed = TRUE;
-#endif
+      goodix_milan_debug_runtime_gallery_validated (result);
       if (!template_valid)
         {
           output->invalid_gallery_count++;
@@ -463,21 +420,13 @@ goodix_milan_runtime_match_gallery (const GoodixMilanRuntimeInput *input,
           goodix_milan_study_queue_free (queue);
           continue;
         }
-#ifdef GOODIX53X5_DEBUG
-      result->queue_before_match_observed = TRUE;
-      result->queue_state_before_match = queue->enabled_state;
-      result->queue_counter_before_match = queue->transaction_counter;
-      result->queue_occupied_before_match = goodix_milan_study_queue_occupied (queue);
-#endif
+      goodix_milan_debug_runtime_queue_before_match (result, queue);
       feature = g_bytes_get_data (gallery->template_bytes, &feature_len);
       status = goodix_milan_runtime_match (
         input, probe, feature, feature_len, &result->match_result, &after_match,
         queue);
       result->evaluated = TRUE;
-#ifdef GOODIX53X5_DEBUG
-      result->queue_after_match_observed = TRUE;
-      result->queue_occupied_after_match = goodix_milan_study_queue_occupied (queue);
-#endif
+      goodix_milan_debug_runtime_queue_after_match (result, queue);
       output->evaluated_gallery_count++;
       if (status != GOODIX_SIGFM_TEMPLATE_OK || !after_match)
         {
@@ -491,13 +440,8 @@ goodix_milan_runtime_match_gallery (const GoodixMilanRuntimeInput *input,
           goodix_milan_study_queue_free (queue);
           continue;
         }
-#ifdef GOODIX53X5_DEBUG
-      result->after_match_template = g_bytes_ref (after_match);
-#endif
-#if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
-      goodix_milan_runtime_hash_bytes (
-        after_match, result->after_match_sha256);
-#endif
+      goodix_milan_debug_runtime_after_match (result, after_match);
+      goodix_milan_debug_runtime_hash_after_match (result, after_match);
       result->score = result->match_result.score;
       result->accepted = result->score > 0;
       output->score = result->score;
@@ -550,26 +494,13 @@ goodix_milan_runtime_study_winner (const GoodixMilanRuntimeInput *input,
   const guint8 *after_match_data;
   gsize after_match_size;
   GoodixSigfmTemplateStatus study_status;
-#ifdef GOODIX53X5_DEBUG
-  GoodixMilanRuntimeGalleryResult *winner_result;
-#endif
-
   after_match_data = g_bytes_get_data (winner_after_match, &after_match_size);
-#ifdef GOODIX53X5_DEBUG
-  output->study_attempted = TRUE;
-#endif
+  goodix_milan_debug_runtime_study_started (output);
   study_status = goodix_milan_runtime_study (
     input, probe, after_match_data, after_match_size, &output->match_result,
     winner_queue, &after_study, &output->study_action);
-#ifdef GOODIX53X5_DEBUG
-  winner_result = g_ptr_array_index (output->gallery_results, winner_position);
-
-  winner_result->queue_after_study_observed = TRUE;
-  winner_result->queue_state_after_study = winner_queue->enabled_state;
-  winner_result->queue_counter_after_study = winner_queue->transaction_counter;
-  winner_result->queue_occupied_after_study =
-    goodix_milan_study_queue_occupied (winner_queue);
-#endif
+  goodix_milan_debug_runtime_queue_after_study (
+    output, winner_position, winner_queue);
   if (study_status != GOODIX_SIGFM_TEMPLATE_OK)
     {
       g_set_error_literal (&output->learning_error, GOODIX_MILAN_PRINT_ERROR,
@@ -579,9 +510,7 @@ goodix_milan_runtime_study_winner (const GoodixMilanRuntimeInput *input,
       goodix_milan_match_free_info (probe);
       return;
     }
-#ifdef GOODIX53X5_DEBUG
-  output->study_completed = TRUE;
-#endif
+  goodix_milan_debug_runtime_study_finished (output);
   if (goodix_milan_runtime_cancelled (
         input, output, GOODIX_MILAN_RUNTIME_CHECKPOINT_AFTER_STUDY,
         winner_position))
@@ -702,9 +631,7 @@ goodix_milan_runtime_output_free (GoodixMilanRuntimeOutput *output)
   if (!output)
     return;
   g_clear_pointer (&output->final_candidate, g_bytes_unref);
-#ifdef GOODIX53X5_DEBUG
-  g_clear_pointer (&output->processed_image, g_bytes_unref);
-#endif
+  goodix_milan_debug_runtime_output_free (output);
   g_clear_pointer (&output->probe_template, g_bytes_unref);
   g_clear_pointer (&output->gallery_results, g_ptr_array_unref);
   g_clear_error (&output->error);

--- a/tools/milan-parity/build-current-runner
+++ b/tools/milan-parity/build-current-runner
@@ -38,7 +38,8 @@ mapfile -t sources < <(
     milan/match/geometry.c milan/match/info.c milan/match/lifecycle.c \
     milan/match/overlap.c milan/match/policy.c milan/match/rescue.c \
     milan/match/score.c milan/match/selection.c milan/match/study.c \
-    milan/match/match.c milan/core.c milan/preprocess/classification.c \
+    milan/match/match.c milan/core.c milan/debug-hooks.c \
+    milan/preprocess/classification.c \
     milan/preprocess/gain.c milan/preprocess/selection.c \
     milan/preprocess/validity.c milan/print.c milan/relations.c milan/runtime.c \
     milan/study/policy.c milan/study/queue.c milan/study/study.c \


### PR DESCRIPTION
## Summary

Move runtime and extraction debug instrumentation behind Milan-owned hooks, using no-op release inlines and concrete debug/parity implementations. No algorithmic or dump-schema change is intended.

## Observation Contracts Preserved

- Runtime and extraction hooks observe values at their original mutation boundaries.
- Template hashes, queue state, counters, lifecycle flags, and retry artifacts are unchanged.
- Matcher hooks remain inline because its legacy diagnostic path is stack-layout-sensitive.

## Evidence

- Release/debug builds, current runner, and Milan suites pass.
- Repeated strict 26-operation projections produced the canonical pre-refactor projection hash.
- `debug-hooks.c` is present in both Meson and current-runner source lists.

## Stack

Item 10 of the 13-PR Milan refactor stack; depends on the preprocess-contract PR.
