### PR TITLE
Match native lower-reference study reanchoring

### DIFF
--- a/drivers/goodix53x5/milan/relations.c
+++ b/drivers/goodix53x5/milan/relations.c
@@ -396,7 +396,6 @@ goodix_milan_relation_matrix_reanchor (
     {
       int32_t slot_index;
       GoodixMilanRelationSlot *slot;
-      int32_t feature_to_old_reference[6];
       int32_t feature_to_new_reference[6];
 
       if (feature == matrix->reference_feature_index)
@@ -409,20 +408,15 @@ goodix_milan_relation_matrix_reanchor (
       if (slot->values[0] < 0)
         continue;
       if (feature > matrix->reference_feature_index)
-        memcpy (feature_to_old_reference, slot->values + 1,
-                sizeof(feature_to_old_reference));
-      else if (goodix_milan_transform_invert (
-                 slot->values + 1, feature_to_old_reference) != 0)
-        return -1;
-      goodix_milan_transform_compose (
-        old_reference_to_new_reference, feature_to_old_reference,
-        feature_to_new_reference);
-      if (feature > matrix->reference_feature_index)
-        memcpy (slot->values + 1, feature_to_new_reference,
-                sizeof(feature_to_new_reference));
-      else if (goodix_milan_transform_invert (
-                 feature_to_new_reference, slot->values + 1) != 0)
-        return -1;
+        goodix_milan_transform_compose (
+          old_reference_to_new_reference, slot->values + 1,
+          feature_to_new_reference);
+      else
+        goodix_milan_transform_compose (
+          slot->values + 1, new_reference_to_old_reference,
+          feature_to_new_reference);
+      memcpy (slot->values + 1, feature_to_new_reference,
+              sizeof (feature_to_new_reference));
     }
   return 0;
 }


### PR DESCRIPTION
## Summary
Fix lower-reference affine composition in `goodix_milan_relation_matrix_reanchor()` to match native Milan fixed-point arithmetic.

The previous implementation used an algebraically equivalent sequence of inversions and composition, but fixed-point rounding produced different template bytes. Compose the stored affine directly with the incoming reference transform instead. Higher-reference edges remain unchanged, and unset edges are still skipped.

This affects reference replacement during normal enrollment and study updates. The change is limited to `drivers/goodix53x5/milan/relations.c`, adds no allocations, and removes two inversions per lower edge.

## Validation
- Two independently generated target/control pairs matched the native DLL byte-for-byte after the fix, including complete replacement templates. Higher-reference-only controls remained unchanged.
- Release build and all four existing test suites passed: `goodix53x5-milan-synthetic`, `goodix53x5-milan-state`, `goodix53x5-milan-runtime`, and `fpi-device`.
- The combined changes in #165, #166, and #168 passed comparison for all 2,698 recorded identify/verify operations across 14 corpora, with no failures or skipped selected operations.

Recorded comparisons used equivalent probe inputs and the established canonical boundary policy for undefined native anti-fake bytes. They do not establish raw-byte equality for allocator-dependent native data or cover enrollment replay and physical hardware behavior.

## Related PRs
First of three dependent changes: #165 -> #166 -> #168. Reverse-engineering documentation is maintained separately on `milan-dev` and is not included in these production changes.