### PR TITLE
Decompose Milan match finalization

### DIFF
--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -136,6 +136,153 @@ typedef struct
   GoodixMilanMatchCandidate candidate;
 } MilanMatchFeatureResult;
 
+typedef struct
+{
+  const GoodixMilanFeatureRecord *enrolled_records;
+  size_t                          enrolled_record_count;
+  size_t                          enrolled_partition_count;
+  const GoodixMilanFeatureView   *enrolled_feature;
+  const GoodixMilanFeatureRecord *probe_records;
+  size_t                          probe_record_count;
+  size_t                          probe_partition_count;
+  const GoodixMilanFeatureView   *probe_feature;
+} MilanMatchDirection;
+
+typedef struct
+{
+  MilanMatchDirection                direction;
+  uint32_t                           sensor_type;
+  int32_t                            image_quality;
+  int32_t                            image_coverage;
+  int32_t                            sibling_tail_hamming_limit;
+  size_t                             feature_index;
+  GoodixMilanMatcherPolicy          *matcher_policy;
+  GoodixMilanMatcherLateContext     *late_policy_context;
+  int32_t                           *late_policy_state;
+  int32_t                           *late_policy_status_counter;
+  GoodixMilanMatchSelection         *match_selection;
+  GoodixMilanMatchFallbackWorkspace *fallback_workspace;
+  int32_t                           *rescue_record;
+  int                               *rejection_candidate_seen;
+  int32_t                           *rejection_count_sum;
+  int32_t                           *rejection_best_detail;
+  int32_t                           *rejection_best_coverage;
+#ifdef GOODIX53X5_DEBUG
+  GoodixMilanMatchDiagnostics       *diagnostics;
+  int32_t                           *probe_policy_metrics;
+  size_t                            *probe_policy_index;
+  int32_t                           *probe_policy_descriptor;
+  int32_t                           *probe_policy_overlap;
+#endif
+} MilanMatchFeatureContext;
+
+typedef struct
+{
+  const GoodixMilanFeatureView          *probe_feature;
+  const uint8_t                         *probe_rescue_mask;
+  const GoodixMilanFeatureRecord        *probe_records;
+  size_t                                 probe_record_count;
+  int32_t                                probe_primary_histogram_class;
+  int32_t                                image_quality;
+  int32_t                                image_coverage;
+  const GoodixMilanAntifakeBlob         *probe_antifake;
+  int                                    caller_blocking_enabled;
+  const uint8_t                         *enrolled_template;
+  size_t                                 enrolled_template_size;
+  const GoodixMilanFeatureRecord *const *live_records;
+  const size_t                          *live_record_counts;
+  const size_t                          *live_partition_counts;
+  size_t                                 triggering_index;
+} MilanMatchPreparedProbeInput;
+
+typedef struct
+{
+  int32_t aggregate[15];
+  size_t  fallback_index;
+  int32_t fallback_quality;
+  int32_t fallback_count;
+  int32_t fallback_coverage;
+  int32_t fallback_transform[6];
+  int32_t direct_aggregate[15];
+  int32_t direct_transform[6];
+  size_t  direct_index;
+  int32_t direct_score_sum;
+  int32_t direct_candidate_count;
+  int     direct_positive;
+  int32_t direct_quality;
+  int32_t direct_count;
+  int32_t direct_coverage;
+  int     direct_is_candidate;
+  int32_t rejection_count_sum;
+  int32_t rejection_best_detail;
+  int32_t rejection_best_coverage;
+  int     rejection_candidate_seen;
+} MilanMatchLegacyState;
+
+typedef struct
+{
+  MilanMatchDirection          direction;
+  int32_t                      sibling_tail_hamming_limit;
+  size_t                       feature_index;
+  GoodixMilanMatcherPolicy    *matcher_policy;
+  MilanMatchLegacyState       *legacy;
+  int32_t                      score_denominator;
+#ifdef GOODIX53X5_DEBUG
+  GoodixMilanMatchDiagnostics *diagnostics;
+  int32_t                     *probe_policy_metrics;
+  size_t                      *probe_policy_index;
+  int32_t                     *probe_policy_descriptor;
+  int32_t                     *policy_aggregate;
+  size_t                      *policy_index;
+#endif
+} MilanMatchReverseContext;
+
+typedef struct
+{
+  const MilanMatchPreparedProbeInput *input;
+  const GoodixMilanUnpackedTemplate  *enrolled;
+  GoodixMilanMatchSelection          *selection;
+  GoodixMilanMatcherPolicy           *policy;
+  GoodixMilanMatcherLateContext      *late_context;
+  const int32_t                      *rescue_records;
+  const int32_t                      *rescue_order;
+  size_t                              rescue_order_count;
+  int32_t                             late_status_counter;
+  int                                 retention_gate;
+  GoodixMilanMatchRescueResult       *rescue_result;
+  int                                *rescue_applied;
+  int                                *effective_rejection;
+  GoodixMilanMatchResult             *result;
+#ifdef GOODIX53X5_DEBUG
+  GoodixMilanMatchDiagnostics        *diagnostics;
+#endif
+} MilanMatchRescueQueueContext;
+
+typedef struct
+{
+  const MilanMatchPreparedProbeInput       *input;
+  const GoodixMilanUnpackedTemplate        *enrolled;
+  GoodixMilanFeatureRecord                 *record_storage;
+  GoodixMilanMatchSelection                *selection;
+  GoodixMilanMatcherPolicy                 *policy;
+  GoodixMilanMatcherLateContext            *late_context;
+  GoodixMilanActiveRelationWinner          *relation_winner;
+  GoodixMilanMatchFallback                 *fallback;
+  GoodixMilanMatchFallbackWorkspace *const *fallback_by_feature;
+  const GoodixMilanMatchRescueResult       *rescue_result;
+  int                                       rescue_applied;
+  int                                       effective_rejection;
+  MilanMatchLegacyState                    *legacy;
+  GoodixMilanMatchResult                   *result;
+#ifdef GOODIX53X5_DEBUG
+  GoodixMilanMatchDiagnostics              *diagnostics;
+  const int32_t                            *policy_aggregate;
+  size_t                                    policy_index;
+  const int32_t                            *probe_policy_metrics;
+  size_t                                    probe_policy_index;
+#endif
+} MilanMatchFinalizationContext;
+
 static int32_t
 milan_match_scale_q8_s32 (int32_t value,
                           int32_t scale)
@@ -364,32 +511,20 @@ milan_match_publish_candidate (
         }
     }
   if (topology && topology->valid)
-    goodix_milan_match_candidate_set_record_metrics (
-      candidate, topology->valid_count, topology->matched_count,
-      topology->topology_percent, topology->geometric_percent,
-      topology->topology_distance);
+    {
+      goodix_milan_match_candidate_set_record_metrics (
+        candidate, topology->valid_count, topology->matched_count,
+        topology->topology_percent, topology->geometric_percent,
+        topology->topology_distance);
+    }
 }
 
 static int
 milan_match_score_counts (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  int32_t                         transform[6],
-  size_t                         *correspondence_count,
-  size_t                         *primary_filtered_count,
-  size_t                         *filtered_count,
-  int32_t                        *score,
-  int32_t                        *topology_percent_output,
-  int32_t                        *geometric_percent_output,
-  int32_t                        *topology_bonus_output,
-  const GoodixMilanFeatureView   *enrolled_feature,
-  const GoodixMilanFeatureView   *probe_feature,
-  size_t                          pair_capacity,
-  GoodixMilanMatchCandidate      *candidate)
+  const MilanMatchDirection *direction,
+  size_t                     pair_capacity,
+  MilanMatchFeatureResult   *result,
+  GoodixMilanMatchCandidate *candidate)
 {
   int32_t pairs[MILAN_MATCH_MAX_PAIRS * 2];
   int32_t initial_transform[6];
@@ -403,17 +538,19 @@ milan_match_score_counts (
   MilanMatchPromotionRepairResult promotion_repair = { 0 };
   size_t match_count;
 
-  if (!transform || !correspondence_count || !filtered_count || !score ||
-      enrolled_partition_count > enrolled_record_count ||
-      probe_partition_count > probe_record_count ||
+  if (!result ||
+      direction->enrolled_partition_count > direction->enrolled_record_count ||
+      direction->probe_partition_count > direction->probe_record_count ||
       goodix_milan_match_correspondences_partitioned (
-        enrolled_records, enrolled_record_count, enrolled_partition_count,
-        probe_records, probe_record_count, probe_partition_count, pairs,
-        pair_capacity, &match_count) != 0)
+        direction->enrolled_records, direction->enrolled_record_count,
+        direction->enrolled_partition_count, direction->probe_records,
+        direction->probe_record_count, direction->probe_partition_count,
+        pairs, pair_capacity, &match_count) != 0)
     return -1;
-  memcpy (initial_transform, transform, sizeof(initial_transform));
+  memcpy (initial_transform, result->transform, sizeof (initial_transform));
   goodix_milan_match_fit_affine_state (
-    enrolled_records, probe_records, pairs, match_count, 1, &primary);
+    direction->enrolled_records, direction->probe_records, pairs, match_count,
+    1, &primary);
   if (match_count < 3)
     memcpy (primary.affine, initial_transform, sizeof(primary.affine));
   if ((!primary.valid || primary.filtered_count == 0) && !candidate)
@@ -421,15 +558,14 @@ milan_match_score_counts (
 
   milan_match_rank_result_init (
     &primary, MILAN_MATCH_RANK_OWNER_PRIMARY, primary.filtered_count >= 3,
-    enrolled_feature, probe_feature, &primary_rank);
+    direction->enrolled_feature, direction->probe_feature, &primary_rank);
   ranked = primary_rank;
   if (!ranked.affine_valid)
     {
       memcpy (ranked.affine, primary.affine, sizeof(ranked.affine));
       ranked.owner = MILAN_MATCH_RANK_OWNER_PRIMARY;
     }
-  if (primary_filtered_count)
-    *primary_filtered_count = (size_t) primary.filtered_count;
+  result->primary_filtered_count = (size_t) primary.filtered_count;
 
   if (primary.valid && primary.filtered_count > 0 &&
       primary.filtered_count <= 15)
@@ -438,111 +574,115 @@ milan_match_score_counts (
       size_t alternate_count;
 
       if (goodix_milan_match_alternate_correspondences_internal (
-            enrolled_records, enrolled_record_count,
-            enrolled_partition_count, probe_records, probe_record_count,
-            probe_partition_count, primary.affine, alternate_pairs,
+            direction->enrolled_records, direction->enrolled_record_count,
+            direction->enrolled_partition_count, direction->probe_records,
+            direction->probe_record_count, direction->probe_partition_count,
+            primary.affine, alternate_pairs,
             pair_capacity, &alternate_count) != 0)
         return -1;
 
       goodix_milan_match_fit_affine_state (
-        enrolled_records, probe_records, alternate_pairs, alternate_count,
+        direction->enrolled_records, direction->probe_records, alternate_pairs,
+        alternate_count,
         1, &alternate);
 
       if (alternate.valid)
         {
           milan_match_rank_result_init (
             &alternate, MILAN_MATCH_RANK_OWNER_ALTERNATE, 1,
-            enrolled_feature, probe_feature, &alternate_rank);
+            direction->enrolled_feature, direction->probe_feature,
+            &alternate_rank);
           milan_match_rank_result_select (&ranked, &alternate_rank);
         }
 
       if (alternate.valid &&
           alternate.filtered_count > primary.filtered_count)
         {
-          if (enrolled_feature && probe_feature)
-            milan_match_promotion_inputs_init (
-              enrolled_records, enrolled_record_count, probe_records,
-              probe_record_count, enrolled_feature, probe_feature,
-              primary.filtered_count, &alternate, &ranked,
-              &forward_overlap, &local_topology);
+          if (direction->enrolled_feature && direction->probe_feature)
+            {
+              milan_match_promotion_inputs_init (
+                direction->enrolled_records, direction->enrolled_record_count,
+                direction->probe_records, direction->probe_record_count,
+                direction->enrolled_feature, direction->probe_feature,
+                primary.filtered_count, &alternate, &ranked,
+                &forward_overlap, &local_topology);
+            }
           else
-            milan_match_topology_result_init (
-              enrolled_records, enrolled_record_count, probe_records,
-              probe_record_count, &alternate,
-              MILAN_MATCH_RANK_OWNER_ALTERNATE, &local_topology);
+            {
+              milan_match_topology_result_init (
+                direction->enrolled_records, direction->enrolled_record_count,
+                direction->probe_records, direction->probe_record_count, &alternate,
+                MILAN_MATCH_RANK_OWNER_ALTERNATE, &local_topology);
+            }
         }
     }
 
   milan_match_promotion_repair_apply (
-    enrolled_records, enrolled_record_count, probe_records, probe_record_count,
+    direction->enrolled_records, direction->enrolled_record_count,
+    direction->probe_records, direction->probe_record_count,
     &primary, &alternate, &ranked, &forward_overlap, &local_topology,
     &promotion_repair);
-  if (!enrolled_feature && !probe_feature && alternate.valid &&
+  if (!direction->enrolled_feature && !direction->probe_feature && alternate.valid &&
       alternate.filtered_count > primary.filtered_count)
     promotion_repair.retained_count = alternate.filtered_count;
-  if (topology_percent_output)
-    *topology_percent_output = promotion_repair.topology.topology_percent;
-  if (geometric_percent_output)
-    *geometric_percent_output = promotion_repair.topology.geometric_percent;
-
-  if (topology_bonus_output)
-    *topology_bonus_output = promotion_repair.topology.topology_bonus;
-  memcpy (transform, ranked.affine, sizeof(ranked.affine));
+  result->topology_percent = promotion_repair.topology.topology_percent;
+  result->geometric_percent = promotion_repair.topology.geometric_percent;
+  result->topology_bonus = promotion_repair.topology.topology_bonus;
+  memcpy (result->transform, ranked.affine, sizeof (ranked.affine));
   if (candidate)
     milan_match_publish_candidate (
       candidate, &primary, &alternate, &ranked,
       promotion_repair.retained_count, &promotion_repair.topology);
-  *correspondence_count = match_count;
-  *filtered_count = (size_t) promotion_repair.retained_count;
-  *score = promotion_repair.retained_count * 100 / (int32_t) pair_capacity;
+  result->filtered_count = (size_t) promotion_repair.retained_count;
+  result->descriptor_score =
+    promotion_repair.retained_count * 100 / (int32_t) pair_capacity;
   return 0;
 }
 
 static int
-milan_match_secondary_diagnostics_capacity (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  size_t                          primary_counts[2],
-  int32_t                         primary_transforms[2][6],
-  size_t                         *selected_count,
-  int32_t                        *selected_count_owner,
-  int32_t                         selected_transform[6],
-  size_t                         *alternate_count,
-  int32_t                         alternate_transform[6],
-  int32_t                         sibling_tail_hamming_limit,
-  size_t                          pair_capacity)
+milan_match_build_cross_class_alternate (
+  const MilanMatchDirection *direction,
+  size_t                     primary_counts[2],
+  int32_t                    primary_transforms[2][6],
+  size_t                    *selected_count,
+  int32_t                   *selected_count_owner,
+  int32_t                    selected_transform[6],
+  size_t                    *alternate_count,
+  int32_t                    alternate_transform[6],
+  int32_t                    sibling_tail_hamming_limit,
+  size_t                     pair_capacity)
 {
   int32_t pairs[2][MILAN_MATCH_MAX_PAIRS * 2];
   size_t pair_counts[2];
   int32_t residual;
 
-  if (!enrolled_records || !probe_records || !primary_counts ||
+  if (!direction->enrolled_records || !direction->probe_records || !primary_counts ||
       !primary_transforms || !selected_count || !selected_transform ||
-      !alternate_count || !alternate_transform || enrolled_record_count == 0 ||
-      enrolled_record_count > 150 || probe_record_count == 0 ||
-      probe_record_count > 150 ||
-      enrolled_partition_count > enrolled_record_count ||
-      probe_partition_count > probe_record_count)
+      !alternate_count || !alternate_transform ||
+      direction->enrolled_record_count == 0 ||
+      direction->enrolled_record_count > 150 ||
+      direction->probe_record_count == 0 ||
+      direction->probe_record_count > 150 ||
+      direction->enrolled_partition_count > direction->enrolled_record_count ||
+      direction->probe_partition_count > direction->probe_record_count)
     return -1;
 
   for (size_t group = 0; group < 2; group++)
     {
       pair_counts[group] = goodix_milan_match_cross_class_correspondences (
-        enrolled_records, enrolled_record_count, enrolled_partition_count,
-        probe_records, probe_record_count, probe_partition_count,
+        direction->enrolled_records, direction->enrolled_record_count,
+        direction->enrolled_partition_count, direction->probe_records,
+        direction->probe_record_count, direction->probe_partition_count,
         (uint8_t) (group + 1), sibling_tail_hamming_limit, pairs[group],
         pair_capacity);
-      primary_counts[group] = pair_counts[group] < 3
-                                ? 0
-                                 : (size_t) goodix_milan_filter_recognition_pairs_internal (
-                                     enrolled_records, probe_records,
-                                     pairs[group], pair_counts[group],
-                                     primary_transforms[group], &residual, NULL,
-                                     NULL);
+      primary_counts[group] = pair_counts[group] < 3 ?
+                              0 :
+                              (size_t) goodix_milan_filter_recognition_pairs_internal (
+        direction->enrolled_records,
+        direction->probe_records,
+        pairs[group], pair_counts[group],
+        primary_transforms[group], &residual, NULL,
+        NULL);
     }
 
   size_t selected_group = primary_counts[0] > primary_counts[1] ? 0 : 1;
@@ -554,86 +694,76 @@ milan_match_secondary_diagnostics_capacity (
           6 * sizeof(*selected_transform));
   int32_t alternate_pairs[MILAN_MATCH_MAX_PAIRS * 2];
   size_t alternate_pair_count =
-    *selected_count < 3
-      ? 0
-      : goodix_milan_match_cross_class_alternate_correspondences (
-          enrolled_records, enrolled_record_count, enrolled_partition_count,
-          probe_records, probe_record_count, probe_partition_count,
-          selected_transform, sibling_tail_hamming_limit, alternate_pairs,
-          pair_capacity);
-  *alternate_count = alternate_pair_count < 3
-                       ? 0
-                        : (size_t) goodix_milan_filter_recognition_pairs_internal (
-                            enrolled_records, probe_records, alternate_pairs,
-                            alternate_pair_count, alternate_transform, &residual,
-                            NULL, NULL);
+    *selected_count < 3 ?
+    0 :
+    goodix_milan_match_cross_class_alternate_correspondences (
+      direction->enrolled_records, direction->enrolled_record_count,
+      direction->enrolled_partition_count, direction->probe_records,
+      direction->probe_record_count, direction->probe_partition_count,
+      selected_transform, sibling_tail_hamming_limit, alternate_pairs,
+      pair_capacity);
+  *alternate_count = alternate_pair_count < 3 ?
+                     0 :
+                     (size_t) goodix_milan_filter_recognition_pairs_internal (
+    direction->enrolled_records,
+    direction->probe_records, alternate_pairs,
+    alternate_pair_count, alternate_transform, &residual,
+    NULL, NULL);
   return 0;
 }
 
 static void
 milan_match_apply_secondary (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  size_t                         *primary_count,
-  size_t                         *filtered_count,
-  int32_t                         transform[6],
-  int32_t                        *topology_percent,
-  int32_t                        *geometric_percent,
-  int32_t                        *topology_bonus,
-  size_t                          pair_capacity,
-  int32_t                         sibling_tail_hamming_limit,
-  const GoodixMilanFeatureView   *enrolled_feature,
-  const GoodixMilanFeatureView   *probe_feature,
-  GoodixMilanMatchCandidate      *candidate)
+  const MilanMatchDirection *direction,
+  MilanMatchFeatureResult   *result,
+  size_t                     pair_capacity,
+  int32_t                    sibling_tail_hamming_limit,
+  GoodixMilanMatchCandidate *candidate)
 {
   int32_t selected_transform[6];
   int32_t alternate_transform[6];
-  size_t selected_count = *filtered_count;
+  size_t selected_count = result->filtered_count;
   size_t alternate_count = 0;
   int32_t residual;
 
-  if (enrolled_partition_count > enrolled_record_count ||
-      probe_partition_count > probe_record_count)
+  if (direction->enrolled_partition_count > direction->enrolled_record_count ||
+      direction->probe_partition_count > direction->probe_record_count)
     return;
-  if (*primary_count >= 9 || *filtered_count >= 9)
+  if (result->primary_filtered_count >= 9 || result->filtered_count >= 9)
     goto bonus;
-  memcpy (selected_transform, transform, sizeof(selected_transform));
-  if (*filtered_count < 4)
+  memcpy (selected_transform, result->transform, sizeof (selected_transform));
+  if (result->filtered_count < 4)
     {
       size_t cross_counts[2];
       int32_t cross_transforms[2][6];
 
-      if (milan_match_secondary_diagnostics_capacity (
-            enrolled_records, enrolled_record_count, enrolled_partition_count,
-            probe_records, probe_record_count, probe_partition_count,
-            cross_counts, cross_transforms, &selected_count,
+      if (milan_match_build_cross_class_alternate (
+            direction, cross_counts, cross_transforms, &selected_count,
             pair_capacity == 42 && candidate ?
               &candidate->words[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] : NULL,
             selected_transform, &alternate_count, alternate_transform,
             sibling_tail_hamming_limit, pair_capacity) != 0)
         goto bonus;
-      if (selected_count > *primary_count)
-        *primary_count = selected_count;
+      if (selected_count > result->primary_filtered_count)
+        result->primary_filtered_count = selected_count;
     }
   else
     {
       int32_t alternate_pairs[MILAN_MATCH_MAX_PAIRS * 2];
 
       size_t pair_count = goodix_milan_match_cross_class_alternate_correspondences (
-        enrolled_records, enrolled_record_count, enrolled_partition_count,
-        probe_records, probe_record_count, probe_partition_count,
+        direction->enrolled_records, direction->enrolled_record_count,
+        direction->enrolled_partition_count, direction->probe_records,
+        direction->probe_record_count, direction->probe_partition_count,
         selected_transform, sibling_tail_hamming_limit, alternate_pairs,
         pair_capacity);
-      alternate_count = pair_count < 3
-                          ? 0
-                           : (size_t) goodix_milan_filter_recognition_pairs_internal (
-                               enrolled_records, probe_records, alternate_pairs,
-                               pair_count, alternate_transform, &residual, NULL,
-                               NULL);
+      alternate_count = pair_count < 3 ?
+                        0 :
+                        (size_t) goodix_milan_filter_recognition_pairs_internal (
+        direction->enrolled_records,
+        direction->probe_records, alternate_pairs,
+        pair_count, alternate_transform, &residual, NULL,
+        NULL);
     }
 
   if (alternate_count > selected_count)
@@ -650,14 +780,16 @@ milan_match_apply_secondary (
       int32_t sibling_strong_orthogonality;
 
       goodix_milan_match_record_metrics_internal (
-        enrolled_records, enrolled_record_count, probe_records,
-        probe_record_count, alternate_transform, (int) alternate_count,
+        direction->enrolled_records, direction->enrolled_record_count,
+        direction->probe_records, direction->probe_record_count,
+        alternate_transform, (int) alternate_count,
         &alternate_topology, &alternate_geometric, &alternate_bonus, &distance,
         &valid_count, &matched_count);
       goodix_milan_match_affine_penalties (
         alternate_transform, &sibling_scale_penalty, &sibling_orthogonality,
         &sibling_strong_orthogonality);
-      if (pair_capacity == 42 && candidate && enrolled_feature && probe_feature)
+      if (pair_capacity == 42 && candidate && direction->enrolled_feature &&
+          direction->probe_feature)
         {
           int32_t sibling_score;
           int32_t sibling_coverage;
@@ -665,7 +797,8 @@ milan_match_apply_secondary (
           int32_t sibling_low_metrics[3];
 
           if (goodix_milan_match_overlap_metrics_with_context (
-                enrolled_feature, probe_feature, alternate_transform,
+                direction->enrolled_feature, direction->probe_feature,
+                alternate_transform,
                 &sibling_score, &sibling_coverage, &sibling_detail,
                 sibling_low_metrics, (int32_t) alternate_count) == 0)
             {
@@ -700,19 +833,21 @@ milan_match_apply_secondary (
            alternate_topology > 75 || alternate_count > 16))
         {
           if (pair_capacity != 42)
-            memcpy (transform, alternate_transform,
-                    sizeof(alternate_transform));
+            memcpy (result->transform, alternate_transform,
+                    sizeof (alternate_transform));
           if (pair_capacity == 42 && candidate)
-            goodix_milan_match_candidate_set_sibling (
-              candidate, (int32_t) alternate_count, alternate_transform,
-              valid_count, matched_count, alternate_topology,
-              alternate_geometric, distance, select_transform);
+            {
+              goodix_milan_match_candidate_set_sibling (
+                candidate, (int32_t) alternate_count, alternate_transform,
+                valid_count, matched_count, alternate_topology,
+                alternate_geometric, distance, select_transform);
+            }
           else
             {
-              *filtered_count = alternate_count;
-              *topology_percent = alternate_topology;
-              *geometric_percent = alternate_geometric;
-              *topology_bonus = alternate_bonus;
+              result->filtered_count = alternate_count;
+              result->topology_percent = alternate_topology;
+              result->geometric_percent = alternate_geometric;
+              result->topology_bonus = alternate_bonus;
             }
         }
     }
@@ -730,86 +865,52 @@ bonus:
         }
       return;
     }
-  if (*topology_bonus)
+  if (result->topology_bonus)
     {
-      if (*primary_count < pair_capacity)
-        (*primary_count)++;
-      if (*filtered_count < pair_capacity)
-        (*filtered_count)++;
+      if (result->primary_filtered_count < pair_capacity)
+        result->primary_filtered_count++;
+      if (result->filtered_count < pair_capacity)
+        result->filtered_count++;
     }
 }
 
 static int
 milan_match_build_feature_candidate (
-  const GoodixMilanFeatureRecord    *enrolled_records,
-  size_t                             enrolled_record_count,
-  size_t                             enrolled_partition_count,
-  const GoodixMilanFeatureRecord    *probe_records,
-  size_t                             probe_record_count,
-  size_t                             probe_partition_count,
-  const GoodixMilanFeatureView      *feature,
-  const GoodixMilanFeatureView      *probe_feature,
-  uint32_t                           sensor_type,
-  int32_t                            image_quality,
-  int32_t                            image_coverage,
-  int32_t                            sibling_tail_hamming_limit,
-  size_t                             feature_index,
-  GoodixMilanMatcherPolicy          *matcher_policy,
-  GoodixMilanMatcherLateContext     *late_policy_context,
-  int32_t                            late_policy_state[3],
-  int32_t                           *late_policy_status_counter,
-  GoodixMilanMatchSelection         *match_selection,
-  GoodixMilanMatchFallbackWorkspace *fallback_workspace,
-  int32_t                            rescue_record[GOODIX_MILAN_MATCH_RESCUE_METRICS],
-  int                               *rejection_candidate_seen,
-  int32_t                           *rejection_count_sum,
-  int32_t                           *rejection_best_detail,
-  int32_t                           *rejection_best_coverage,
-  MilanMatchFeatureResult           *feature_result
-#ifdef GOODIX53X5_DEBUG
-  , GoodixMilanMatchDiagnostics     *diagnostics,
-  int32_t                            probe_policy_metrics[15],
-  size_t                            *probe_policy_index,
-  int32_t                           *probe_policy_descriptor,
-  int32_t                           *probe_policy_overlap
-#endif
-  )
+  const MilanMatchFeatureContext *context,
+  MilanMatchFeatureResult        *feature_result)
 {
-  size_t correspondence_count;
   int32_t overlap_score;
   int32_t overlap_coverage;
   int32_t overlap_detail;
   int32_t low_bitmap_metrics[3];
+  const MilanMatchDirection *direction = &context->direction;
+  const GoodixMilanFeatureView *feature = direction->enrolled_feature;
+  const GoodixMilanFeatureView *probe_feature = direction->probe_feature;
+  uint32_t sensor_type = context->sensor_type;
+  GoodixMilanMatcherPolicy *matcher_policy = context->matcher_policy;
+  GoodixMilanMatcherLateContext *late_policy_context =
+    context->late_policy_context;
 
   memset (feature_result->metrics, 0, sizeof (feature_result->metrics));
   if (milan_match_score_counts (
-        enrolled_records, enrolled_record_count, enrolled_partition_count,
-        probe_records, probe_record_count, probe_partition_count,
-        feature_result->transform, &correspondence_count,
-        &feature_result->primary_filtered_count,
-        &feature_result->filtered_count, &feature_result->descriptor_score,
-        &feature_result->topology_percent, &feature_result->geometric_percent,
-        &feature_result->topology_bonus, feature, probe_feature,
+        direction,
         sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31,
+        feature_result,
         sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? &feature_result->candidate : NULL) != 0)
     return 1;
   milan_match_apply_secondary (
-    enrolled_records, enrolled_record_count, enrolled_partition_count,
-    probe_records, probe_record_count, probe_partition_count,
-    &feature_result->primary_filtered_count, &feature_result->filtered_count,
-    feature_result->transform, &feature_result->topology_percent,
-    &feature_result->geometric_percent, &feature_result->topology_bonus,
-    sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31, sibling_tail_hamming_limit,
-    feature, probe_feature,
+    direction, feature_result,
+    sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31,
+    context->sibling_tail_hamming_limit,
     sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? &feature_result->candidate : NULL);
   if (sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
     {
       if (!goodix_milan_match_candidate_admit (&feature_result->candidate))
         {
-          fallback_workspace->enabled =
+          context->fallback_workspace->enabled =
             feature_result->candidate.words[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] >= 3 &&
             matcher_policy->configuration[GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE] == 1 &&
-            match_selection->acceptance_evidence == 0;
+            context->match_selection->acceptance_evidence == 0;
           return 1;
         }
       memcpy (feature_result->metrics, feature_result->candidate.words,
@@ -835,11 +936,12 @@ milan_match_build_feature_candidate (
         (int32_t) feature_result->filtered_count) != 0)
     return 1;
 #ifdef GOODIX53X5_DEBUG
-  if (diagnostics && overlap_score > diagnostics->overlap_score)
+  if (context->diagnostics &&
+      overlap_score > context->diagnostics->overlap_score)
     {
-      diagnostics->overlap_score = overlap_score;
-      diagnostics->overlap_detail = overlap_detail;
-      diagnostics->overlap_coverage = overlap_coverage;
+      context->diagnostics->overlap_score = overlap_score;
+      context->diagnostics->overlap_detail = overlap_detail;
+      context->diagnostics->overlap_coverage = overlap_coverage;
     }
 #endif
 
@@ -866,43 +968,45 @@ milan_match_build_feature_candidate (
       feature_result->metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] < 36)
     feature_result->metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] = 36;
 #ifdef GOODIX53X5_DEBUG
-  if (diagnostics && feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
+  if (context->diagnostics &&
+      context->feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
     {
-      memcpy (diagnostics->feature_metrics[feature_index][0],
+      memcpy (context->diagnostics->feature_metrics[context->feature_index][0],
               feature_result->metrics, 15 * sizeof (*feature_result->metrics));
-      memcpy (diagnostics->feature_transforms[feature_index][0],
+      memcpy (context->diagnostics->feature_transforms[context->feature_index][0],
               feature_result->transform, sizeof (feature_result->transform));
     }
-  if (diagnostics &&
-      feature_result->descriptor_score > diagnostics->descriptor_score)
+  if (context->diagnostics && feature_result->descriptor_score >
+      context->diagnostics->descriptor_score)
     {
-      diagnostics->descriptor_score = feature_result->descriptor_score;
-      diagnostics->filtered_count = (int32_t) feature_result->filtered_count;
-      memcpy (diagnostics->transform, feature_result->transform,
-              sizeof (diagnostics->transform));
+      context->diagnostics->descriptor_score = feature_result->descriptor_score;
+      context->diagnostics->filtered_count =
+        (int32_t) feature_result->filtered_count;
+      memcpy (context->diagnostics->transform, feature_result->transform,
+              sizeof (context->diagnostics->transform));
     }
-  if (feature_result->descriptor_score > *probe_policy_descriptor)
+  if (feature_result->descriptor_score > *context->probe_policy_descriptor)
     {
-      *probe_policy_descriptor = feature_result->descriptor_score;
-      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
+      *context->probe_policy_descriptor = feature_result->descriptor_score;
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT];
-      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
-      *probe_policy_index = feature_index;
+      *context->probe_policy_index = context->feature_index;
     }
-  if (overlap_score > *probe_policy_overlap)
+  if (overlap_score > *context->probe_policy_overlap)
     {
-      *probe_policy_overlap = overlap_score;
-      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
+      *context->probe_policy_overlap = overlap_score;
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE];
-      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
-      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8];
     }
 #endif
   if (goodix_milan_match_initial_flags (
-        feature_result->metrics, image_quality, image_coverage,
+        feature_result->metrics, context->image_quality, context->image_coverage,
         matcher_policy->configuration, &feature_result->match_flag,
         &feature_result->candidate_flag, NULL) != 0)
     return 1;
@@ -911,15 +1015,15 @@ milan_match_build_feature_candidate (
       feature_result->metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] > 4 &&
       feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] > 195)
     {
-      *rejection_candidate_seen = 1;
-      *rejection_count_sum +=
+      *context->rejection_candidate_seen = 1;
+      *context->rejection_count_sum +=
         feature_result->metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT];
       if (feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] >
-          *rejection_best_detail)
+          *context->rejection_best_detail)
         {
-          *rejection_best_detail =
+          *context->rejection_best_detail =
             feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
-          *rejection_best_coverage =
+          *context->rejection_best_coverage =
             feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8];
         }
     }
@@ -938,8 +1042,9 @@ milan_match_build_feature_candidate (
       int32_t refined_matched_count;
 
       if (goodix_milan_refine_record_similarity (
-            enrolled_records, enrolled_record_count, enrolled_partition_count,
-            probe_records, probe_record_count, probe_partition_count,
+            direction->enrolled_records, direction->enrolled_record_count,
+            direction->enrolled_partition_count, direction->probe_records,
+            direction->probe_record_count, direction->probe_partition_count,
             feature_result->transform, 2, refined_transform) == 0 &&
           goodix_milan_match_overlap_metrics_with_context (
             feature, probe_feature, refined_transform, &refined_overlap_score,
@@ -965,8 +1070,9 @@ milan_match_build_feature_candidate (
           feature_result->metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
             refined_overlap_coverage * MILAN_MATCH_OVERLAP_COVERAGE_SCALE_Q8 >> 8;
           goodix_milan_match_record_metrics_internal (
-            enrolled_records, enrolled_record_count, probe_records,
-            probe_record_count, feature_result->transform,
+            direction->enrolled_records, direction->enrolled_record_count,
+            direction->probe_records, direction->probe_record_count,
+            feature_result->transform,
             (int) feature_result->filtered_count,
             &feature_result->topology_percent,
             &feature_result->geometric_percent,
@@ -996,16 +1102,19 @@ milan_match_build_feature_candidate (
               feature_result->metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] < 36)
             feature_result->metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] = 36;
 #ifdef GOODIX53X5_DEBUG
-          if (diagnostics &&
-              feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
-            memcpy (diagnostics->feature_transforms[feature_index][0],
-                    feature_result->transform,
-                    sizeof (feature_result->transform));
+          if (context->diagnostics &&
+              context->feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
+            {
+              memcpy (context->diagnostics->feature_transforms[
+                        context->feature_index][0],
+                      feature_result->transform,
+                      sizeof (feature_result->transform));
+            }
 #endif
         }
     }
   if (goodix_milan_match_initial_flags (
-        feature_result->metrics, image_quality, image_coverage,
+        feature_result->metrics, context->image_quality, context->image_coverage,
         matcher_policy->configuration, &feature_result->match_flag,
         &feature_result->candidate_flag, NULL) != 0)
     return 1;
@@ -1025,32 +1134,37 @@ milan_match_build_feature_candidate (
           late_policy_context->accumulated_high_class > 1)
         memcpy (feature_result->metrics + 6, low_bitmap_metrics,
                 sizeof (low_bitmap_metrics));
-      memcpy (rescue_record, feature_result->metrics,
-              GOODIX_MILAN_MATCH_RESCUE_METRICS * sizeof (*rescue_record));
+      memcpy (context->rescue_record, feature_result->metrics,
+              GOODIX_MILAN_MATCH_RESCUE_METRICS *
+              sizeof (*context->rescue_record));
       goodix_milan_matcher_policy_evaluate (
-        matcher_policy, feature_result->metrics, image_quality, image_coverage,
+        matcher_policy, feature_result->metrics, context->image_quality,
+        context->image_coverage,
         late_policy_context->accumulated_high_class,
         &feature_result->match_flag, &feature_result->candidate_flag);
       goodix_milan_matcher_policy_apply_late_veto (
         matcher_policy, feature_result->metrics, &feature_result->match_flag,
         &feature_result->candidate_flag);
       status = goodix_milan_matcher_policy_apply_status (
-        feature_result->metrics, feature_result->transform, late_policy_state,
-        (int32_t) probe_record_count, image_coverage, image_quality,
-        &feature_result->match_flag, late_policy_status_counter);
+        feature_result->metrics, feature_result->transform,
+        context->late_policy_state, (int32_t) direction->probe_record_count,
+        context->image_coverage, context->image_quality,
+        &feature_result->match_flag, context->late_policy_status_counter);
       if (status)
         return 1;
       /* The native profile-9 probe has no active masked-overlap context;
        * its caller class tuple and therefore its support ratio are zero. */
       goodix_milan_matcher_policy_apply_final (
-        feature_result->metrics, image_quality,
-        late_policy_context->accumulated_high_class, late_policy_state[1], 0,
+        feature_result->metrics, context->image_quality,
+        late_policy_context->accumulated_high_class,
+        context->late_policy_state[1], 0,
         &feature_result->match_flag, &feature_result->candidate_flag);
     }
   else
     {
-      memcpy (rescue_record, feature_result->metrics,
-              GOODIX_MILAN_MATCH_RESCUE_METRICS * sizeof (*rescue_record));
+      memcpy (context->rescue_record, feature_result->metrics,
+              GOODIX_MILAN_MATCH_RESCUE_METRICS *
+              sizeof (*context->rescue_record));
     }
   return 0;
 }
@@ -1081,6 +1195,10 @@ milan_match_publish_feature_candidate (
   int contributes = 0;
   int retained = 0;
   int blocked = 0;
+
+#ifndef GOODIX53X5_DEBUG
+  (void) order_index;
+#endif
 
   memset (&contribution_event, 0, sizeof (contribution_event));
   if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
@@ -1145,11 +1263,13 @@ milan_match_publish_feature_candidate (
         enrolled, feature_index, feature_result->transform, routed);
 
       if (relation_status == 0)
-        goodix_milan_active_relation_winner_update (
-          active_relation_winner, 1,
-          feature_result->metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT],
-          (int32_t) feature_index, feature_result->transform,
-          routed + MILAN_MATCH_RELATION_AFFINE_FIRST);
+        {
+          goodix_milan_active_relation_winner_update (
+            active_relation_winner, 1,
+            feature_result->metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT],
+            (int32_t) feature_index, feature_result->transform,
+            routed + MILAN_MATCH_RELATION_AFFINE_FIRST);
+        }
     }
 #ifdef GOODIX53X5_DEBUG
   int outer_eligible =
@@ -1221,61 +1341,694 @@ milan_match_validate_winner (const int32_t metrics[GOODIX_MILAN_CANDIDATE_WORDS]
     score);
 }
 
+static void
+milan_match_reverse_feature (const MilanMatchReverseContext *context)
+{
+  MilanMatchFeatureResult reverse;
+  int32_t forward_transform[6];
+  int32_t low_metrics[3];
+  int32_t overlap_score;
+  int32_t overlap_coverage;
+  int32_t overlap_detail;
+  int32_t match_flag;
+  int32_t candidate_flag;
+
+  if (milan_match_score_counts (&context->direction, 31, &reverse, NULL) != 0)
+    return;
+  milan_match_apply_secondary (
+    &context->direction, &reverse, 31,
+    context->sibling_tail_hamming_limit, NULL);
+  reverse.descriptor_score = (int32_t) reverse.filtered_count * 100 / 31;
+#ifdef GOODIX53X5_DEBUG
+  if (context->diagnostics &&
+      reverse.descriptor_score > context->diagnostics->descriptor_score)
+    {
+      context->diagnostics->descriptor_score = reverse.descriptor_score;
+      context->diagnostics->filtered_count = (int32_t) reverse.filtered_count;
+      if (goodix_milan_transform_invert (
+            reverse.transform, forward_transform) == 0)
+        memcpy (context->diagnostics->transform, forward_transform,
+                sizeof (context->diagnostics->transform));
+    }
+#endif
+  /* Native quirk: the reverse affine enters fitting uninitialized; only its
+   * metrics array is cleared before publication. */
+  memset (reverse.metrics, 0, sizeof (reverse.metrics));
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
+    (int32_t) reverse.primary_filtered_count;
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
+    (int32_t) reverse.filtered_count;
+  if (goodix_milan_match_overlap_metrics_with_context (
+        context->direction.enrolled_feature,
+        context->direction.probe_feature, reverse.transform, &overlap_score,
+        &overlap_coverage, &overlap_detail, low_metrics,
+        (int32_t) reverse.filtered_count) != 0)
+    return;
+
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] = overlap_score;
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] = overlap_detail;
+  memcpy (reverse.metrics + 6, low_metrics, sizeof (low_metrics));
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
+    overlap_coverage * MILAN_MATCH_OVERLAP_COVERAGE_SCALE_Q8 >> 8;
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] =
+    reverse.topology_percent;
+  reverse.metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] =
+    reverse.geometric_percent;
+  if ((abs (reverse.transform[2]) > MILAN_MATCH_LARGE_TRANSLATION_Q8 ||
+       abs (reverse.transform[5]) > MILAN_MATCH_LARGE_TRANSLATION_Q8) &&
+      reverse.metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] < 36)
+    reverse.metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] = 36;
+#ifdef GOODIX53X5_DEBUG
+  if (context->diagnostics &&
+      context->feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
+    {
+      memcpy (context->diagnostics->feature_metrics[context->feature_index][1],
+              reverse.metrics, 15 * sizeof (*reverse.metrics));
+      if (goodix_milan_transform_invert (
+            reverse.transform, forward_transform) == 0)
+        memcpy (context->diagnostics->feature_transforms[
+                  context->feature_index][1], forward_transform,
+                sizeof (forward_transform));
+    }
+#endif
+  if (goodix_milan_match_initial_flags (
+        reverse.metrics,
+        context->direction.probe_feature->fields.tagged_values[3],
+        context->direction.probe_feature->fields.tagged_values[4],
+        context->matcher_policy->configuration, &match_flag, &candidate_flag,
+        NULL) != 0 ||
+      goodix_milan_transform_invert (
+        reverse.transform, forward_transform) != 0)
+    return;
+#ifdef GOODIX53X5_DEBUG
+  if (reverse.descriptor_score > *context->probe_policy_descriptor)
+    {
+      *context->probe_policy_descriptor = reverse.descriptor_score;
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
+        reverse.metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT];
+      context->probe_policy_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
+        reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
+      *context->probe_policy_index = context->feature_index;
+    }
+  if (reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] >
+      context->policy_aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ||
+      (reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ==
+       context->policy_aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] &&
+       reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] >
+       context->policy_aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL]))
+    {
+      memcpy (context->policy_aggregate, reverse.metrics,
+              15 * sizeof (*context->policy_aggregate));
+      *context->policy_index = context->feature_index;
+    }
+#endif
+
+  int eligible =
+    reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > 4 &&
+    reverse.metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] > 30 &&
+    (match_flag == 1 || goodix_milan_match_fallback_candidate_eligible (
+       reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
+       MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
+       reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL]));
+
+  /* Native FUN_180055a40 keeps the earlier winner on a complete rank tie. */
+  if (eligible &&
+      (candidate_flag > context->legacy->direct_is_candidate ||
+       (candidate_flag == context->legacy->direct_is_candidate &&
+        (reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] >
+         context->legacy->direct_quality ||
+         (reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] ==
+          context->legacy->direct_quality &&
+          reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] >
+          context->legacy->direct_count) ||
+         (reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] ==
+          context->legacy->direct_quality &&
+          reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ==
+          context->legacy->direct_count &&
+          reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] >
+          context->legacy->direct_coverage)))))
+    {
+      memcpy (context->legacy->direct_aggregate, reverse.metrics,
+              sizeof (context->legacy->direct_aggregate));
+      context->legacy->direct_index = context->feature_index;
+      context->legacy->direct_quality =
+        reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
+      context->legacy->direct_count =
+        reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
+      context->legacy->direct_coverage =
+        reverse.metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8];
+      context->legacy->direct_is_candidate = candidate_flag;
+      memcpy (context->legacy->direct_transform, forward_transform,
+              sizeof (context->legacy->direct_transform));
+    }
+  if (eligible)
+    {
+      context->legacy->direct_score_sum +=
+        ((reverse.metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] *
+          MILAN_MATCH_Q8_ONE + (context->score_denominator >> 1)) /
+         context->score_denominator);
+      context->legacy->direct_candidate_count++;
+    }
+}
+
+static int
+milan_match_relaxed_feature (const MilanMatchDirection     *direction,
+                             size_t                         feature_index,
+                             MilanMatchLegacyState         *legacy
+#ifdef GOODIX53X5_DEBUG
+                             , GoodixMilanMatchDiagnostics *diagnostics
+#endif
+                             )
+{
+  int32_t pairs[62];
+  int32_t transform[6];
+  int32_t residual;
+  int32_t overlap_score;
+  int32_t overlap_coverage;
+  int32_t overlap_detail;
+  int32_t low_metrics[3];
+  size_t filtered_count;
+  size_t pair_count;
+
+  pair_count = goodix_milan_match_relaxed_correspondences (
+    direction->enrolled_records, direction->enrolled_record_count,
+    direction->enrolled_partition_count, direction->probe_records,
+    direction->probe_record_count, direction->probe_partition_count, pairs);
+  if (pair_count < 3 ||
+      goodix_milan_filter_recognition_pairs (
+        direction->enrolled_records, direction->probe_records, pairs,
+        pair_count, transform, &filtered_count, &residual) != 0 ||
+      filtered_count <= 4 ||
+      goodix_milan_match_overlap_metrics_with_context (
+        direction->enrolled_feature, direction->probe_feature, transform,
+        &overlap_score, &overlap_coverage, &overlap_detail, low_metrics,
+        (int32_t) filtered_count) != 0 ||
+      !goodix_milan_match_fallback_candidate_eligible (
+        overlap_score, MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD, overlap_detail))
+    return 0;
+#ifdef GOODIX53X5_DEBUG
+  if (diagnostics)
+    diagnostics->fallback_count += 2;
+#endif
+  int32_t scaled_coverage =
+    overlap_coverage * MILAN_MATCH_OVERLAP_COVERAGE_SCALE_Q8 >> 8;
+
+  /* Native FUN_180055a40 ranks detail, count, then coverage; ties stay put. */
+  if (overlap_detail > legacy->fallback_quality ||
+      (overlap_detail == legacy->fallback_quality &&
+       (int32_t) filtered_count > legacy->fallback_count) ||
+      (overlap_detail == legacy->fallback_quality &&
+       (int32_t) filtered_count == legacy->fallback_count &&
+       scaled_coverage > legacy->fallback_coverage))
+    {
+      legacy->aggregate[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
+        (int32_t) filtered_count;
+      legacy->aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
+        (int32_t) filtered_count;
+      legacy->aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] = overlap_score;
+      legacy->aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
+        overlap_detail;
+      memcpy (legacy->aggregate + 6, low_metrics, sizeof (low_metrics));
+      legacy->aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
+        scaled_coverage;
+      legacy->fallback_quality = overlap_detail;
+      legacy->fallback_count = (int32_t) filtered_count;
+      legacy->fallback_coverage = scaled_coverage;
+      legacy->fallback_index = feature_index;
+      memcpy (legacy->fallback_transform, transform,
+              sizeof (legacy->fallback_transform));
+    }
+  return 1;
+}
+
+static int
+milan_match_rescue_and_queue (MilanMatchRescueQueueContext *context)
+{
+  if (goodix_milan_match_rescue_caller_eligible (
+        context->selection->q8_contributor_count,
+        context->selection->postloop_blocking_count,
+        context->selection->rejection_evidence,
+        context->enrolled->metadata.sensor_type))
+    {
+      GoodixMilanMatchRescueInput rescue_input = {
+        .type = context->enrolled->metadata.sensor_type,
+        .width = GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
+        .height = GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS,
+        .half_resolution = 1,
+        .source_mask = context->input->probe_rescue_mask,
+        .source_mask_size = GOODIX_MILAN_MATCH_RESCUE_MASK_SIZE,
+        .source_stride = GOODIX_MILAN_MATCH_RESCUE_MASK_STRIDE,
+        .records = context->rescue_records,
+        .record_count = context->enrolled->feature_count,
+        .ordered_features = context->rescue_order,
+        .ordered_count = context->rescue_order_count,
+        .incoming_score = context->selection->score_latched ?
+                          context->selection->latched_score : 0,
+      };
+
+      if (goodix_milan_match_rescue_evaluate (
+            &rescue_input, context->rescue_result) != 0)
+        return -1;
+      *context->rescue_applied = context->rescue_result->set_acceptance;
+    }
+
+  *context->effective_rejection = context->selection->rejection_evidence != 0 ||
+                                  (*context->rescue_applied &&
+                                   context->rescue_result->set_rejection);
+  if (context->enrolled->metadata.sensor_type ==
+      GOODIX_MILAN_PRINT_SENSOR_TYPE && !context->retention_gate)
+    *context->effective_rejection = 0;
+
+  if (context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
+    {
+      context->result->study_control.queue_candidate_eligible =
+        *context->effective_rejection == 0 &&
+        context->policy->configuration[
+          GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE] == 1 &&
+        context->late_context->probe_low_class == 0 &&
+        context->input->image_coverage > 65 &&
+        context->input->image_quality > 15 &&
+        context->late_context->accumulated_high_class < 4 &&
+        context->late_context->probe_primary_histogram_class < 3 &&
+        context->enrolled->metadata.queue_state == 0;
+#ifdef GOODIX53X5_DEBUG
+      if (context->diagnostics)
+        {
+          context->diagnostics->queue_study_evidence =
+            *context->effective_rejection;
+          context->diagnostics->queue_configuration_enabled =
+            context->policy->configuration[
+              GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE];
+          context->diagnostics->queue_probe_low_class =
+            context->late_context->probe_low_class;
+          context->diagnostics->queue_accumulated_high_class =
+            context->late_context->accumulated_high_class;
+          context->diagnostics->queue_status_count =
+            context->late_status_counter;
+        }
+#endif
+    }
+  return 0;
+}
+
+static int
+milan_match_finalize (MilanMatchFinalizationContext *context)
+{
+  GoodixMilanMatchResult *result = context->result;
+  GoodixMilanMatchSelection *selection = context->selection;
+  int32_t aggregate_score = 0;
+
+#ifdef GOODIX53X5_DEBUG
+  if (context->diagnostics)
+    {
+      if (context->enrolled->metadata.sensor_type ==
+          GOODIX_MILAN_PRINT_SENSOR_TYPE)
+        memcpy (context->diagnostics->direct_aggregate,
+                selection->winner_metrics,
+                sizeof (context->diagnostics->direct_aggregate));
+      else
+        memcpy (context->diagnostics->direct_aggregate,
+                context->legacy->direct_aggregate,
+                sizeof (context->legacy->direct_aggregate));
+      memcpy (context->diagnostics->policy_aggregate,
+              context->policy_aggregate,
+              sizeof (context->diagnostics->policy_aggregate));
+      memcpy (context->diagnostics->probe_policy_aggregate,
+              context->probe_policy_metrics,
+              sizeof (context->diagnostics->probe_policy_aggregate));
+      context->diagnostics->direct_feature_index =
+        context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ?
+        selection->winner_feature :
+        (context->legacy->direct_index == SIZE_MAX ?
+         -1 : (int32_t) context->legacy->direct_index);
+      context->diagnostics->policy_feature_index =
+        context->policy_index == SIZE_MAX ? -1 : (int32_t) context->policy_index;
+      context->diagnostics->probe_policy_feature_index =
+        context->probe_policy_index == SIZE_MAX ?
+        -1 : (int32_t) context->probe_policy_index;
+      context->diagnostics->q8_sum =
+        context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ?
+        selection->q8_sum : context->legacy->direct_score_sum;
+      context->diagnostics->q8_contributor_count =
+        context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ?
+        selection->q8_contributor_count :
+        context->legacy->direct_candidate_count;
+      context->diagnostics->postloop_blocking_count =
+        selection->postloop_blocking_count;
+      context->diagnostics->postloop_blocking_sum =
+        selection->postloop_blocking_sum;
+      context->diagnostics->postloop_blocking_override =
+        goodix_milan_match_selection_blocking_override (selection);
+      context->diagnostics->final_selected_feature_index =
+        context->rescue_applied ?
+        context->rescue_result->selected_feature :
+        (context->enrolled->metadata.sensor_type ==
+         GOODIX_MILAN_PRINT_SENSOR_TYPE ?
+         selection->selected_feature :
+         (context->legacy->direct_index == SIZE_MAX ?
+          -1 : (int32_t) context->legacy->direct_index));
+    }
+#endif
+
+  /* FUN_180055a40 keeps relation ownership independent of later rescue. */
+  if (context->relation_winner->valid)
+    {
+      result->relation.relation_count = context->relation_winner->count;
+      result->relation.relation_values[MILAN_MATCH_RELATION_SENTINEL] = 0;
+      memcpy (result->relation.relation_values +
+              MILAN_MATCH_RELATION_AFFINE_FIRST,
+              context->relation_winner->routed,
+              sizeof (context->relation_winner->routed));
+    }
+
+  if (context->rescue_applied)
+    {
+      result->score = context->rescue_result->score;
+      result->matched_feature_index =
+        (size_t) context->rescue_result->selected_feature;
+      result->lifecycle_update_feature_mask =
+        goodix_milan_match_selection_lifecycle_mask (selection);
+      if (context->rescue_result->retain_transform)
+        memcpy (result->match_transform,
+                context->rescue_result->selected_transform,
+                sizeof (context->rescue_result->selected_transform));
+      if (goodix_milan_match_selection_blocking_override (selection))
+        result->score = -65536;
+      return 0;
+    }
+
+  if (context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      !selection->score_latched &&
+      (context->late_context->accumulated_high_class >= 4 ||
+       context->late_context->probe_primary_histogram_class >= 2))
+    {
+      result->score = goodix_milan_match_selection_blocking_override (selection) ?
+                      -65536 : 0;
+      return 0;
+    }
+  if (context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      !selection->score_latched &&
+      context->policy->configuration[
+        GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE] == 0)
+    {
+      result->score = 0;
+      return 0;
+    }
+
+  if (context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      goodix_milan_match_selection_finalize (
+        selection,
+        context->policy->configuration[GOODIX_MILAN_POLICY_CONFIG_PACKED_MODE],
+        selection->postloop_blocking_count, milan_match_validate_winner,
+        context->policy))
+    {
+      result->score = selection->latched_score;
+      result->lifecycle_update_feature_mask =
+        goodix_milan_match_selection_lifecycle_mask (selection);
+      if (selection->selected_feature >= 0)
+        {
+          result->matched_feature_index = (size_t) selection->selected_feature;
+          memcpy (result->match_transform, selection->selected_transform,
+                  sizeof (selection->selected_transform));
+        }
+      if (goodix_milan_match_selection_blocking_override (selection))
+        result->score = -65536;
+      return 0;
+    }
+
+  if (context->enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
+    {
+      for (size_t feature_index = 0;
+           feature_index < context->enrolled->feature_count; feature_index++)
+        {
+          const GoodixMilanMatchFallbackWorkspace *workspace =
+            context->fallback_by_feature[feature_index];
+          GoodixMilanFeatureView feature;
+          int32_t transform[6];
+          size_t filtered_count;
+          int32_t residual;
+          int32_t overlap;
+          int32_t coverage;
+          int32_t detail;
+          int32_t low_metrics[3];
+          int32_t average_scale;
+          int32_t absolute_dot_q16;
+          int32_t transform_classifier;
+          const GoodixMilanFeatureRecord *records;
+
+          if (!workspace || !workspace->enabled || workspace->pair_count < 3 ||
+              workspace->feature < 0 ||
+              (size_t) workspace->feature >= context->enrolled->feature_count ||
+              goodix_milan_template_parse_feature_element (
+                context->enrolled->feature_elements[workspace->feature],
+                context->enrolled->feature_element_sizes[workspace->feature],
+                &feature) != 0 ||
+              feature.record_count == 0 || feature.record_count > 150)
+            continue;
+          if (context->input->live_records &&
+              context->input->live_records[workspace->feature])
+            {
+              if (!context->input->live_record_counts ||
+                  context->input->live_record_counts[workspace->feature] !=
+                  feature.record_count)
+                continue;
+              records = context->input->live_records[workspace->feature];
+            }
+          else
+            {
+              if (goodix_milan_feature_unpack_template_records (
+                    feature.packed_records, feature.record_count,
+                    (size_t) feature.fields.tagged_values[2],
+                    context->record_storage, 150) != 0)
+                continue;
+              records = context->record_storage;
+            }
+          if (goodix_milan_filter_recognition_pairs (
+                records, context->input->probe_records, workspace->pairs,
+                workspace->pair_count, transform, &filtered_count,
+                &residual) != 0)
+            continue;
+          int32_t decoded_high =
+            (context->policy->configuration[
+               GOODIX_MILAN_POLICY_CONFIG_PACKED_MODE] >> 8) & 7;
+
+          decoded_high = decoded_high == 0 ? 0 :
+                         decoded_high <= 2 ? decoded_high :
+                         decoded_high <= 5 ? decoded_high + 1 : 0;
+          transform_classifier = goodix_milan_match_transform_proximity (
+            transform, decoded_high, context->enrolled->metadata.sensor_type);
+          if (filtered_count <= 4 || transform_classifier != 0)
+            continue;
+          if (goodix_milan_match_overlap_metrics_with_context (
+                &feature, context->input->probe_feature, transform, &overlap,
+                &coverage, &detail, low_metrics,
+                (int32_t) filtered_count) != 0)
+            continue;
+          goodix_milan_match_affine_details (
+            transform, &average_scale, &absolute_dot_q16);
+          int32_t accumulated = goodix_milan_match_fallback_consider (
+            context->fallback, workspace->feature, (int32_t) filtered_count,
+            transform_classifier, overlap,
+            context->policy->configuration[
+              GOODIX_MILAN_POLICY_CONFIG_METRIC_OFFSET] +
+            MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
+            detail,
+            coverage * context->policy->configuration[
+              GOODIX_MILAN_POLICY_CONFIG_OVERLAP_COVERAGE_SCALE_Q8] >> 8,
+            context->policy->configuration[
+              GOODIX_MILAN_POLICY_CONFIG_ALTERNATE_PENALTY] != 0,
+            average_scale, absolute_dot_q16, transform);
+          (void) accumulated;
+        }
+
+      if (context->fallback->winner_valid)
+        {
+          GoodixMilanFeatureView feature;
+          int32_t metrics[15] = { 0 };
+          int32_t fallback_score = 0;
+
+          if (goodix_milan_template_parse_feature_element (
+                context->enrolled->feature_elements[
+                  context->fallback->winner.feature],
+                context->enrolled->feature_element_sizes[
+                  context->fallback->winner.feature], &feature) != 0 ||
+              goodix_milan_match_low_bitmap_metrics (
+                feature.low_bitmap, feature.inline_mask,
+                context->input->probe_feature->low_bitmap,
+                context->input->probe_feature->inline_mask,
+                context->fallback->winner.transform, metrics + 6) != 0)
+            return -1;
+          metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
+            context->fallback->winner.filtered_count;
+          metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
+            context->fallback->winner.filtered_count;
+          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
+            context->fallback->winner.overlap;
+          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
+            context->fallback->winner.raw_detail;
+          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
+            context->fallback->winner.coverage;
+          goodix_milan_match_affine_penalties (
+            context->fallback->winner.transform,
+            metrics + GOODIX_MILAN_CANDIDATE_SCALE_PENALTY,
+            metrics + GOODIX_MILAN_CANDIDATE_ORTHOGONALITY_PENALTY,
+            metrics + GOODIX_MILAN_CANDIDATE_STRONG_ORTHOGONALITY_PENALTY);
+          if (goodix_milan_match_final_score (
+                metrics, context->enrolled->metadata.sensor_type,
+                context->policy->configuration[
+                  GOODIX_MILAN_POLICY_CONFIG_FINAL_SCORE_ALTERNATE_POLICY] != 0,
+                &fallback_score) != 0)
+            return -1;
+          if (fallback_score > 0)
+            {
+              result->score = fallback_score > 100 ? 100 : fallback_score;
+              if (goodix_milan_match_selection_publish_fallback (
+                    selection, result->score,
+                    selection->postloop_blocking_count, &result->score) < 0)
+                return -1;
+              return 0;
+            }
+        }
+      result->score = goodix_milan_match_fallback_rejection_score (
+        context->fallback);
+      if (selection->postloop_blocking_count > 0)
+        result->score = -65536;
+    }
+
+  if (context->enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      context->legacy->direct_index != SIZE_MAX &&
+      context->legacy->direct_candidate_count > 0 &&
+      (context->legacy->direct_positive ||
+       (goodix_milan_match_final_score (
+          context->legacy->direct_aggregate,
+          context->enrolled->metadata.sensor_type, 1, &aggregate_score) == 0 &&
+        aggregate_score > 0)))
+    {
+      result->score = (context->legacy->direct_score_sum * 100 /
+                       context->legacy->direct_candidate_count) >> 8;
+      result->matched_feature_index = context->legacy->direct_index;
+      result->lifecycle_update_feature_mask =
+        UINT64_C (1) << context->legacy->direct_index;
+      memcpy (result->match_transform, context->legacy->direct_transform,
+              sizeof (context->legacy->direct_transform));
+      result->relation.relation_count = context->legacy->direct_count;
+      int relation_status = goodix_milan_match_reference_transform (
+        context->enrolled, context->legacy->direct_index,
+        result->match_transform, result->relation.relation_values);
+      if (relation_status < 0)
+        result->relation.relation_count = -1;
+      else if (relation_status > 0)
+        result->relation.relation_count = 0;
+      return 0;
+    }
+  if (context->legacy->fallback_index != SIZE_MAX &&
+      goodix_milan_match_final_score (
+        context->legacy->aggregate, 23, 0, &result->score) == 0)
+    {
+#ifdef GOODIX53X5_DEBUG
+      if (context->diagnostics)
+        {
+          context->diagnostics->fallback_feature_index =
+            (int32_t) context->legacy->fallback_index;
+          memcpy (context->diagnostics->fallback_metrics,
+                  context->legacy->aggregate,
+                  sizeof (context->diagnostics->fallback_metrics));
+        }
+#endif
+      if (result->score > 0)
+        {
+          result->matched_feature_index = context->legacy->fallback_index;
+          result->lifecycle_update_feature_mask =
+            UINT64_C (1) << context->legacy->fallback_index;
+          memcpy (result->match_transform, context->legacy->fallback_transform,
+                  sizeof (context->legacy->fallback_transform));
+          result->relation.relation_count = context->legacy->fallback_count;
+          int relation_status = goodix_milan_match_reference_transform (
+            context->enrolled, context->legacy->fallback_index,
+            result->match_transform, result->relation.relation_values);
+          if (relation_status < 0)
+            result->relation.relation_count = -1;
+          else if (relation_status > 0)
+            result->relation.relation_count = 0;
+        }
+    }
+  if (context->enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      result->matched_feature_index == SIZE_MAX)
+    {
+      int rejection_reason = (context->legacy->rejection_count_sum < 6) << 2;
+
+      if (context->legacy->rejection_candidate_seen &&
+          context->legacy->rejection_best_detail < 208)
+        rejection_reason |= 2;
+      if (context->legacy->rejection_candidate_seen &&
+          context->legacy->rejection_best_coverage < 128)
+        rejection_reason |= 1;
+      result->score = -rejection_reason;
+    }
+  return 0;
+}
+
 static int
 milan_match_prepared_probe (
-  const GoodixMilanFeatureView   *probe_feature,
-  const uint8_t                   probe_rescue_mask[308],
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  int32_t                         probe_primary_histogram_class,
-  int32_t                         image_quality,
-  int32_t                         image_coverage,
-  const GoodixMilanAntifakeBlob  *probe_antifake,
-  int                             caller_blocking_enabled,
-  const uint8_t *enrolled_template,
-  size_t         enrolled_template_size,
-  const GoodixMilanFeatureRecord *const live_records[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
-  const size_t live_record_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
-  const size_t live_partition_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
-  size_t triggering_index,
-  size_t        *matched_feature_index,
-  int32_t       *score,
-  int32_t        match_transform[6],
-  int32_t       *relation_count,
-  int32_t        relation_values[7],
-  uint64_t      *direct_positive_feature_mask,
-  uint64_t      *contributor_feature_mask,
-  uint64_t      *lifecycle_update_feature_mask,
-  size_t        *retained_evidence_count,
-  int32_t        retained_evidence_feature_indices[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY],
-  int32_t        retained_evidence_transforms[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY][6],
-  int32_t       *retained_evidence_flag,
-  int32_t       *study_finalization_gate,
-  int32_t       *study_action_gate,
-  int32_t       *queue_candidate_eligible
+  const MilanMatchPreparedProbeInput *input,
+  GoodixMilanMatchResult             *match_result
 #ifdef GOODIX53X5_DEBUG
   , GoodixMilanMatchDiagnostics *diagnostics
 #endif
   )
 {
+  const GoodixMilanFeatureView *probe_feature = input->probe_feature;
+  const uint8_t *probe_rescue_mask = input->probe_rescue_mask;
+  const GoodixMilanFeatureRecord *probe_records = input->probe_records;
+  size_t probe_record_count = input->probe_record_count;
+  int32_t probe_primary_histogram_class =
+    input->probe_primary_histogram_class;
+  int32_t image_quality = input->image_quality;
+  int32_t image_coverage = input->image_coverage;
+  const GoodixMilanAntifakeBlob *probe_antifake = input->probe_antifake;
+  int caller_blocking_enabled = input->caller_blocking_enabled;
+  const uint8_t *enrolled_template = input->enrolled_template;
+  size_t enrolled_template_size = input->enrolled_template_size;
+  const GoodixMilanFeatureRecord *const *live_records = input->live_records;
+  const size_t *live_record_counts = input->live_record_counts;
+  const size_t *live_partition_counts = input->live_partition_counts;
+  size_t triggering_index = input->triggering_index;
+  size_t *matched_feature_index = &match_result->matched_feature_index;
+  int32_t *score = &match_result->score;
+  int32_t *match_transform = match_result->match_transform;
+  int32_t *relation_count = &match_result->relation.relation_count;
+  int32_t *relation_values = match_result->relation.relation_values;
+  uint64_t *direct_positive_feature_mask =
+    &match_result->direct_positive_feature_mask;
+  uint64_t *contributor_feature_mask = &match_result->contributor_feature_mask;
+  uint64_t *lifecycle_update_feature_mask =
+    &match_result->lifecycle_update_feature_mask;
+  size_t *retained_evidence_count = &match_result->retained_evidence_count;
+  int32_t *retained_evidence_feature_indices =
+    match_result->retained_evidence_feature_indices;
+
+  int32_t (*retained_evidence_transforms)[6] =
+    match_result->retained_evidence_transforms;
+  int32_t *retained_evidence_flag = &match_result->retained_evidence_flag;
+  int32_t *study_finalization_gate =
+    &match_result->study_control.study_finalization_gate;
+  int32_t *study_action_gate = &match_result->study_control.study_action_gate;
+  int32_t *queue_candidate_eligible =
+    &match_result->study_control.queue_candidate_eligible;
   GoodixMilanUnpackedTemplate *enrolled = NULL;
   GoodixMilanFeatureRecord *enrolled_records_storage = NULL;
   const GoodixMilanFeatureRecord *enrolled_records = NULL;
-  int32_t aggregate[15] = { 0 };
-  size_t fallback_index = SIZE_MAX;
-  int32_t fallback_quality = INT32_MIN;
-  int32_t fallback_count = INT32_MIN;
-  int32_t fallback_coverage = INT32_MIN;
-  int32_t direct_aggregate[15] = { 0 };
-  int32_t direct_transform[6] = { 0 };
-  size_t direct_index = SIZE_MAX;
-  int32_t direct_score_sum = 0;
-  int32_t direct_candidate_count = 0;
-  int direct_positive = 0;
-  int32_t direct_quality = INT32_MIN;
-  int32_t direct_count = INT32_MIN;
-  int32_t direct_coverage = INT32_MIN;
-  int direct_is_candidate = 0;
+  MilanMatchLegacyState legacy = {
+    .fallback_index = SIZE_MAX,
+    .fallback_quality = INT32_MIN,
+    .fallback_count = INT32_MIN,
+    .fallback_coverage = INT32_MIN,
+    .direct_index = SIZE_MAX,
+    .direct_quality = INT32_MIN,
+    .direct_count = INT32_MIN,
+    .direct_coverage = INT32_MIN,
+    .rejection_best_detail = INT32_MIN,
+  };
 #ifdef GOODIX53X5_DEBUG
   int32_t policy_aggregate[15] = { 0 };
   size_t policy_index = SIZE_MAX;
@@ -1284,14 +2037,9 @@ milan_match_prepared_probe (
   int32_t probe_policy_descriptor = INT32_MIN;
   int32_t probe_policy_overlap = INT32_MIN;
 #endif
-  int32_t fallback_transform[6] = { 0 };
   GoodixMilanActiveRelationWinner active_relation_winner;
   size_t probe_partition_count;
   int32_t score_denominator = 31;
-  int32_t rejection_count_sum = 0;
-  int32_t rejection_best_detail = INT32_MIN;
-  int32_t rejection_best_coverage = 0;
-  int rejection_candidate_seen = 0;
   int32_t late_policy_status_counter = 0;
   GoodixMilanMatcherPolicy matcher_policy = { 0 };
   GoodixMilanMatcherLateContext late_policy_context = { 0 };
@@ -1508,21 +2256,44 @@ milan_match_prepared_probe (
                 feature.fields.tagged_values[0]))
             continue;
         }
-      if (milan_match_build_feature_candidate (
-            enrolled_records, feature.record_count, enrolled_partition_count,
-            probe_records, probe_record_count, probe_partition_count, &feature,
-            probe_feature, enrolled->metadata.sensor_type, image_quality,
-            image_coverage, sibling_tail_hamming_limit, feature_index,
-            &matcher_policy, &late_policy_context, late_policy_state,
-            &late_policy_status_counter, &match_selection, fallback_workspace,
-            rescue_records[feature_index], &rejection_candidate_seen,
-            &rejection_count_sum, &rejection_best_detail,
-            &rejection_best_coverage, &feature_result
+      MilanMatchFeatureContext feature_context = {
+        .direction = {
+          .enrolled_records = enrolled_records,
+          .enrolled_record_count = feature.record_count,
+          .enrolled_partition_count = enrolled_partition_count,
+          .enrolled_feature = &feature,
+          .probe_records = probe_records,
+          .probe_record_count = probe_record_count,
+          .probe_partition_count = probe_partition_count,
+          .probe_feature = probe_feature,
+        },
+        .sensor_type = enrolled->metadata.sensor_type,
+        .image_quality = image_quality,
+        .image_coverage = image_coverage,
+        .sibling_tail_hamming_limit = sibling_tail_hamming_limit,
+        .feature_index = feature_index,
+        .matcher_policy = &matcher_policy,
+        .late_policy_context = &late_policy_context,
+        .late_policy_state = late_policy_state,
+        .late_policy_status_counter = &late_policy_status_counter,
+        .match_selection = &match_selection,
+        .fallback_workspace = fallback_workspace,
+        .rescue_record = rescue_records[feature_index],
+        .rejection_candidate_seen = &legacy.rejection_candidate_seen,
+        .rejection_count_sum = &legacy.rejection_count_sum,
+        .rejection_best_detail = &legacy.rejection_best_detail,
+        .rejection_best_coverage = &legacy.rejection_best_coverage,
 #ifdef GOODIX53X5_DEBUG
-            , diagnostics, probe_policy_metrics, &probe_policy_index,
-            &probe_policy_descriptor, &probe_policy_overlap
+        .diagnostics = diagnostics,
+        .probe_policy_metrics = probe_policy_metrics,
+        .probe_policy_index = &probe_policy_index,
+        .probe_policy_descriptor = &probe_policy_descriptor,
+        .probe_policy_overlap = &probe_policy_overlap,
 #endif
-                                              ) != 0)
+      };
+
+      if (milan_match_build_feature_candidate (
+            &feature_context, &feature_result) != 0)
         continue;
 
       int publish_status = milan_match_publish_feature_candidate (
@@ -1554,25 +2325,29 @@ milan_match_prepared_probe (
              direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
              MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
              direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])) &&
-          (match_flag > direct_is_candidate ||
-           (match_flag == direct_is_candidate &&
-             (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] > direct_quality ||
-              (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] == direct_quality &&
-               direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > direct_count) ||
-              (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] == direct_quality &&
-               direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] == direct_count &&
-               direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] >
-                 direct_coverage)))))
+          (match_flag > legacy.direct_is_candidate ||
+           (match_flag == legacy.direct_is_candidate &&
+            (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] > legacy.direct_quality ||
+             (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] == legacy.direct_quality &&
+              direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > legacy.direct_count) ||
+             (direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] == legacy.direct_quality &&
+              direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] == legacy.direct_count &&
+              direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] >
+              legacy.direct_coverage)))))
         {
-          memcpy (direct_aggregate, direct_metrics, sizeof(direct_aggregate));
-          direct_index = feature_index;
-          direct_quality = direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
-          direct_count = direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
-          direct_coverage =
+          memcpy (legacy.direct_aggregate, direct_metrics,
+                  sizeof (legacy.direct_aggregate));
+          legacy.direct_index = feature_index;
+          legacy.direct_quality =
+            direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
+          legacy.direct_count =
+            direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
+          legacy.direct_coverage =
             direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8];
-          direct_is_candidate = match_flag;
-          direct_positive = candidate_flag == 1;
-          memcpy (direct_transform, transform, sizeof(direct_transform));
+          legacy.direct_is_candidate = match_flag;
+          legacy.direct_positive = candidate_flag == 1;
+          memcpy (legacy.direct_transform, transform,
+                  sizeof (legacy.direct_transform));
         }
       if (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
           direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > 4 &&
@@ -1583,186 +2358,41 @@ milan_match_prepared_probe (
               MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
               direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])))
         {
-          direct_score_sum +=
+          legacy.direct_score_sum +=
             ((direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] *
                 MILAN_MATCH_Q8_ONE + (score_denominator >> 1)) /
              score_denominator);
-          direct_candidate_count++;
+          legacy.direct_candidate_count++;
         }
-      int32_t reverse_transform[6];
-      int32_t reverse_forward_transform[6];
-      int32_t reverse_metrics[GOODIX_MILAN_CANDIDATE_WORDS] = { 0 };
-      int32_t reverse_low_metrics[3];
-      size_t reverse_correspondence_count;
-      size_t reverse_primary_filtered_count;
-      size_t reverse_filtered_count;
-      int32_t reverse_descriptor_score;
-      int32_t reverse_topology_percent;
-      int32_t reverse_geometric_percent;
-      int32_t reverse_topology_bonus;
-      int32_t reverse_overlap_score;
-      int32_t reverse_overlap_coverage;
-      int32_t reverse_overlap_detail;
-      int32_t reverse_match_flag;
-      int32_t reverse_candidate_flag;
-
-       if (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-          milan_match_score_counts (
-            probe_records, probe_record_count, probe_partition_count,
-            enrolled_records, feature.record_count, enrolled_partition_count,
-            reverse_transform,
-            &reverse_correspondence_count, &reverse_primary_filtered_count,
-            &reverse_filtered_count, &reverse_descriptor_score,
-            &reverse_topology_percent, &reverse_geometric_percent,
-             &reverse_topology_bonus, probe_feature, &feature,
-              enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE
-                ? 42 : 31, NULL) == 0)
+      if (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE)
         {
-          milan_match_apply_secondary (
-            probe_records, probe_record_count, probe_partition_count,
-            enrolled_records, feature.record_count, enrolled_partition_count,
-            &reverse_primary_filtered_count, &reverse_filtered_count,
-            reverse_transform,
-            &reverse_topology_percent, &reverse_geometric_percent,
-            &reverse_topology_bonus,
-            enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31,
-            sibling_tail_hamming_limit,
-            probe_feature, &feature, NULL);
-          reverse_descriptor_score =
-            (int32_t) reverse_filtered_count * 100 /
-            (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31);
+          MilanMatchReverseContext reverse_context = {
+            .direction = {
+              .enrolled_records = probe_records,
+              .enrolled_record_count = probe_record_count,
+              .enrolled_partition_count = probe_partition_count,
+              .enrolled_feature = probe_feature,
+              .probe_records = enrolled_records,
+              .probe_record_count = feature.record_count,
+              .probe_partition_count = enrolled_partition_count,
+              .probe_feature = &feature,
+            },
+            .sibling_tail_hamming_limit = sibling_tail_hamming_limit,
+            .feature_index = feature_index,
+            .matcher_policy = &matcher_policy,
+            .legacy = &legacy,
+            .score_denominator = score_denominator,
 #ifdef GOODIX53X5_DEBUG
-          if (diagnostics &&
-              reverse_descriptor_score > diagnostics->descriptor_score)
-            {
-              diagnostics->descriptor_score = reverse_descriptor_score;
-              diagnostics->filtered_count = (int32_t) reverse_filtered_count;
-               if (goodix_milan_transform_invert (
-                    reverse_transform, reverse_forward_transform) == 0)
-                memcpy (diagnostics->transform, reverse_forward_transform,
-                        sizeof(diagnostics->transform));
-            }
+            .diagnostics = diagnostics,
+            .probe_policy_metrics = probe_policy_metrics,
+            .probe_policy_index = &probe_policy_index,
+            .probe_policy_descriptor = &probe_policy_descriptor,
+            .policy_aggregate = policy_aggregate,
+            .policy_index = &policy_index,
 #endif
-          reverse_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
-            (int32_t) reverse_primary_filtered_count;
-          reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
-            (int32_t) reverse_filtered_count;
-          if (goodix_milan_match_overlap_metrics_with_context (
-                probe_feature, &feature, reverse_transform,
-                &reverse_overlap_score, &reverse_overlap_coverage,
-                &reverse_overlap_detail, reverse_low_metrics,
-                (int32_t) reverse_filtered_count) == 0)
-            {
-              reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
-                reverse_overlap_score;
-              reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
-                reverse_overlap_detail;
-              memcpy (reverse_metrics + 6, reverse_low_metrics,
-                      sizeof(reverse_low_metrics));
-              reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
-                reverse_overlap_coverage * MILAN_MATCH_OVERLAP_COVERAGE_SCALE_Q8 >> 8;
-              reverse_metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] =
-                reverse_topology_percent;
-              reverse_metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] =
-                reverse_geometric_percent;
-              if ((abs (reverse_transform[2]) > MILAN_MATCH_LARGE_TRANSLATION_Q8 ||
-                   abs (reverse_transform[5]) > MILAN_MATCH_LARGE_TRANSLATION_Q8) &&
-                  reverse_metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] < 36)
-                reverse_metrics[GOODIX_MILAN_CANDIDATE_GEOMETRIC_PERCENT] = 36;
-#ifdef GOODIX53X5_DEBUG
-              if (diagnostics &&
-                  feature_index < GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY)
-                {
-                  memcpy (diagnostics->feature_metrics[feature_index][1],
-                          reverse_metrics, 15 * sizeof(*reverse_metrics));
-                   if (goodix_milan_transform_invert (
-                        reverse_transform, reverse_forward_transform) == 0)
-                    memcpy (diagnostics->feature_transforms[feature_index][1],
-                            reverse_forward_transform,
-                            sizeof(reverse_forward_transform));
-                }
-#endif
-              if (goodix_milan_match_initial_flags (
-                    reverse_metrics, feature.fields.tagged_values[3],
-                    feature.fields.tagged_values[4], matcher_policy.configuration,
-                    &reverse_match_flag, &reverse_candidate_flag, NULL) == 0 &&
-                   goodix_milan_transform_invert (
-                    reverse_transform, reverse_forward_transform) == 0)
-                {
-#ifdef GOODIX53X5_DEBUG
-                  if (reverse_descriptor_score > probe_policy_descriptor)
-                    {
-                      probe_policy_descriptor = reverse_descriptor_score;
-                      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
-                        reverse_metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT];
-                      probe_policy_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
-                        reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
-                      probe_policy_index = feature_index;
-                    }
-                  if (reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] >
-                        policy_aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ||
-                      (reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ==
-                         policy_aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] &&
-                       reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] >
-                         policy_aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL]))
-                    {
-                      memcpy (policy_aggregate, reverse_metrics,
-                              sizeof(policy_aggregate));
-                      policy_index = feature_index;
-                    }
-#endif
-                  if (reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > 4 &&
-                      reverse_metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] > 30 &&
-                      (reverse_match_flag == 1 ||
-                       goodix_milan_match_fallback_candidate_eligible (
-                         reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
-                         MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
-                         reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])) &&
-                      (reverse_candidate_flag > direct_is_candidate ||
-                       (reverse_candidate_flag == direct_is_candidate &&
-                        (reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] >
-                           direct_quality ||
-                         (reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] ==
-                            direct_quality &&
-                          reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] >
-                            direct_count) ||
-                         (reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] ==
-                            direct_quality &&
-                          reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] ==
-                            direct_count &&
-                          reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] >
-                            direct_coverage)))))
-                    {
-                      memcpy (direct_aggregate, reverse_metrics,
-                              sizeof(direct_aggregate));
-                      direct_index = feature_index;
-                      direct_quality =
-                        reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL];
-                      direct_count =
-                        reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT];
-                      direct_coverage = reverse_metrics[
-                        GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8];
-                      direct_is_candidate = reverse_candidate_flag;
-                      memcpy (direct_transform, reverse_forward_transform,
-                              sizeof(direct_transform));
-                    }
-                  if (reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > 4 &&
-                      reverse_metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] > 30 &&
-                      (reverse_match_flag == 1 ||
-                       goodix_milan_match_fallback_candidate_eligible (
-                         reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
-                         MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
-                         reverse_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])))
-                    {
-                      direct_score_sum +=
-                        ((reverse_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] *
-                            MILAN_MATCH_Q8_ONE +
-                          (score_denominator >> 1)) /
-                         score_denominator);
-                      direct_candidate_count++;
-                    }
-                }
-            }
+          };
+
+          milan_match_reverse_feature (&reverse_context);
         }
       if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
         fallback_workspace->enabled =
@@ -1770,68 +2400,24 @@ milan_match_prepared_probe (
           match_selection.acceptance_evidence == 0;
       if (fallback_enabled && enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE)
         {
-          int32_t relaxed_pairs[62];
-          int32_t relaxed_transform[6];
-          int32_t relaxed_residual;
-          int32_t relaxed_overlap_score;
-          int32_t relaxed_overlap_coverage;
-          int32_t relaxed_overlap_detail;
-          int32_t relaxed_low_metrics[3];
-          size_t relaxed_filtered_count;
-          size_t relaxed_pair_count;
+          MilanMatchDirection relaxed_direction = {
+            .enrolled_records = enrolled_records,
+            .enrolled_record_count = feature.record_count,
+            .enrolled_partition_count = enrolled_partition_count,
+            .enrolled_feature = &feature,
+            .probe_records = probe_records,
+            .probe_record_count = probe_record_count,
+            .probe_partition_count = probe_partition_count,
+            .probe_feature = probe_feature,
+          };
 
-          relaxed_pair_count = goodix_milan_match_relaxed_correspondences (
-            enrolled_records, feature.record_count, enrolled_partition_count,
-            probe_records, probe_record_count, probe_partition_count,
-            relaxed_pairs);
-          if (relaxed_pair_count < 3 ||
-              goodix_milan_filter_recognition_pairs (
-                enrolled_records, probe_records, relaxed_pairs,
-                relaxed_pair_count, relaxed_transform,
-                &relaxed_filtered_count, &relaxed_residual) != 0 ||
-              relaxed_filtered_count <= 4 ||
-              goodix_milan_match_overlap_metrics_with_context (
-                &feature, probe_feature, relaxed_transform,
-                &relaxed_overlap_score, &relaxed_overlap_coverage,
-                &relaxed_overlap_detail, relaxed_low_metrics,
-                (int32_t) relaxed_filtered_count) != 0 ||
-              !goodix_milan_match_fallback_candidate_eligible (
-                relaxed_overlap_score, MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
-                relaxed_overlap_detail))
-            continue;
+          if (!milan_match_relaxed_feature (
+                &relaxed_direction, feature_index, &legacy
 #ifdef GOODIX53X5_DEBUG
-          if (diagnostics)
-            diagnostics->fallback_count += 2;
+                , diagnostics
 #endif
-          int32_t scaled_coverage =
-            relaxed_overlap_coverage * MILAN_MATCH_OVERLAP_COVERAGE_SCALE_Q8 >> 8;
-
-          if (relaxed_overlap_detail > fallback_quality ||
-              (relaxed_overlap_detail == fallback_quality &&
-               (int32_t) relaxed_filtered_count > fallback_count) ||
-              (relaxed_overlap_detail == fallback_quality &&
-               (int32_t) relaxed_filtered_count == fallback_count &&
-               scaled_coverage > fallback_coverage))
-            {
-              aggregate[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
-                (int32_t) relaxed_filtered_count;
-              aggregate[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
-                (int32_t) relaxed_filtered_count;
-              aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
-                relaxed_overlap_score;
-              aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
-                relaxed_overlap_detail;
-              memcpy (aggregate + 6, relaxed_low_metrics,
-                      sizeof(relaxed_low_metrics));
-              aggregate[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
-                scaled_coverage;
-              fallback_quality = relaxed_overlap_detail;
-              fallback_count = (int32_t) relaxed_filtered_count;
-              fallback_coverage = scaled_coverage;
-              fallback_index = feature_index;
-              memcpy (fallback_transform, relaxed_transform,
-                      sizeof(fallback_transform));
-            }
+                                           ))
+            continue;
         }
     }
 
@@ -1843,368 +2429,54 @@ milan_match_prepared_probe (
         goodix_milan_match_selection_direct_mask (&match_selection);
     }
 
-  if (goodix_milan_match_rescue_caller_eligible (
-        match_selection.q8_contributor_count,
-        match_selection.postloop_blocking_count,
-        match_selection.rejection_evidence,
-        enrolled->metadata.sensor_type))
-    {
-      GoodixMilanMatchRescueInput rescue_input = {
-        .type = enrolled->metadata.sensor_type,
-        .width = GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS,
-        .height = GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS,
-        .half_resolution = 1,
-        .source_mask = probe_rescue_mask,
-        .source_mask_size = GOODIX_MILAN_MATCH_RESCUE_MASK_SIZE,
-        .source_stride = GOODIX_MILAN_MATCH_RESCUE_MASK_STRIDE,
-        .records = &rescue_records[0][0],
-        .record_count = enrolled->feature_count,
-        .ordered_features = rescue_order,
-        .ordered_count = rescue_order_count,
-        .incoming_score = match_selection.score_latched
-                            ? match_selection.latched_score : 0,
-      };
-
-      if (goodix_milan_match_rescue_evaluate (
-            &rescue_input, &rescue_result) != 0)
-        goto out;
-      rescue_applied = rescue_result.set_acceptance;
-    }
-
-  effective_rejection = match_selection.rejection_evidence != 0 ||
-                        (rescue_applied && rescue_result.set_rejection);
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE && !retention_gate)
-    effective_rejection = 0;
-
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
-    {
-      *queue_candidate_eligible =
-        effective_rejection == 0 &&
-        matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE] == 1 &&
-        late_policy_context.probe_low_class == 0 && image_coverage > 65 &&
-        image_quality > 15 && late_policy_context.accumulated_high_class < 4 &&
-        late_policy_context.probe_primary_histogram_class < 3 &&
-        enrolled->metadata.queue_state == 0;
+  MilanMatchRescueQueueContext rescue_context = {
+    .input = input,
+    .enrolled = enrolled,
+    .selection = &match_selection,
+    .policy = &matcher_policy,
+    .late_context = &late_policy_context,
+    .rescue_records = &rescue_records[0][0],
+    .rescue_order = rescue_order,
+    .rescue_order_count = rescue_order_count,
+    .late_status_counter = late_policy_status_counter,
+    .retention_gate = retention_gate,
+    .rescue_result = &rescue_result,
+    .rescue_applied = &rescue_applied,
+    .effective_rejection = &effective_rejection,
+    .result = match_result,
 #ifdef GOODIX53X5_DEBUG
-      if (diagnostics)
-        {
-          diagnostics->queue_study_evidence = effective_rejection;
-          diagnostics->queue_configuration_enabled =
-            matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE];
-          diagnostics->queue_probe_low_class = late_policy_context.probe_low_class;
-          diagnostics->queue_accumulated_high_class =
-            late_policy_context.accumulated_high_class;
-          diagnostics->queue_status_count = late_policy_status_counter;
-        }
+    .diagnostics = diagnostics,
 #endif
-    }
+  };
 
+  if (milan_match_rescue_and_queue (&rescue_context) != 0)
+    goto out;
+
+  MilanMatchFinalizationContext finalization = {
+    .input = input,
+    .enrolled = enrolled,
+    .record_storage = enrolled_records_storage,
+    .selection = &match_selection,
+    .policy = &matcher_policy,
+    .late_context = &late_policy_context,
+    .relation_winner = &active_relation_winner,
+    .fallback = &match_fallback,
+    .fallback_by_feature = fallback_by_feature,
+    .rescue_result = &rescue_result,
+    .rescue_applied = rescue_applied,
+    .effective_rejection = effective_rejection,
+    .legacy = &legacy,
+    .result = match_result,
 #ifdef GOODIX53X5_DEBUG
-  if (diagnostics)
-    {
-      if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
-        memcpy (diagnostics->direct_aggregate, match_selection.winner_metrics,
-                sizeof(diagnostics->direct_aggregate));
-      else
-        memcpy (diagnostics->direct_aggregate, direct_aggregate,
-                sizeof(direct_aggregate));
-      memcpy (diagnostics->policy_aggregate, policy_aggregate,
-              sizeof(policy_aggregate));
-      memcpy (diagnostics->probe_policy_aggregate, probe_policy_metrics,
-              sizeof(probe_policy_metrics));
-      diagnostics->direct_feature_index =
-        enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE
-                                            ? match_selection.winner_feature
-                                            : (direct_index == SIZE_MAX
-                                                 ? -1
-                                                 : (int32_t) direct_index);
-      diagnostics->policy_feature_index =
-        policy_index == SIZE_MAX ? -1 : (int32_t) policy_index;
-      diagnostics->probe_policy_feature_index =
-        probe_policy_index == SIZE_MAX ? -1 : (int32_t) probe_policy_index;
-      diagnostics->q8_sum = enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE
-                              ? match_selection.q8_sum
-                              : direct_score_sum;
-      diagnostics->q8_contributor_count =
-        enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE
-                                             ? match_selection.q8_contributor_count
-                                             : direct_candidate_count;
-      diagnostics->postloop_blocking_count =
-        match_selection.postloop_blocking_count;
-      diagnostics->postloop_blocking_sum =
-        match_selection.postloop_blocking_sum;
-      diagnostics->postloop_blocking_override =
-        goodix_milan_match_selection_blocking_override (&match_selection);
-      diagnostics->final_selected_feature_index =
-        rescue_applied
-          ? rescue_result.selected_feature
-          : (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE
-               ? match_selection.selected_feature
-               : (direct_index == SIZE_MAX ? -1 : (int32_t) direct_index));
-    }
+    .diagnostics = diagnostics,
+    .policy_aggregate = policy_aggregate,
+    .policy_index = policy_index,
+    .probe_policy_metrics = probe_policy_metrics,
+    .probe_policy_index = probe_policy_index,
 #endif
-  int32_t aggregate_score = 0;
+  };
 
-  if (active_relation_winner.valid)
-    {
-      *relation_count = active_relation_winner.count;
-      relation_values[MILAN_MATCH_RELATION_SENTINEL] = 0;
-      memcpy (relation_values + MILAN_MATCH_RELATION_AFFINE_FIRST,
-              active_relation_winner.routed,
-              sizeof(active_relation_winner.routed));
-    }
-
-  if (rescue_applied)
-    {
-      *score = rescue_result.score;
-      *matched_feature_index = (size_t) rescue_result.selected_feature;
-      *lifecycle_update_feature_mask =
-        goodix_milan_match_selection_lifecycle_mask (&match_selection);
-      if (rescue_result.retain_transform)
-        memcpy (match_transform, rescue_result.selected_transform,
-                sizeof(rescue_result.selected_transform));
-      result = 0;
-      if (goodix_milan_match_selection_blocking_override (&match_selection))
-        *score = -65536;
-      goto out;
-    }
-
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-      !match_selection.score_latched &&
-      (late_policy_context.accumulated_high_class >= 4 ||
-       late_policy_context.probe_primary_histogram_class >= 2))
-    {
-      *score = goodix_milan_match_selection_blocking_override (&match_selection)
-                 ? -65536 : 0;
-      result = 0;
-      goto out;
-    }
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-      !match_selection.score_latched &&
-      matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_FEATURE_MODE] == 0)
-    {
-      *score = 0;
-      result = 0;
-      goto out;
-    }
-
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-      goodix_milan_match_selection_finalize (
-        &match_selection,
-        matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_PACKED_MODE],
-        match_selection.postloop_blocking_count,
-        milan_match_validate_winner, &matcher_policy))
-    {
-      *score = match_selection.latched_score;
-      *lifecycle_update_feature_mask =
-        goodix_milan_match_selection_lifecycle_mask (&match_selection);
-      if (match_selection.selected_feature >= 0)
-        {
-          *matched_feature_index = (size_t) match_selection.selected_feature;
-          memcpy (match_transform, match_selection.selected_transform,
-                  sizeof(match_selection.selected_transform));
-        }
-      result = 0;
-      if (goodix_milan_match_selection_blocking_override (&match_selection))
-        *score = -65536;
-      goto out;
-    }
-  if (enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
-    {
-      for (size_t feature_index = 0; feature_index < enrolled->feature_count;
-           feature_index++)
-        {
-          const GoodixMilanMatchFallbackWorkspace *workspace =
-            fallback_by_feature[feature_index];
-          GoodixMilanFeatureView feature;
-          int32_t fallback_candidate_transform[6];
-          size_t filtered_count;
-          int32_t residual;
-          int32_t overlap;
-          int32_t coverage;
-          int32_t detail;
-          int32_t low_metrics[3];
-          int32_t average_scale;
-          int32_t absolute_dot_q16;
-          int32_t transform_classifier;
-
-          if (!workspace || !workspace->enabled || workspace->pair_count < 3 ||
-              workspace->feature < 0 ||
-              (size_t) workspace->feature >= enrolled->feature_count ||
-               goodix_milan_template_parse_feature_element (
-                 enrolled->feature_elements[workspace->feature],
-                 enrolled->feature_element_sizes[workspace->feature],
-                 &feature) != 0 ||
-               feature.record_count == 0 || feature.record_count > 150)
-             continue;
-          if (live_records && live_records[workspace->feature])
-            {
-              if (!live_record_counts ||
-                  live_record_counts[workspace->feature] !=
-                    feature.record_count)
-                continue;
-              enrolled_records = live_records[workspace->feature];
-            }
-          else
-            {
-              if (goodix_milan_feature_unpack_template_records (
-                    feature.packed_records, feature.record_count,
-                    (size_t) feature.fields.tagged_values[2],
-                    enrolled_records_storage, 150) != 0)
-                continue;
-              enrolled_records = enrolled_records_storage;
-            }
-          if (goodix_milan_filter_recognition_pairs (
-                enrolled_records, probe_records, workspace->pairs,
-                workspace->pair_count, fallback_candidate_transform,
-                &filtered_count, &residual) != 0)
-            continue;
-          int32_t decoded_high =
-            (matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_PACKED_MODE] >> 8) & 7;
-
-          decoded_high = decoded_high == 0 ? 0
-                         : decoded_high <= 2 ? decoded_high
-                         : decoded_high <= 5 ? decoded_high + 1 : 0;
-          transform_classifier = goodix_milan_match_transform_proximity (
-            fallback_candidate_transform, decoded_high,
-            enrolled->metadata.sensor_type);
-          if (filtered_count <= 4 || transform_classifier != 0)
-            continue;
-          if (goodix_milan_match_overlap_metrics_with_context (
-                &feature, probe_feature, fallback_candidate_transform,
-                &overlap, &coverage, &detail, low_metrics,
-                (int32_t) filtered_count) != 0)
-            continue;
-          goodix_milan_match_affine_details (
-            fallback_candidate_transform, &average_scale,
-            &absolute_dot_q16);
-          int32_t accumulated = goodix_milan_match_fallback_consider (
-            &match_fallback, workspace->feature, (int32_t) filtered_count,
-            transform_classifier, overlap,
-            matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_METRIC_OFFSET] +
-            MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
-            detail,
-            coverage * matcher_policy.configuration[
-              GOODIX_MILAN_POLICY_CONFIG_OVERLAP_COVERAGE_SCALE_Q8] >> 8,
-            matcher_policy.configuration[
-              GOODIX_MILAN_POLICY_CONFIG_ALTERNATE_PENALTY] != 0,
-            average_scale, absolute_dot_q16,
-            fallback_candidate_transform);
-          (void) accumulated;
-        }
-
-      if (match_fallback.winner_valid)
-        {
-          GoodixMilanFeatureView feature;
-          int32_t metrics[15] = { 0 };
-          int32_t fallback_score = 0;
-
-          if (goodix_milan_template_parse_feature_element (
-                enrolled->feature_elements[match_fallback.winner.feature],
-                enrolled->feature_element_sizes[match_fallback.winner.feature],
-                &feature) != 0 ||
-              goodix_milan_match_low_bitmap_metrics (
-                feature.low_bitmap, feature.inline_mask,
-                probe_feature->low_bitmap, probe_feature->inline_mask,
-                match_fallback.winner.transform, metrics + 6) != 0)
-            goto out;
-          metrics[GOODIX_MILAN_CANDIDATE_PRIMARY_COUNT] =
-            match_fallback.winner.filtered_count;
-          metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] =
-            match_fallback.winner.filtered_count;
-          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE] =
-            match_fallback.winner.overlap;
-          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL] =
-            match_fallback.winner.raw_detail;
-          metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_COVERAGE_Q8] =
-            match_fallback.winner.coverage;
-          goodix_milan_match_affine_penalties (
-            match_fallback.winner.transform,
-            metrics + GOODIX_MILAN_CANDIDATE_SCALE_PENALTY,
-            metrics + GOODIX_MILAN_CANDIDATE_ORTHOGONALITY_PENALTY,
-            metrics + GOODIX_MILAN_CANDIDATE_STRONG_ORTHOGONALITY_PENALTY);
-          if (goodix_milan_match_final_score (
-                metrics, enrolled->metadata.sensor_type,
-                matcher_policy.configuration[
-                  GOODIX_MILAN_POLICY_CONFIG_FINAL_SCORE_ALTERNATE_POLICY] != 0,
-                &fallback_score) != 0)
-            goto out;
-          if (fallback_score > 0)
-            {
-              *score = fallback_score > 100 ? 100 : fallback_score;
-              if (goodix_milan_match_selection_publish_fallback (
-                    &match_selection, *score,
-                    match_selection.postloop_blocking_count,
-                    score) < 0)
-                goto out;
-              result = 0;
-              goto out;
-            }
-        }
-      *score = goodix_milan_match_fallback_rejection_score (&match_fallback);
-      if (match_selection.postloop_blocking_count > 0)
-        *score = -65536;
-    }
-  if (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-      direct_index != SIZE_MAX && direct_candidate_count > 0 &&
-      (direct_positive ||
-       (goodix_milan_match_final_score (
-          direct_aggregate, enrolled->metadata.sensor_type, 1,
-          &aggregate_score) == 0 && aggregate_score > 0)))
-    {
-      *score = (direct_score_sum * 100 / direct_candidate_count) >> 8;
-      *matched_feature_index = direct_index;
-      *lifecycle_update_feature_mask = UINT64_C(1) << direct_index;
-      memcpy (match_transform, direct_transform, sizeof(direct_transform));
-      *relation_count = direct_count;
-      int relation_status = goodix_milan_match_reference_transform (
-        enrolled, direct_index, match_transform, relation_values);
-      if (relation_status < 0)
-        *relation_count = -1;
-      else if (relation_status > 0)
-        *relation_count = 0;
-      result = 0;
-      goto out;
-    }
-  if (fallback_index != SIZE_MAX &&
-      goodix_milan_match_final_score (
-        aggregate, 23, 0, score) == 0)
-    {
-#ifdef GOODIX53X5_DEBUG
-      if (diagnostics)
-        {
-          diagnostics->fallback_feature_index = (int32_t) fallback_index;
-          memcpy (diagnostics->fallback_metrics, aggregate,
-                  sizeof(diagnostics->fallback_metrics));
-        }
-#endif
-      if (*score > 0)
-        {
-          *matched_feature_index = fallback_index;
-          *lifecycle_update_feature_mask = UINT64_C(1) << fallback_index;
-          memcpy (match_transform, fallback_transform,
-                  sizeof(fallback_transform));
-          *relation_count = fallback_count;
-          int relation_status = goodix_milan_match_reference_transform (
-            enrolled, fallback_index, match_transform, relation_values);
-          if (relation_status < 0)
-            *relation_count = -1;
-          else if (relation_status > 0)
-            *relation_count = 0;
-        }
-    }
-  if (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
-      *matched_feature_index == SIZE_MAX)
-    {
-      int rejection_reason = (rejection_count_sum < 6) << 2;
-
-      if (rejection_candidate_seen && rejection_best_detail < 208)
-        rejection_reason |= 2;
-      if (rejection_candidate_seen && rejection_best_coverage < 128)
-        rejection_reason |= 1;
-      *score = -rejection_reason;
-    }
-  result = 0;
+  result = milan_match_finalize (&finalization);
 
 out:
   *retained_evidence_count = match_selection.retained_evidence_count;
@@ -2280,27 +2552,25 @@ milan_match_probe_result_internal (
   probe_feature.fields.tagged_values[2] = (int32_t) probe_partition_count;
   probe_feature.fields.optional_c7 = probe_optional_c7;
   probe_feature.antifake = probe_antifake;
+  MilanMatchPreparedProbeInput prepared_input = {
+    .probe_feature = &probe_feature,
+    .probe_rescue_mask = probe_rescue_mask,
+    .probe_records = probe_records,
+    .probe_record_count = probe_record_count,
+    .probe_primary_histogram_class = probe_primary_histogram_class,
+    .image_quality = image_quality,
+    .image_coverage = image_coverage,
+    .probe_antifake = probe_antifake,
+    .caller_blocking_enabled = caller_blocking_enabled,
+    .enrolled_template = enrolled_template,
+    .enrolled_template_size = enrolled_template_size,
+    .live_records = live_records,
+    .live_record_counts = live_record_counts,
+    .live_partition_counts = live_partition_counts,
+    .triggering_index = triggering_index,
+  };
   result = milan_match_prepared_probe (
-    &probe_feature, probe_rescue_mask, probe_records, probe_record_count,
-    probe_primary_histogram_class, image_quality, image_coverage, probe_antifake,
-    caller_blocking_enabled,
-    enrolled_template,
-    enrolled_template_size, live_records, live_record_counts,
-    live_partition_counts, triggering_index,
-    &match_result->matched_feature_index,
-    &match_result->score, match_result->match_transform,
-    &match_result->relation.relation_count,
-    match_result->relation.relation_values,
-    &match_result->direct_positive_feature_mask,
-    &match_result->contributor_feature_mask,
-    &match_result->lifecycle_update_feature_mask,
-    &match_result->retained_evidence_count,
-    match_result->retained_evidence_feature_indices,
-    match_result->retained_evidence_transforms,
-    &match_result->retained_evidence_flag,
-    &match_result->study_control.study_finalization_gate,
-    &match_result->study_control.study_action_gate,
-    &match_result->study_control.queue_candidate_eligible
+    &prepared_input, match_result
 #ifdef GOODIX53X5_DEBUG
     , diagnostics
 #endif


### PR DESCRIPTION
## Summary

Complete `milan_match_prepared_probe()` decomposition with explicit direction, feature, rescue/queue, and finalization contexts. Its body falls from 1,007 to 532 lines and oversized helper APIs are reduced to compact context parameters. No behavioral change is intended.

## Native Contracts Preserved

- Reverse matching, relaxed fallback, rescue, queue, relation, and final-result precedence is unchanged.
- Earlier winners retain complete ties; fallback ranking remains detail/count/coverage.
- Layout-sensitive matcher diagnostics remain inline and preserve their existing behavior.

## Evidence

- 1,200 full prepared-probe cases matched results and diagnostics byte-for-byte.
- Sanitized coverage passed; queue-hook and relation-output mutations were detected.
- Release/debug builds, current runner, and Milan suites pass.

## Stack

Item 12 of the 13-PR Milan refactor stack; depends on the matcher-vocabulary PR.
