### PR TITLE
Complete Milan refactor hygiene

### DIFF
--- a/drivers/goodix53x5/milan/antifake/antifake.h
+++ b/drivers/goodix53x5/milan/antifake/antifake.h
@@ -56,17 +56,17 @@ _Static_assert (_Alignof (GoodixMilanAntifakeBlob) == _Alignof (uint8_t),
 _Static_assert (offsetof (GoodixMilanAntifakeBlob, bytes) == 0,
                 "Milan anti-fake blob data moved");
 _Static_assert (GOODIX_MILAN_ANTIFAKE_RECORDS_SIZE ==
-                  GOODIX_MILAN_ANTIFAKE_CANDIDATE_COUNT_OFFSET,
+                GOODIX_MILAN_ANTIFAKE_CANDIDATE_COUNT_OFFSET,
                 "Milan anti-fake record extent changed");
 _Static_assert (GOODIX_MILAN_ANTIFAKE_RECORD_DATA_44_OFFSET + 4U ==
-                  GOODIX_MILAN_ANTIFAKE_RECORD_SIZE,
+                GOODIX_MILAN_ANTIFAKE_RECORD_SIZE,
                 "Milan anti-fake record layout changed");
 _Static_assert (GOODIX_MILAN_ANTIFAKE_MASK_OFFSET +
-                  GOODIX_MILAN_ANTIFAKE_MASK_SIZE ==
-                  GOODIX_MILAN_ANTIFAKE_CALIBRATION_SCALAR_OFFSET,
+                GOODIX_MILAN_ANTIFAKE_MASK_SIZE ==
+                GOODIX_MILAN_ANTIFAKE_CALIBRATION_SCALAR_OFFSET,
                 "Milan anti-fake mask extent changed");
 _Static_assert (GOODIX_MILAN_ANTIFAKE_PAIR_SCORE_OFFSET + sizeof (int32_t) <=
-                  GOODIX_MILAN_ANTIFAKE_SIZE,
+                GOODIX_MILAN_ANTIFAKE_SIZE,
                 "Milan anti-fake pair score exceeds the blob");
 
 static inline uint8_t *
@@ -83,7 +83,7 @@ goodix_milan_antifake_const_data (const GoodixMilanAntifakeBlob *blob)
 
 static inline uint8_t *
 goodix_milan_antifake_record (GoodixMilanAntifakeBlob *blob,
-                              size_t                    index)
+                              size_t                   index)
 {
   return blob->bytes + GOODIX_MILAN_ANTIFAKE_RECORDS_OFFSET +
          index * GOODIX_MILAN_ANTIFAKE_RECORD_SIZE;
@@ -103,7 +103,7 @@ goodix_milan_antifake_record_x (const uint8_t *record)
   int32_t value;
 
   memcpy (&value, record + GOODIX_MILAN_ANTIFAKE_RECORD_X_OFFSET,
-          sizeof(value));
+          sizeof (value));
   return value;
 }
 
@@ -112,7 +112,7 @@ goodix_milan_antifake_set_record_x (uint8_t *record,
                                     int32_t  value)
 {
   memcpy (record + GOODIX_MILAN_ANTIFAKE_RECORD_X_OFFSET, &value,
-          sizeof(value));
+          sizeof (value));
 }
 
 static inline int32_t
@@ -121,7 +121,7 @@ goodix_milan_antifake_record_y (const uint8_t *record)
   int32_t value;
 
   memcpy (&value, record + GOODIX_MILAN_ANTIFAKE_RECORD_Y_OFFSET,
-          sizeof(value));
+          sizeof (value));
   return value;
 }
 
@@ -130,7 +130,7 @@ goodix_milan_antifake_set_record_y (uint8_t *record,
                                     int32_t  value)
 {
   memcpy (record + GOODIX_MILAN_ANTIFAKE_RECORD_Y_OFFSET, &value,
-          sizeof(value));
+          sizeof (value));
 }
 
 static inline uint8_t *
@@ -151,31 +151,31 @@ goodix_milan_antifake_candidate_count (const GoodixMilanAntifakeBlob *blob)
   uint32_t value;
 
   memcpy (&value, blob->bytes + GOODIX_MILAN_ANTIFAKE_CANDIDATE_COUNT_OFFSET,
-          sizeof(value));
+          sizeof (value));
   return value;
 }
 
 static inline void
 goodix_milan_antifake_set_candidate_count (GoodixMilanAntifakeBlob *blob,
-                                           uint32_t                  value)
+                                           uint32_t                 value)
 {
   memcpy (blob->bytes + GOODIX_MILAN_ANTIFAKE_CANDIDATE_COUNT_OFFSET, &value,
-          sizeof(value));
+          sizeof (value));
 }
 
 #define GOODIX_MILAN_ANTIFAKE_SCALAR_ACCESSORS(name, offset) \
   static inline int32_t \
-  goodix_milan_antifake_##name (const GoodixMilanAntifakeBlob *blob) \
+  goodix_milan_antifake_ ## name (const GoodixMilanAntifakeBlob * blob) \
   { \
     int32_t value; \
-    memcpy (&value, blob->bytes + (offset), sizeof(value)); \
+    memcpy (&value, blob->bytes + (offset), sizeof (value)); \
     return value; \
   } \
   static inline void \
-  goodix_milan_antifake_set_##name (GoodixMilanAntifakeBlob *blob, \
-                                    int32_t                   value) \
+  goodix_milan_antifake_set_ ## name (GoodixMilanAntifakeBlob * blob, \
+                                      int32_t value) \
   { \
-    memcpy (blob->bytes + (offset), &value, sizeof(value)); \
+    memcpy (blob->bytes + (offset), &value, sizeof (value)); \
   }
 
 GOODIX_MILAN_ANTIFAKE_SCALAR_ACCESSORS (texture,
@@ -197,8 +197,7 @@ GOODIX_MILAN_ANTIFAKE_SCALAR_ACCESSORS (pair_score,
 
 #undef GOODIX_MILAN_ANTIFAKE_SCALAR_ACCESSORS
 
-typedef enum
-{
+typedef enum {
   GOODIX_MILAN_ANTIFAKE_BOUNDARY_NOT_EVALUATED,
   GOODIX_MILAN_ANTIFAKE_BOUNDARY_STABLE,
   GOODIX_MILAN_ANTIFAKE_BOUNDARY_AMBIGUOUS,
@@ -213,142 +212,126 @@ typedef struct
   GoodixMilanAntifakeBlob          nonzero_projection;
 } GoodixMilanAntifakeBoundaryResult;
 
-int goodix_milan_antifake_residual (
-  const uint16_t *calibration,
-  const uint16_t *raw_frame,
-  size_t          rows,
-  size_t          columns,
-  int32_t         sensor_offset,
-  uint16_t        chip_type,
-  uint16_t       *residual);
+int goodix_milan_antifake_residual (const uint16_t *calibration,
+                                    const uint16_t *raw_frame,
+                                    size_t          rows,
+                                    size_t          columns,
+                                    int32_t         sensor_offset,
+                                    uint16_t        chip_type,
+                                    uint16_t       *residual);
 
-int goodix_milan_antifake_impulse_filter (
-  uint16_t *residual,
-  size_t    rows,
-  size_t    columns,
-  int32_t  *threshold);
+int goodix_milan_antifake_impulse_filter (uint16_t *residual,
+                                          size_t    rows,
+                                          size_t    columns,
+                                          int32_t  *threshold);
 
-int goodix_milan_antifake_statistics (
-  const uint16_t *residual,
-  const uint8_t  *mask,
-  size_t          rows,
-  size_t          columns,
-  int32_t        *texture,
-  int32_t        *mean);
+int goodix_milan_antifake_statistics (const uint16_t *residual,
+                                      const uint8_t  *mask,
+                                      size_t          rows,
+                                      size_t          columns,
+                                      int32_t        *texture,
+                                      int32_t        *mean);
 
-int goodix_milan_antifake_block_variation (
-  const uint16_t *residual,
-  const uint8_t  *mask,
-  size_t          rows,
-  size_t          columns,
-  size_t          block_size,
-  int32_t        *variation);
+int goodix_milan_antifake_block_variation (const uint16_t *residual,
+                                           const uint8_t  *mask,
+                                           size_t          rows,
+                                           size_t          columns,
+                                           size_t          block_size,
+                                           int32_t        *variation);
 
-int goodix_milan_antifake_model_score (
-  const int32_t vector[51],
-  int32_t      *score);
+int goodix_milan_antifake_model_score (const int32_t vector[51],
+                                       int32_t      *score);
 
-int goodix_milan_antifake_model_vector (
-  const uint16_t *residual,
-  const uint8_t  *mask,
-  size_t          rows,
-  size_t          columns,
-  size_t          border,
-  int32_t         vector[51]);
+int goodix_milan_antifake_model_vector (const uint16_t *residual,
+                                        const uint8_t  *mask,
+                                        size_t          rows,
+                                        size_t          columns,
+                                        size_t          border,
+                                        int32_t         vector[51]);
 
-int goodix_milan_antifake_class_map (
-  const uint8_t *image,
-  const uint8_t *mask,
-  size_t         rows,
-  size_t         columns,
-  uint8_t       *classes);
+int goodix_milan_antifake_class_map (const uint8_t *image,
+                                     const uint8_t *mask,
+                                     size_t         rows,
+                                     size_t         columns,
+                                     uint8_t       *classes);
 
-int goodix_milan_antifake_boundary_score (
-  const uint16_t *residual,
-  const uint8_t  *classes,
-  size_t          rows,
-  size_t          columns,
-  int32_t        *score);
+int goodix_milan_antifake_boundary_score (const uint16_t *residual,
+                                          const uint8_t  *classes,
+                                          size_t          rows,
+                                          size_t          columns,
+                                          int32_t        *score);
 
-int goodix_milan_antifake_build (
-  const uint16_t *calibration,
-  const uint16_t *raw_frame,
-  const uint8_t  *classification_plane,
-  const uint8_t  *feature_mask,
-  size_t          feature_mask_size,
-  size_t          rows,
-  size_t          columns,
-  uint16_t        t_code,
-  uint16_t        dac_high,
-  uint16_t        dac_low,
-  uint16_t        chip_type,
-  int32_t         calibration_scalar,
-  GoodixMilanAntifakeBlob *antifake,
-  size_t          antifake_size);
+int goodix_milan_antifake_build (const uint16_t          *calibration,
+                                 const uint16_t          *raw_frame,
+                                 const uint8_t           *classification_plane,
+                                 const uint8_t           *feature_mask,
+                                 size_t                   feature_mask_size,
+                                 size_t                   rows,
+                                 size_t                   columns,
+                                 uint16_t                 t_code,
+                                 uint16_t                 dac_high,
+                                 uint16_t                 dac_low,
+                                 uint16_t                 chip_type,
+                                 int32_t                  calibration_scalar,
+                                 GoodixMilanAntifakeBlob *antifake,
+                                 size_t                   antifake_size);
 
-int goodix_milan_antifake_build_with_boundary (
-  const uint16_t                   *calibration,
-  const uint16_t                   *raw_frame,
-  const uint8_t                    *classification_plane,
-  const uint8_t                    *feature_mask,
-  size_t                            feature_mask_size,
-  size_t                            rows,
-  size_t                            columns,
-  uint16_t                          t_code,
-  uint16_t                          dac_high,
-  uint16_t                          dac_low,
-  uint16_t                          chip_type,
-  int32_t                           calibration_scalar,
-  GoodixMilanAntifakeBlob          *antifake,
-  size_t                            antifake_size,
-  GoodixMilanAntifakeBoundaryResult *boundary_result);
+int goodix_milan_antifake_build_with_boundary (const uint16_t                    *calibration,
+                                               const uint16_t                    *raw_frame,
+                                               const uint8_t                     *classification_plane,
+                                               const uint8_t                     *feature_mask,
+                                               size_t                             feature_mask_size,
+                                               size_t                             rows,
+                                               size_t                             columns,
+                                               uint16_t                           t_code,
+                                               uint16_t                           dac_high,
+                                               uint16_t                           dac_low,
+                                               uint16_t                           chip_type,
+                                               int32_t                            calibration_scalar,
+                                               GoodixMilanAntifakeBlob           *antifake,
+                                               size_t                             antifake_size,
+                                               GoodixMilanAntifakeBoundaryResult *boundary_result);
 
-int goodix_milan_antifake_score_pair (
-  const GoodixMilanAntifakeBlob *prior,
-  size_t          prior_size,
-  const GoodixMilanAntifakeBlob *current,
-  size_t          current_size,
-  const int32_t   current_to_prior[6],
-  int32_t        *score);
+int goodix_milan_antifake_score_pair (const GoodixMilanAntifakeBlob *prior,
+                                      size_t                         prior_size,
+                                      const GoodixMilanAntifakeBlob *current,
+                                      size_t                         current_size,
+                                      const int32_t                  current_to_prior[6],
+                                      int32_t                       *score);
 
-int goodix_milan_antifake_pair_metrics (
-  const GoodixMilanAntifakeBlob *prior,
-  size_t         prior_size,
-  const GoodixMilanAntifakeBlob *current,
-  size_t         current_size,
-  const int32_t  current_to_prior[6],
-  int32_t        metrics[5]);
+int goodix_milan_antifake_pair_metrics (const GoodixMilanAntifakeBlob *prior,
+                                        size_t                         prior_size,
+                                        const GoodixMilanAntifakeBlob *current,
+                                        size_t                         current_size,
+                                        const int32_t                  current_to_prior[6],
+                                        int32_t                        metrics[5]);
 
-int goodix_milan_antifake_feature_update (
-  GoodixMilanAntifakeBlob *antifake,
-  size_t          antifake_size,
-  const uint16_t *source,
-  size_t          rows,
-  size_t          columns);
+int goodix_milan_antifake_feature_update (GoodixMilanAntifakeBlob *antifake,
+                                          size_t                   antifake_size,
+                                          const uint16_t          *source,
+                                          size_t                   rows,
+                                          size_t                   columns);
 
-int goodix_milan_antifake_feature_maps (
-  const uint16_t *source,
-  size_t          rows,
-  size_t          columns,
-  uint8_t        *dense_orientation,
-  uint32_t       *magnitude,
-  int16_t        *gradient_orientation);
+int goodix_milan_antifake_feature_maps (const uint16_t *source,
+                                        size_t          rows,
+                                        size_t          columns,
+                                        uint8_t        *dense_orientation,
+                                        uint32_t       *magnitude,
+                                        int16_t        *gradient_orientation);
 
-int goodix_milan_antifake_feature_record (
-  const uint8_t            *dense_orientation,
-  const uint32_t           *magnitude,
-  const int16_t            *gradient_orientation,
-  size_t                    rows,
-  size_t                    columns,
-  int32_t                   x,
-  int32_t                   y,
-  GoodixMilanFeatureRecord *record);
+int goodix_milan_antifake_feature_record (const uint8_t            *dense_orientation,
+                                          const uint32_t           *magnitude,
+                                          const int16_t            *gradient_orientation,
+                                          size_t                    rows,
+                                          size_t                    columns,
+                                          int32_t                   x,
+                                          int32_t                   y,
+                                          GoodixMilanFeatureRecord *record);
 
-int goodix_milan_antifake_build_mask (
-  const uint8_t *feature_mask,
-  size_t         feature_mask_size,
-  size_t         rows,
-  size_t         columns,
-  uint8_t       *mask,
-  uint8_t       *packed,
-  size_t         packed_size);
+int goodix_milan_antifake_build_mask (const uint8_t *feature_mask,
+                                      size_t         feature_mask_size,
+                                      size_t         rows,
+                                      size_t         columns,
+                                      uint8_t       *mask,
+                                      uint8_t       *packed,
+                                      size_t         packed_size);

--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -8,6 +8,10 @@
  * version 2.1 of the License, or (at your option) any later version.
  */
 
+/* Produces profile-9/type-12 processed images, quality, and retained state.
+ * Native owners are preprocessor, FUN_18006d540, FUN_180067500, and
+ * FUN_180069820. */
+
 #include "milan/milan.h"
 #include "milan/private.h"
 #include "milan/preprocess/gain.h"
@@ -320,7 +324,7 @@ goodix_milan_preprocess (GoodixMilanPreprocessState *state,
     }
   else
     {
-      /* Rejection suppresses map evolution, not application of persisted gain. */
+      /* Native quirk: rejection suppresses map evolution, not persisted gain. */
       profile9_update_source (normalized_live, setup_map, count, working);
       for (size_t i = 0; i < count; i++)
         {
@@ -525,7 +529,7 @@ profile9_normalize_outer_edges (uint16_t *frame,
     if (frame[i] > MILAN_ADC_MAX)
       frame[i] = MILAN_ADC_MAX;
 
-  /* Validated profile-9 frames copy outer edges but preserve inner-edge data. */
+  /* Native quirk: validated frames copy outer edges but preserve inner edges. */
   memcpy (frame, frame + columns, columns * sizeof(*frame));
   memcpy (frame + (rows - 1) * columns, frame + (rows - 2) * columns,
           columns * sizeof(*frame));
@@ -1749,12 +1753,12 @@ quality_patch_score_core (const uint8_t *frame,
     return -1;
 
   count = rows * columns;
-  if (count > SIZE_MAX / sizeof(*gradient_x))
+  if (count > SIZE_MAX / sizeof (*gradient_x))
     return -1;
-  gradient_x = calloc (count, sizeof(*gradient_x));
-  gradient_y = calloc (count, sizeof(*gradient_y));
-  magnitude = calloc (count, sizeof(*magnitude));
-  patch_scores = malloc (count * sizeof(*patch_scores));
+  gradient_x = calloc (count, sizeof (*gradient_x));
+  gradient_y = calloc (count, sizeof (*gradient_y));
+  magnitude = calloc (count, sizeof (*magnitude));
+  patch_scores = malloc (count * sizeof (*patch_scores));
   if (!gradient_x || !gradient_y || !magnitude || !patch_scores)
     goto allocation_failed;
   for (size_t i = 0; i < count; i++)
@@ -2336,11 +2340,11 @@ milan_render_local_contrast (const uint16_t *source,
 
 static int
 milan_contrast_core (const uint16_t *source,
-                      const uint8_t  *mask,
-                      size_t          rows,
-                      size_t          columns,
-                      uint8_t         *output,
-                      int              refine_diagonals)
+                     const uint8_t  *mask,
+                     size_t          rows,
+                     size_t          columns,
+                     uint8_t        *output,
+                     int             refine_diagonals)
 {
   size_t count;
   uint16_t *horizontal_min;
@@ -2352,13 +2356,13 @@ milan_contrast_core (const uint16_t *source,
     return -1;
 
   count = rows * columns;
-  if (count > SIZE_MAX / sizeof(uint16_t))
+  if (count > SIZE_MAX / sizeof (uint16_t))
     return -1;
 
-  horizontal_min = malloc (count * sizeof(*horizontal_min));
-  horizontal_max = malloc (count * sizeof(*horizontal_max));
-  vertical_min = malloc (count * sizeof(*vertical_min));
-  vertical_max = malloc (count * sizeof(*vertical_max));
+  horizontal_min = malloc (count * sizeof (*horizontal_min));
+  horizontal_max = malloc (count * sizeof (*horizontal_max));
+  vertical_min = malloc (count * sizeof (*vertical_min));
+  vertical_max = malloc (count * sizeof (*vertical_max));
   if (!horizontal_min || !horizontal_max || !vertical_min || !vertical_max)
     goto allocation_failed;
 

--- a/drivers/goodix53x5/milan/debug-hooks.h
+++ b/drivers/goodix53x5/milan/debug-hooks.h
@@ -14,59 +14,42 @@
 #include "milan/study/queue.h"
 
 #ifdef GOODIX53X5_DEBUG
-void goodix_milan_debug_runtime_gallery_result_free (
-  GoodixMilanRuntimeGalleryResult *result);
-void goodix_milan_debug_runtime_setup_failed (
-  GoodixMilanRuntimeOutput *output,
-  gint32                    status);
-void goodix_milan_debug_runtime_preprocess_started (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_runtime_preprocess_status (
-  GoodixMilanRuntimeOutput *output,
-  gint32                    status);
-void goodix_milan_debug_runtime_preprocess_finished (
-  GoodixMilanRuntimeOutput *output,
-  gint32                    status,
-  const guint8             *processed);
-void goodix_milan_debug_runtime_extraction_started (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_runtime_extraction_finished (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_runtime_gallery_input (
-  GoodixMilanRuntimeGalleryResult *result,
-  GBytes                          *input_template);
-void goodix_milan_debug_runtime_gallery_validated (
-  GoodixMilanRuntimeGalleryResult *result);
-void goodix_milan_debug_runtime_queue_before_match (
-  GoodixMilanRuntimeGalleryResult *result,
-  const GoodixStudyQueue          *queue);
-void goodix_milan_debug_runtime_queue_after_match (
-  GoodixMilanRuntimeGalleryResult *result,
-  const GoodixStudyQueue          *queue);
-void goodix_milan_debug_runtime_after_match (
-  GoodixMilanRuntimeGalleryResult *result,
-  GBytes                          *after_match);
-void goodix_milan_debug_runtime_study_started (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_runtime_queue_after_study (
-  GoodixMilanRuntimeOutput *output,
-  gsize                     winner_position,
-  const GoodixStudyQueue   *queue);
-void goodix_milan_debug_runtime_study_finished (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_runtime_output_free (
-  GoodixMilanRuntimeOutput *output);
-void goodix_milan_debug_extraction_antifake (
-  GoodixMilanExtractionDiagnostics *diagnostics,
-  const guint16                    *calibration,
-  const guint16                    *raw_frame,
-  const guint8                     *primary_contrast_plane,
-  const guint8                     *feature_mask,
-  guint16                           t_code,
-  guint16                           dac_high,
-  guint16                           dac_low,
-  guint16                           sensor_subtype,
-  gint32                            calibration_scalar);
+void goodix_milan_debug_runtime_gallery_result_free (GoodixMilanRuntimeGalleryResult *result);
+void goodix_milan_debug_runtime_setup_failed (GoodixMilanRuntimeOutput *output,
+                                              gint32                    status);
+void goodix_milan_debug_runtime_preprocess_started (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_preprocess_status (GoodixMilanRuntimeOutput *output,
+                                                   gint32                    status);
+void goodix_milan_debug_runtime_preprocess_finished (GoodixMilanRuntimeOutput *output,
+                                                     gint32                    status,
+                                                     const guint8             *processed);
+void goodix_milan_debug_runtime_extraction_started (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_extraction_finished (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_gallery_input (GoodixMilanRuntimeGalleryResult *result,
+                                               GBytes                          *input_template);
+void goodix_milan_debug_runtime_gallery_validated (GoodixMilanRuntimeGalleryResult *result);
+void goodix_milan_debug_runtime_queue_before_match (GoodixMilanRuntimeGalleryResult *result,
+                                                    const GoodixStudyQueue          *queue);
+void goodix_milan_debug_runtime_queue_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                                   const GoodixStudyQueue          *queue);
+void goodix_milan_debug_runtime_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                             GBytes                          *after_match);
+void goodix_milan_debug_runtime_study_started (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_queue_after_study (GoodixMilanRuntimeOutput *output,
+                                                   gsize                     winner_position,
+                                                   const GoodixStudyQueue   *queue);
+void goodix_milan_debug_runtime_study_finished (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_runtime_output_free (GoodixMilanRuntimeOutput *output);
+void goodix_milan_debug_extraction_antifake (GoodixMilanExtractionDiagnostics *diagnostics,
+                                             const guint16                    *calibration,
+                                             const guint16                    *raw_frame,
+                                             const guint8                     *primary_contrast_plane,
+                                             const guint8                     *feature_mask,
+                                             guint16                           t_code,
+                                             guint16                           dac_high,
+                                             guint16                           dac_low,
+                                             guint16                           sensor_subtype,
+                                             gint32                            calibration_scalar);
 #else
 static inline void
 goodix_milan_debug_runtime_gallery_result_free (
@@ -212,9 +195,8 @@ goodix_milan_debug_extraction_antifake (
 #endif
 
 #if defined(GOODIX53X5_DEBUG) || defined(GOODIX53X5_PARITY)
-void goodix_milan_debug_runtime_hash_after_match (
-  GoodixMilanRuntimeGalleryResult *result,
-  GBytes                          *after_match);
+void goodix_milan_debug_runtime_hash_after_match (GoodixMilanRuntimeGalleryResult *result,
+                                                  GBytes                          *after_match);
 #else
 static inline void
 goodix_milan_debug_runtime_hash_after_match (GoodixMilanRuntimeGalleryResult *result,

--- a/drivers/goodix53x5/milan/match/geometry.c
+++ b/drivers/goodix53x5/milan/match/geometry.c
@@ -697,10 +697,10 @@ goodix_milan_match_record_metrics_internal (
 
       if (transformed_x < 0x600 ||
           transformed_x >=
-            (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS - 7) * 0x100 ||
+          (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS - 7) * 0x100 ||
           transformed_y < 0x600 ||
           transformed_y >=
-            (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS - 7) * 0x100)
+          (GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS - 7) * 0x100)
         continue;
       valid_topology_records++;
 
@@ -1015,19 +1015,19 @@ milan_fill_record_index_map (const GoodixMilanFeatureRecord *records,
                              int16_t                         map[GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS])
 {
   memset (map, 0xff,
-          GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS * sizeof(*map));
+          GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS * sizeof (*map));
   for (size_t index = begin; index < end; index++)
     {
       int32_t x = ((uint16_t) records[index].refined_x + 0x80) >> 8;
       int32_t y = ((uint16_t) records[index].refined_y + 0x80) >> 8;
       int32_t left = x > radius ? x - radius : 0;
-      int32_t right = x + radius < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS
-                        ? x + radius
-                        : GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS - 1;
+      int32_t right = x + radius < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS ?
+                      x + radius :
+                      GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS - 1;
       int32_t top = y > radius ? y - radius : 0;
-      int32_t bottom = y + radius < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS
-                         ? y + radius
-                         : GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS - 1;
+      int32_t bottom = y + radius < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS ?
+                       y + radius :
+                       GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS - 1;
 
       for (int32_t row = top; row <= bottom; row++)
         for (int32_t column = left; column <= right; column++)

--- a/drivers/goodix53x5/milan/match/info.c
+++ b/drivers/goodix53x5/milan/match/info.c
@@ -189,25 +189,27 @@ goodix_milan_match_update_extraction_classification (
       current_classes[i] = 2;
 
   if (state->retained_count == 3)
-    for (guint class_value = 1; class_value <= 2; class_value++)
-      {
-        for (guint i = 0;
-             i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
-             i++)
-          component_mask[i] =
-            current_classes[i] == class_value &&
-            state->retained_class_planes[0][i] == class_value &&
-            state->retained_class_planes[1][i] == class_value &&
-            state->retained_class_planes[2][i] == class_value
-              ? UINT8_MAX : 0;
-        goodix_milan_match_retain_class_components (
-          component_mask, 31, 350, labels, queue);
-        for (guint i = 0;
-             i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
-             i++)
-          if (component_mask[i] != 0 && stable_classes[i] == 0)
-            stable_classes[i] = (guint8) class_value;
-      }
+    {
+      for (guint class_value = 1; class_value <= 2; class_value++)
+        {
+          for (guint i = 0;
+               i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
+               i++)
+            component_mask[i] =
+              current_classes[i] == class_value &&
+              state->retained_class_planes[0][i] == class_value &&
+              state->retained_class_planes[1][i] == class_value &&
+              state->retained_class_planes[2][i] == class_value ?
+              UINT8_MAX : 0;
+          goodix_milan_match_retain_class_components (
+            component_mask, 31, 350, labels, queue);
+          for (guint i = 0;
+               i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS;
+               i++)
+            if (component_mask[i] != 0 && stable_classes[i] == 0)
+              stable_classes[i] = (guint8) class_value;
+        }
+    }
 
   for (guint i = 0; i < GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS; i++)
     {
@@ -317,20 +319,19 @@ goodix_milan_match_decode_entry_classes (const guint8 *image,
     }
 }
 
-static GoodixMilanExtractionStatus goodix_milan_match_extract_planes (
-  const guint8  *image,
-  const guint8  *primary_contrast_plane,
-  GoodixMilanExtractionClassificationState *classification_state,
-  const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
-  const guint16 *calibration,
-  const guint16 *raw_frame,
-  guint16        t_code,
-  guint16        dac_high,
-  guint16        dac_low,
-  guint16        sensor_subtype,
-  gint32         calibration_scalar,
-  GoodixMatchInfo **result,
-  GoodixMilanExtractionDiagnostics *diagnostics);
+static GoodixMilanExtractionStatus goodix_milan_match_extract_planes (const guint8                              *image,
+                                                                      const guint8                              *primary_contrast_plane,
+                                                                      GoodixMilanExtractionClassificationState  *classification_state,
+                                                                      const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
+                                                                      const guint16                             *calibration,
+                                                                      const guint16                             *raw_frame,
+                                                                      guint16                                    t_code,
+                                                                      guint16                                    dac_high,
+                                                                      guint16                                    dac_low,
+                                                                      guint16                                    sensor_subtype,
+                                                                      gint32                                     calibration_scalar,
+                                                                      GoodixMatchInfo                          **result,
+                                                                      GoodixMilanExtractionDiagnostics          *diagnostics);
 
 GoodixMatchInfo *
 goodix_milan_match_extract_native (const guint8               *image,
@@ -411,19 +412,19 @@ goodix_milan_match_extract_native_result_debug (
 #endif
 
 static GoodixMilanExtractionStatus
-goodix_milan_match_extract_planes (const guint8  *image,
-                             const guint8  *primary_contrast_plane,
-                             GoodixMilanExtractionClassificationState *classification_state,
-                             const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
-                             const guint16 *calibration,
-                             const guint16 *raw_frame,
-                             guint16        t_code,
-                             guint16        dac_high,
-                             guint16        dac_low,
-                             guint16        sensor_subtype,
-                              gint32         calibration_scalar,
-                              GoodixMatchInfo **result,
-                              GoodixMilanExtractionDiagnostics *diagnostics)
+goodix_milan_match_extract_planes (const guint8                              *image,
+                                   const guint8                              *primary_contrast_plane,
+                                   GoodixMilanExtractionClassificationState  *classification_state,
+                                   const GoodixMilanExtractionAuxiliaryState *auxiliary_state,
+                                   const guint16                             *calibration,
+                                   const guint16                             *raw_frame,
+                                   guint16                                    t_code,
+                                   guint16                                    dac_high,
+                                   guint16                                    dac_low,
+                                   guint16                                    sensor_subtype,
+                                   gint32                                     calibration_scalar,
+                                   GoodixMatchInfo                          **result,
+                                   GoodixMilanExtractionDiagnostics          *diagnostics)
 {
   GoodixMatchInfo *info = NULL;
   guint8 *cropped = NULL;

--- a/drivers/goodix53x5/milan/match/lifecycle-private.h
+++ b/drivers/goodix53x5/milan/match/lifecycle-private.h
@@ -17,12 +17,11 @@ gboolean goodix_milan_match_queue_matches_template (const GoodixStudyQueue *queu
                                                const guint8           *feature,
                                                gsize                   feature_len);
 
-GoodixSigfmTemplateStatus goodix_milan_match_serialized_feature_result_internal (
-  GoodixMatchInfo             *probe_info,
-  const guint8                *feature,
-  gsize                        feature_len,
-  GoodixMilanMatchResult      *match_result,
-  GBytes                     **updated_feature,
+GoodixSigfmTemplateStatus goodix_milan_match_serialized_feature_result_internal (GoodixMatchInfo                *probe_info,
+                                                                                 const guint8                   *feature,
+                                                                                 gsize                           feature_len,
+                                                                                 GoodixMilanMatchResult         *match_result,
+                                                                                 GBytes                        **updated_feature,
 #ifdef GOODIX53X5_DEBUG
   GoodixMilanMatchDiagnostics *diagnostics,
 #endif

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -8,6 +8,9 @@
  * version 2.1 of the License, or (at your option) any later version.
  */
 
+/* Orchestrates profile-9/type-12 matching and publishes selected evidence.
+ * Native owner FUN_180055a40 is dispatched by FUN_18005edb0 and FUN_18005d330. */
+
 #include "milan/milan.h"
 #include "milan/print.h"
 #include "milan/private.h"
@@ -46,8 +49,7 @@ enum
   MILAN_MATCH_LARGE_TRANSLATION_Q8 = 51 * MILAN_MATCH_Q8_ONE,
 };
 
-enum
-{
+enum {
   GOODIX_MILAN_POLICY_CONFIG_METRIC_OFFSET = 0,
   GOODIX_MILAN_POLICY_CONFIG_RETENTION_GATE = 4,
   GOODIX_MILAN_POLICY_CONFIG_OVERLAP_COVERAGE_SCALE_Q8 = 12,
@@ -60,8 +62,7 @@ enum
   GOODIX_MILAN_POLICY_CONFIG_RECOGNITION_MODE = 19,
 };
 
-enum
-{
+enum {
   MILAN_MATCH_RELATION_SENTINEL = 0,
   MILAN_MATCH_RELATION_AFFINE_FIRST = 1,
   MILAN_MATCH_RELATION_AFFINE_XX = 1,
@@ -1092,7 +1093,7 @@ milan_match_build_feature_candidate (
                 feature_result->metrics + GOODIX_MILAN_CANDIDATE_VALID_RECORD_COUNT,
                 feature_result->candidate.words +
                 GOODIX_MILAN_CANDIDATE_VALID_RECORD_COUNT,
-                      5 * sizeof (*feature_result->metrics));
+                5 * sizeof (*feature_result->metrics));
             }
           if (sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE &&
               (abs (feature_result->transform[2]) >
@@ -1182,14 +1183,14 @@ milan_match_publish_feature_candidate (
   GoodixMilanMatcherPolicy          *matcher_policy,
   GoodixMilanMatchSelection         *match_selection,
   GoodixMilanActiveRelationWinner   *active_relation_winner,
-  int                                retention_gate
-#ifdef GOODIX53X5_DEBUG
+  int retention_gate
+#ifdef                               GOODIX53X5_DEBUG
   , GoodixMilanMatchDiagnostics     *diagnostics,
   int32_t                            recognition_mode_before,
   int32_t                            policy_aggregate[15],
   size_t                            *policy_index
 #endif
-  )
+                                      )
 {
   GoodixMilanMatchContributionEvent contribution_event;
   int contributes = 0;
@@ -1498,7 +1499,7 @@ milan_match_relaxed_feature (const MilanMatchDirection     *direction,
 #ifdef GOODIX53X5_DEBUG
                              , GoodixMilanMatchDiagnostics *diagnostics
 #endif
-                             )
+                            )
 {
   int32_t pairs[62];
   int32_t transform[6];
@@ -1690,7 +1691,7 @@ milan_match_finalize (MilanMatchFinalizationContext *context)
     }
 #endif
 
-  /* FUN_180055a40 keeps relation ownership independent of later rescue. */
+  /* Native quirk: relation ownership remains independent of later rescue. */
   if (context->relation_winner->valid)
     {
       result->relation.relation_count = context->relation_winner->count;
@@ -1972,10 +1973,10 @@ static int
 milan_match_prepared_probe (
   const MilanMatchPreparedProbeInput *input,
   GoodixMilanMatchResult             *match_result
-#ifdef GOODIX53X5_DEBUG
-  , GoodixMilanMatchDiagnostics *diagnostics
+#ifdef                                GOODIX53X5_DEBUG
+  , GoodixMilanMatchDiagnostics      *diagnostics
 #endif
-  )
+                           )
 {
   const GoodixMilanFeatureView *probe_feature = input->probe_feature;
   const uint8_t *probe_rescue_mask = input->probe_rescue_mask;
@@ -2046,13 +2047,13 @@ milan_match_prepared_probe (
   int32_t sibling_tail_hamming_limit = MILAN_MATCH_DESCRIPTOR_DISTANCE_LIMIT;
   GoodixMilanMatchSelection match_selection = { 0 };
   int32_t rescue_records[GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT]
-                         [GOODIX_MILAN_MATCH_RESCUE_METRICS] = { { 0 } };
+  [GOODIX_MILAN_MATCH_RESCUE_METRICS] = { { 0 } };
   int32_t rescue_order[GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT] = { 0 };
   size_t rescue_order_count = 0;
   GoodixMilanMatchRescueResult rescue_result;
   GoodixMilanMatchFallback match_fallback;
   GoodixMilanMatchFallbackWorkspace
-    *fallback_by_feature[GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT] = { 0 };
+  *fallback_by_feature[GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT] = { 0 };
   int rescue_applied = 0;
   int retention_gate = 0;
   int retention_gate_latched = 0;
@@ -2068,16 +2069,16 @@ milan_match_prepared_probe (
       !contributor_feature_mask || !lifecycle_update_feature_mask ||
       !retained_evidence_count || !retained_evidence_feature_indices ||
       !retained_evidence_transforms || !retained_evidence_flag ||
-       !study_finalization_gate || !study_action_gate ||
-       !queue_candidate_eligible)
+      !study_finalization_gate || !study_action_gate ||
+      !queue_candidate_eligible)
     return -1;
   *matched_feature_index = SIZE_MAX;
   *score = -7;
-  memset (match_transform, 0, 6 * sizeof(*match_transform));
+  memset (match_transform, 0, 6 * sizeof (*match_transform));
   match_transform[0] = MILAN_MATCH_Q8_ONE;
   match_transform[4] = MILAN_MATCH_Q8_ONE;
   *relation_count = 0;
-  memset (relation_values, 0, 7 * sizeof(*relation_values));
+  memset (relation_values, 0, 7 * sizeof (*relation_values));
   relation_values[MILAN_MATCH_RELATION_AFFINE_XX] = MILAN_MATCH_Q8_ONE;
   relation_values[MILAN_MATCH_RELATION_AFFINE_YY] = MILAN_MATCH_Q8_ONE;
   *direct_positive_feature_mask = 0;
@@ -2086,7 +2087,7 @@ milan_match_prepared_probe (
   *retained_evidence_count = 0;
   memset (retained_evidence_transforms, 0,
           GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY * 6 *
-            sizeof(*retained_evidence_transforms[0]));
+          sizeof (*retained_evidence_transforms[0]));
   *retained_evidence_flag = 0;
   *study_finalization_gate = 0;
   *study_action_gate = 0;
@@ -2094,7 +2095,7 @@ milan_match_prepared_probe (
 #ifdef GOODIX53X5_DEBUG
   if (diagnostics)
     {
-      memset (diagnostics, 0, sizeof(*diagnostics));
+      memset (diagnostics, 0, sizeof (*diagnostics));
       diagnostics->fallback_feature_index = -1;
       diagnostics->direct_feature_index = -1;
       diagnostics->policy_feature_index = -1;
@@ -2102,8 +2103,8 @@ milan_match_prepared_probe (
       diagnostics->probe_optional_c7 = probe_feature->fields.optional_c7;
     }
 #endif
-  enrolled = malloc (sizeof(*enrolled));
-  enrolled_records_storage = malloc (150 * sizeof(*enrolled_records_storage));
+  enrolled = malloc (sizeof (*enrolled));
+  enrolled_records_storage = malloc (150 * sizeof (*enrolled_records_storage));
   if (!enrolled || !enrolled_records_storage ||
       goodix_milan_template_unpack (
         enrolled_template, enrolled_template_size, enrolled) != 0)
@@ -2133,11 +2134,11 @@ milan_match_prepared_probe (
         probe_primary_histogram_class);
       retention_gate =
         matcher_policy.configuration[GOODIX_MILAN_POLICY_CONFIG_RETENTION_GATE] != 0 &&
-                       (((uint32_t) probe_feature->fields.optional_c7 >> 8) &
-                        7) != 5;
+        (((uint32_t) probe_feature->fields.optional_c7 >> 8) &
+         7) != 5;
       sibling_tail_hamming_limit =
         matcher_policy.configuration[GOODIX_MILAN_MATCHER_CONFIGURATION_OFFSET +
-                              GOODIX_MILAN_MATCHER_TAIL_HAMMING_LIMIT_INDEX];
+                                     GOODIX_MILAN_MATCHER_TAIL_HAMMING_LIMIT_INDEX];
     }
   else
     {
@@ -2161,7 +2162,7 @@ milan_match_prepared_probe (
       size_t feature_index = SIZE_MAX;
 
       feature_index = goodix_milan_template_read_u32 (
-        enrolled->tail_state + order_index * sizeof(uint32_t));
+        enrolled->tail_state + order_index * sizeof (uint32_t));
 
       if (order_index >= GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT ||
           feature_index >= GOODIX_MILAN_PROFILE9_ACTIVE_FEATURE_LIMIT)
@@ -2353,14 +2354,14 @@ milan_match_prepared_probe (
           direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] > 4 &&
           direct_metrics[GOODIX_MILAN_CANDIDATE_TOPOLOGY_PERCENT] > 30 &&
           (candidate_flag == 1 ||
-         goodix_milan_match_fallback_candidate_eligible (
-              direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
-              MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
-              direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])))
+           goodix_milan_match_fallback_candidate_eligible (
+             direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_SCORE],
+             MILAN_MATCH_FALLBACK_OVERLAP_THRESHOLD,
+             direct_metrics[GOODIX_MILAN_CANDIDATE_OVERLAP_DETAIL])))
         {
           legacy.direct_score_sum +=
             ((direct_metrics[GOODIX_MILAN_CANDIDATE_RETAINED_COUNT] *
-                MILAN_MATCH_Q8_ONE + (score_denominator >> 1)) /
+              MILAN_MATCH_Q8_ONE + (score_denominator >> 1)) /
              score_denominator);
           legacy.direct_candidate_count++;
         }

--- a/drivers/goodix53x5/milan/match/policy.c
+++ b/drivers/goodix53x5/milan/match/policy.c
@@ -1119,7 +1119,7 @@ goodix_milan_matcher_policy_apply_late_veto (
 {
   if (policy->configuration[GOODIX_MILAN_POLICY_CONFIG_PACKED_MODE] > 0 &&
       policy->configuration[GOODIX_MILAN_POLICY_CONFIG_SUBTYPE] ==
-        GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      GOODIX_MILAN_PRINT_SENSOR_TYPE &&
       ((metrics[GOODIX_MILAN_POLICY_METRIC_PRIMARY] < 9 &&
         metrics[GOODIX_MILAN_POLICY_METRIC_GEOMETRY] < 12) ||
        (metrics[GOODIX_MILAN_POLICY_METRIC_PRIMARY] < 8 &&
@@ -1340,7 +1340,7 @@ overlap_status_type12 (int32_t area,
 {
   return area * 100 >
          (100 - margin) * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS *
-           GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
+         GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
 }
 
 static int
@@ -1349,7 +1349,7 @@ overlap_clears_match_flag_type12 (int32_t area,
 {
   return area * 100 >
          (95 - margin) * GOODIX_MILAN_EXTRACTION_CLASSIFICATION_ROWS *
-           GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
+         GOODIX_MILAN_EXTRACTION_CLASSIFICATION_COLUMNS;
 }
 
 int

--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -168,8 +168,8 @@ goodix_milan_match_study_feature_internal (
         &probe_view) != 0)
     goto invalid;
   finalize_current_study = finalize_study &&
-    (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE ||
-     match_result->study_control.study_finalization_gate != 0);
+                           (enrolled->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE ||
+                            match_result->study_control.study_finalization_gate != 0);
   if (match_result->study_control.study_action_gate == 0)
     {
       g_free (packed);
@@ -356,11 +356,11 @@ goodix_milan_match_set_live_feature (GoodixStudyFollowupContext *context,
 }
 
 static GoodixSigfmTemplateStatus
-goodix_milan_match_live_gallery_result (GoodixMatchInfo                 *probe,
-                                   GoodixStudyFollowupContext      *context,
-                                   gsize                            triggering_index,
-                                   GoodixMilanMatchResult          *match_result,
-                                  GBytes                         **updated_feature)
+goodix_milan_match_live_gallery_result (GoodixMatchInfo            *probe,
+                                        GoodixStudyFollowupContext *context,
+                                        gsize                       triggering_index,
+                                        GoodixMilanMatchResult     *match_result,
+                                        GBytes                    **updated_feature)
 {
   const GoodixMilanFeatureRecord *live_records[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };
   size_t live_record_counts[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY] = { 0 };

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -562,12 +562,11 @@ int goodix_milan_study_action0_transient (
 int goodix_milan_study_finalize_action0_transient (
   GoodixMilanStudyTransientState *transient_state);
 
-int goodix_milan_study_finalize (
-  const uint8_t *current_template,
-  size_t         current_template_size,
-  uint32_t       queue_state,
-  uint32_t       queue_transaction_counter,
-  int            finalize_transaction,
-  uint8_t       *packed,
-  size_t         packed_capacity,
-  size_t        *packed_size);
+int goodix_milan_study_finalize (const uint8_t *current_template,
+                                 size_t         current_template_size,
+                                 uint32_t       queue_state,
+                                 uint32_t       queue_transaction_counter,
+                                 int            finalize_transaction,
+                                 uint8_t       *packed,
+                                 size_t         packed_capacity,
+                                 size_t        *packed_size);

--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -8,6 +8,10 @@
  * version 2.1 of the License, or (at your option) any later version.
  */
 
+/* Builds profile-9/type-12 contrast and broken-pixel classifications.
+ * Native owners are FUN_18004d510, FUN_18004ce40, FUN_18004e0e0, and
+ * FUN_18006b290. */
+
 #include "milan/private.h"
 #include "milan/preprocess/state.h"
 

--- a/drivers/goodix53x5/milan/preprocess/state.h
+++ b/drivers/goodix53x5/milan/preprocess/state.h
@@ -28,8 +28,7 @@
 #define GOODIX_MILAN_PREPROCESS_RETRY 0x7531
 #define GOODIX_MILAN_PREPROCESS_RETRY_CLASSIFICATION 0xc351
 
-typedef enum
-{
+typedef enum {
   GOODIX_MILAN_PURPOSE_IDENTIFY = 0,
   GOODIX_MILAN_PURPOSE_ENROLL = 1,
 } GoodixMilanPreprocessPurpose;
@@ -64,7 +63,7 @@ typedef struct
 typedef struct
 {
   uint8_t  retained_class_planes[3]
-                                [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
+  [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
   uint32_t retained_count;
   uint32_t high_class_hysteresis;
 } GoodixMilanExtractionClassificationState;
@@ -72,7 +71,7 @@ typedef struct
 typedef struct
 {
   uint8_t  retained_class_planes[3]
-                                [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
+  [GOODIX_MILAN_EXTRACTION_CLASSIFICATION_PIXELS];
   uint32_t retained_count;
 } GoodixMilanExtractionPersistenceState;
 
@@ -84,27 +83,27 @@ typedef struct
 
 typedef struct
 {
-  uint16_t setup_map[GOODIX_MILAN_SENSOR_PIXELS];
-  uint16_t calibration_map[GOODIX_MILAN_SENSOR_PIXELS];
-  uint16_t coarse_reference[GOODIX_MILAN_SENSOR_PIXELS / 4];
-  uint16_t auxiliary_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
-  uint16_t secondary_auxiliary_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
-  uint16_t application_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
-  uint32_t sample_count;
-  uint32_t stable_count;
-  uint32_t update_state;
-  uint32_t auxiliary_sample_count;
-  uint32_t profile9_history_count;
-  uint32_t profile9_history_update_count;
-  uint32_t profile9_history_mask_threshold;
-  uint32_t profile9_history_mask_average;
-  uint16_t profile9_history_reference[GOODIX_MILAN_SENSOR_PIXELS];
-  uint8_t  profile9_reference_age[GOODIX_MILAN_SENSOR_PIXELS];
-  uint8_t  profile9_component_age[GOODIX_MILAN_SENSOR_PIXELS];
-  GoodixMilanProfile9ClassCounts profile9_class_counts;
-  uint8_t  primary_contrast[GOODIX_MILAN_SENSOR_PIXELS];
-  int32_t  primary_contrast_valid;
-  int32_t  selected_refined;
+  uint16_t                          setup_map[GOODIX_MILAN_SENSOR_PIXELS];
+  uint16_t                          calibration_map[GOODIX_MILAN_SENSOR_PIXELS];
+  uint16_t                          coarse_reference[GOODIX_MILAN_SENSOR_PIXELS / 4];
+  uint16_t                          auxiliary_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
+  uint16_t                          secondary_auxiliary_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
+  uint16_t                          application_gain_map[GOODIX_MILAN_SENSOR_PIXELS];
+  uint32_t                          sample_count;
+  uint32_t                          stable_count;
+  uint32_t                          update_state;
+  uint32_t                          auxiliary_sample_count;
+  uint32_t                          profile9_history_count;
+  uint32_t                          profile9_history_update_count;
+  uint32_t                          profile9_history_mask_threshold;
+  uint32_t                          profile9_history_mask_average;
+  uint16_t                          profile9_history_reference[GOODIX_MILAN_SENSOR_PIXELS];
+  uint8_t                           profile9_reference_age[GOODIX_MILAN_SENSOR_PIXELS];
+  uint8_t                           profile9_component_age[GOODIX_MILAN_SENSOR_PIXELS];
+  GoodixMilanProfile9ClassCounts    profile9_class_counts;
+  uint8_t                           primary_contrast[GOODIX_MILAN_SENSOR_PIXELS];
+  int32_t                           primary_contrast_valid;
+  int32_t                           selected_refined;
   GoodixMilanPostRenderObservations post_render;
   /* Retained planes/hysteresis persist in generation-owned preprocess state.
    * Auxiliary bytes describe the latest completed preprocessing call and feed
@@ -113,8 +112,8 @@ typedef struct
   /* Native serializes the retained ring before extraction appends the current
    * sample, so persistence needs the corresponding entry snapshot. */
   GoodixMilanExtractionPersistenceState extraction_persistence;
-  GoodixMilanExtractionAuxiliaryState extraction_auxiliary;
-  uint8_t application_gain_initialized;
+  GoodixMilanExtractionAuxiliaryState   extraction_auxiliary;
+  uint8_t                               application_gain_initialized;
 } GoodixMilanPreprocessState;
 
 _Static_assert (sizeof (GoodixMilanProfile9ClassCounts) == 12,
@@ -135,27 +134,27 @@ _Static_assert (offsetof (GoodixMilanPreprocessState,
                 "Milan preprocess profile-9 class counts moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
                           profile9_class_counts) +
-                  offsetof (GoodixMilanProfile9ClassCounts,
-                            profile9_class1_count) == 137840,
+                offsetof (GoodixMilanProfile9ClassCounts,
+                          profile9_class1_count) == 137840,
                 "Milan preprocess profile-9 class-1 count moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
                           profile9_class_counts) +
-                  offsetof (GoodixMilanProfile9ClassCounts,
-                            profile9_class2_count) == 137844,
+                offsetof (GoodixMilanProfile9ClassCounts,
+                          profile9_class2_count) == 137844,
                 "Milan preprocess profile-9 class-2 count moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
                           profile9_class_counts) +
-                  offsetof (GoodixMilanProfile9ClassCounts,
-                            profile9_class3_count) == 137848,
+                offsetof (GoodixMilanProfile9ClassCounts,
+                          profile9_class3_count) == 137848,
                 "Milan preprocess profile-9 class-3 count moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, primary_contrast) ==
-                  137852,
+                137852,
                 "Milan preprocess primary contrast moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState,
                           primary_contrast_valid) == 147356,
                 "Milan preprocess primary contrast validity moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, selected_refined) ==
-                  147360,
+                147360,
                 "Milan preprocess selected output moved");
 _Static_assert (sizeof (GoodixMilanPostRenderObservations) == 32,
                 "Milan post-render observations size changed");
@@ -180,35 +179,35 @@ _Static_assert (offsetof (GoodixMilanPostRenderObservations, status) == 28,
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) == 147364,
                 "Milan preprocess post-render observations moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, primary_metric) ==
-                  147364,
+                offsetof (GoodixMilanPostRenderObservations, primary_metric) ==
+                147364,
                 "Milan preprocess post-render primary metric moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, fallback_metric) ==
-                  147368,
+                offsetof (GoodixMilanPostRenderObservations, fallback_metric) ==
+                147368,
                 "Milan preprocess post-render fallback metric moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, disagreement) ==
-                  147372,
+                offsetof (GoodixMilanPostRenderObservations, disagreement) ==
+                147372,
                 "Milan preprocess post-render disagreement moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, component_score) ==
-                  147376,
+                offsetof (GoodixMilanPostRenderObservations, component_score) ==
+                147376,
                 "Milan preprocess post-render component score moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, component_flag) ==
-                  147380,
+                offsetof (GoodixMilanPostRenderObservations, component_flag) ==
+                147380,
                 "Milan preprocess post-render component flag moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, quality_gate) ==
-                  147384,
+                offsetof (GoodixMilanPostRenderObservations, quality_gate) ==
+                147384,
                 "Milan preprocess post-render quality gate moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, update_applied) ==
-                  147388,
+                offsetof (GoodixMilanPostRenderObservations, update_applied) ==
+                147388,
                 "Milan preprocess post-render update applied moved");
 _Static_assert (offsetof (GoodixMilanPreprocessState, post_render) +
-                  offsetof (GoodixMilanPostRenderObservations, status) == 147392,
+                offsetof (GoodixMilanPostRenderObservations, status) == 147392,
                 "Milan preprocess post-render status moved");
 _Static_assert (sizeof (GoodixMilanExtractionClassificationState) == 27464,
                 "Milan extraction classification state size changed");
@@ -246,113 +245,108 @@ _Static_assert (sizeof (GoodixMilanPreprocessState) == 202324,
 _Static_assert (_Alignof (GoodixMilanPreprocessState) == 4,
                 "Milan preprocess state alignment changed");
 
-void goodix_milan_preprocess_reset (
-  GoodixMilanPreprocessState *state);
+void goodix_milan_preprocess_reset (GoodixMilanPreprocessState *state);
 
-int goodix_milan_preprocess_clamp_and_admit_raw (
-  uint16_t *frame,
-  size_t    rows,
-  size_t    columns,
-  size_t    border,
-  unsigned  required_percent);
+int goodix_milan_preprocess_clamp_and_admit_raw (uint16_t *frame,
+                                                 size_t    rows,
+                                                 size_t    columns,
+                                                 size_t    border,
+                                                 unsigned  required_percent);
 
-int goodix_milan_preprocess (
-  GoodixMilanPreprocessState *state,
-  GoodixMilanProfileState    *profile_state,
-  const uint16_t             *setup_frame,
-  const uint16_t             *live_frame,
-  GoodixMilanPreprocessPurpose purpose,
-  uint8_t                    *output,
-  int                        *quality,
-  int                        *coverage);
+int goodix_milan_preprocess (GoodixMilanPreprocessState  *state,
+                             GoodixMilanProfileState     *profile_state,
+                             const uint16_t              *setup_frame,
+                             const uint16_t              *live_frame,
+                             GoodixMilanPreprocessPurpose purpose,
+                             uint8_t                     *output,
+                             int                         *quality,
+                             int                         *coverage);
 
 int goodix_milan_preprocess_normalize (uint16_t *frame,
-                                   size_t    rows,
-                                   size_t    columns);
+                                       size_t    rows,
+                                       size_t    columns);
 
 int goodix_milan_preprocess_make_setup_map (const uint16_t *frame,
-                                        size_t          rows,
-                                        size_t          columns,
-                                        uint16_t       *setup_map,
-                                        uint32_t       *rounded_mean);
+                                            size_t          rows,
+                                            size_t          columns,
+                                            uint16_t       *setup_map,
+                                            uint32_t       *rounded_mean);
 
 int goodix_milan_preprocess_build_mask (const uint16_t *normalized_live,
-                                    const uint16_t *setup_map,
-                                    size_t          rows,
-                                    size_t          columns,
-                                    uint8_t         *mask,
-                                    uint16_t        *threshold,
-                                    uint16_t        *valid_percent);
+                                        const uint16_t *setup_map,
+                                        size_t          rows,
+                                        size_t          columns,
+                                        uint8_t        *mask,
+                                        uint16_t       *threshold,
+                                        uint16_t       *valid_percent);
 
 int goodix_milan_preprocess_no_update_frame (const uint16_t *normalized_live,
-                                         const uint16_t *setup_map,
-                                         size_t          rows,
-                                         size_t          columns,
-                                         uint16_t       *output);
+                                             const uint16_t *setup_map,
+                                             size_t          rows,
+                                             size_t          columns,
+                                             uint16_t       *output);
 
-int goodix_milan_profile9_build_contrast_mask (
-  const uint16_t *normalized_live,
-  const uint16_t *setup_map,
-  size_t          rows,
-  size_t          columns,
-  uint8_t        *contrast_mask,
-  size_t         *admitted_pixels);
+int goodix_milan_profile9_build_contrast_mask (const uint16_t *normalized_live,
+                                               const uint16_t *setup_map,
+                                               size_t          rows,
+                                               size_t          columns,
+                                               uint8_t        *contrast_mask,
+                                               size_t         *admitted_pixels);
 
-int goodix_milan_profile9_build_broken_mask (
-  GoodixMilanPreprocessState *state,
-  const uint16_t             *difference,
-  const uint16_t             *setup_map,
-  const uint16_t             *normalized_live,
-  const uint8_t              *contrast_mask,
-  size_t                      rows,
-  size_t                      columns,
-  uint8_t                    *broken_mask,
-  uint8_t                    *class_plane,
-  int                        *mode,
-  int                        *apply_mask);
+int goodix_milan_profile9_build_broken_mask (GoodixMilanPreprocessState *state,
+                                             const uint16_t             *difference,
+                                             const uint16_t             *setup_map,
+                                             const uint16_t             *normalized_live,
+                                             const uint8_t              *contrast_mask,
+                                             size_t                      rows,
+                                             size_t                      columns,
+                                             uint8_t                    *broken_mask,
+                                             uint8_t                    *class_plane,
+                                             int                        *mode,
+                                             int                        *apply_mask);
 
 int goodix_milan_preprocess_refine (const uint16_t *source,
-                                const uint8_t  *mask,
-                                uint16_t        valid_percent,
-                                size_t          rows,
-                                size_t          columns,
-                                uint8_t         *output);
+                                    const uint8_t  *mask,
+                                    uint16_t        valid_percent,
+                                    size_t          rows,
+                                    size_t          columns,
+                                    uint8_t        *output);
 
 int goodix_milan_preprocess_select_output (const uint8_t *contrast,
-                                       const uint8_t *refined,
-                                       const uint8_t *mask,
-                                       size_t         rows,
-                                       size_t         columns,
-                                       int            threshold,
-                                       uint8_t       *output,
-                                       int           *selected_refined);
+                                           const uint8_t *refined,
+                                           const uint8_t *mask,
+                                           size_t         rows,
+                                           size_t         columns,
+                                           int            threshold,
+                                           uint8_t       *output,
+                                           int           *selected_refined);
 
 int goodix_milan_preprocess_quality_mask_coverage (const uint8_t *mask,
-                                                size_t         count);
+                                                   size_t         count);
 
 int goodix_milan_preprocess_quality_coverage_mask (const uint8_t *frame,
+                                                   size_t         rows,
+                                                   size_t         columns,
+                                                   uint8_t       *mask,
+                                                   int           *raw_coverage);
+int goodix_milan_preprocess_selection_mask (const uint8_t *frame,
+                                            size_t         rows,
+                                            size_t         columns,
+                                            uint8_t       *mask);
+int goodix_milan_preprocess_quality_valid_mask (const uint8_t *frame,
                                                 size_t         rows,
                                                 size_t         columns,
                                                 uint8_t       *mask,
-                                                int           *raw_coverage);
-int goodix_milan_preprocess_selection_mask (const uint8_t *frame,
-                                         size_t         rows,
-                                         size_t         columns,
-                                         uint8_t       *mask);
-int goodix_milan_preprocess_quality_valid_mask (const uint8_t *frame,
-                                             size_t         rows,
-                                             size_t         columns,
-                                             uint8_t       *mask,
-                                             int           *valid_score);
+                                                int           *valid_score);
 
 int goodix_milan_preprocess_quality (const uint8_t *frame,
-                                 size_t         rows,
-                                 size_t         columns,
-                                 int           *quality,
-                                 int           *coverage);
+                                     size_t         rows,
+                                     size_t         columns,
+                                     int           *quality,
+                                     int           *coverage);
 
 int goodix_milan_preprocess_contrast (const uint16_t *source,
-                                   const uint8_t  *mask,
-                                  size_t          rows,
-                                  size_t          columns,
-                                 uint8_t         *output);
+                                      const uint8_t  *mask,
+                                      size_t          rows,
+                                      size_t          columns,
+                                      uint8_t        *output);

--- a/drivers/goodix53x5/milan/runtime.c
+++ b/drivers/goodix53x5/milan/runtime.c
@@ -8,6 +8,9 @@
  * version 2.1 of the License, or (at your option) any later version.
  */
 
+/* Runs profile-9/type-12 extraction, ordered gallery arbitration, and study.
+ * Native owners are identifyImage, FUN_18005edb0, and FUN_18005d330. */
+
 #include "milan/runtime.h"
 
 #include "milan/debug-hooks.h"

--- a/drivers/goodix53x5/milan/study/queue.c
+++ b/drivers/goodix53x5/milan/study/queue.c
@@ -118,10 +118,10 @@ goodix_milan_study_queue_validate (const GoodixStudyQueue *queue)
 }
 
 GoodixStudyQueueEnqueueResult
-goodix_milan_study_queue_enqueue (GoodixStudyQueue           *queue,
-                            const GoodixMatchInfo      *incoming,
-                            GoodixStudyQueueMetricFunc  metric_func,
-                            gpointer                    user_data)
+goodix_milan_study_queue_enqueue (GoodixStudyQueue          *queue,
+                                  const GoodixMatchInfo     *incoming,
+                                  GoodixStudyQueueMetricFunc metric_func,
+                                  gpointer                   user_data)
 {
   gsize occupied;
   gsize newest_slot = SIZE_MAX;
@@ -176,11 +176,11 @@ goodix_milan_study_queue_enqueue (GoodixStudyQueue           *queue,
 }
 
 gboolean
-goodix_milan_study_queue_process (GoodixStudyQueue             *queue,
-                            gsize                         primary_selected_index,
-                            GoodixStudyQueueFollowupFunc  followup_func,
-                            gpointer                      user_data,
-                            gboolean                     *mutated)
+goodix_milan_study_queue_process (GoodixStudyQueue            *queue,
+                                  gsize                        primary_selected_index,
+                                  GoodixStudyQueueFollowupFunc followup_func,
+                                  gpointer                     user_data,
+                                  gboolean                    *mutated)
 {
   gsize continuation[GOODIX_STUDY_QUEUE_CAPACITY];
   gsize head = 0;

--- a/drivers/goodix53x5/milan/study/queue.h
+++ b/drivers/goodix53x5/milan/study/queue.h
@@ -57,17 +57,15 @@ gboolean goodix_milan_study_queue_validate (const GoodixStudyQueue *queue);
 gsize    goodix_milan_study_queue_occupied (const GoodixStudyQueue *queue);
 gsize    goodix_milan_study_queue_allocated (const GoodixStudyQueue *queue);
 
-GoodixStudyQueueEnqueueResult goodix_milan_study_queue_enqueue (
-  GoodixStudyQueue           *queue,
-  const GoodixMatchInfo      *incoming,
-  GoodixStudyQueueMetricFunc  metric_func,
-  gpointer                    user_data);
+GoodixStudyQueueEnqueueResult goodix_milan_study_queue_enqueue (GoodixStudyQueue          *queue,
+                                                                const GoodixMatchInfo     *incoming,
+                                                                GoodixStudyQueueMetricFunc metric_func,
+                                                                gpointer                   user_data);
 
-gboolean goodix_milan_study_queue_process (
-  GoodixStudyQueue             *queue,
-  gsize                         primary_selected_index,
-  GoodixStudyQueueFollowupFunc  followup_func,
-  gpointer                      user_data,
-  gboolean                     *mutated);
+gboolean goodix_milan_study_queue_process (GoodixStudyQueue            *queue,
+                                           gsize                        primary_selected_index,
+                                           GoodixStudyQueueFollowupFunc followup_func,
+                                           gpointer                     user_data,
+                                           gboolean                    *mutated);
 
 void goodix_milan_study_queue_disable (GoodixStudyQueue *queue);


### PR DESCRIPTION
## Summary

Complete integration hygiene across the Milan refactor: format changed regions, add concise native-owner headers, and mark preserved native quirks. No behavioral change is intended.

## Contracts Preserved

- Native-correlated layout assertions remain intact by maintainer decision.
- Matcher, runtime, classification, queue, policy, and debug observation order is unchanged.
- Formatting is limited to changed regions; inherited formatter churn is excluded.

## Integration Evidence

- Release and debug builds pass; Milan synthetic, state, and runtime suites pass in both modes.
- Historical capture parity passes 1,994/1,994 operations.
- Finalized live integration capture passes 172/172 replayable identify/verify operations.
- Ten-template galleries were exercised; direct enrollment replay is unsupported by the native authority.
- Validated source identity: `2139a88af3eea878ed66f115415aabc5f6ca17d02e59d0d27ceef71d460f04a2`.
- Hardware integration testing observed no issues.

## Stack

Item 13 and tip of the 13-PR Milan refactor stack; depends on matcher finalization. This exact tip (`a95eea20`) is the source installed and tested during integration.
