### PR TITLE
Clamp existing Milan gallery partition endpoints

### DIFF
--- a/drivers/goodix53x5/milan/match/lifecycle.c
+++ b/drivers/goodix53x5/milan/match/lifecycle.c
@@ -24,6 +24,8 @@
 #include "milan/match/info-private.h"
 #include "milan/match/lifecycle-private.h"
 #include "milan/milan.h"
+#include "milan/private.h"
+#include "milan/print.h"
 #include "milan/study/queue.h"
 
 #include <string.h>
@@ -70,6 +72,7 @@ goodix_milan_match_serialized_feature_result_internal (
   const guint8 *matched_milan;
   size_t normalized_milan_len = 0;
   size_t updated_milan_len = 0;
+  GoodixMilanUnpackedTemplate *unpacked;
 
   if (updated_feature)
     *updated_feature = NULL;
@@ -107,6 +110,55 @@ goodix_milan_match_serialized_feature_result_internal (
       g_free (normalized_milan);
       return GOODIX_SIGFM_TEMPLATE_INVALID;
     }
+  unpacked = g_malloc (sizeof (*unpacked));
+  if (goodix_milan_template_unpack (
+        normalized_milan, normalized_milan_len, unpacked) == 0 &&
+      unpacked->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
+    {
+      for (size_t i = 0; i < unpacked->feature_count; i++)
+        {
+          GoodixMilanFeatureView view;
+
+          if (goodix_milan_template_parse_feature_element (
+                unpacked->feature_elements[i], unpacked->feature_element_sizes[i],
+                &view) == 0 && view.record_count > 0 &&
+              view.record_count <= 150 &&
+              view.fields.tagged_values[2] == (int32_t) view.record_count)
+            {
+              /* Unpack borrows our writable gallery copy, never the probe. */
+              if (goodix_milan_template_patch_feature_scalar (
+                    (guint8 *) unpacked->feature_elements[i],
+                    unpacked->feature_element_sizes[i], 0xb7,
+                    (int32_t) view.record_count - 1) != 0)
+                {
+                  g_free (unpacked);
+                  g_free (updated_milan);
+                  g_free (normalized_milan);
+                  return GOODIX_SIGFM_TEMPLATE_INVALID;
+                }
+              if (!updated_milan)
+                updated_milan = g_malloc (normalized_milan_len);
+            }
+        }
+    }
+  if (updated_milan)
+    {
+      if (goodix_milan_template_pack (
+            unpacked->feature_elements, unpacked->feature_element_sizes,
+            unpacked->feature_count, unpacked->relations, unpacked->relation_count,
+            &unpacked->metadata, unpacked->tail_state, sizeof (unpacked->tail_state),
+            updated_milan, normalized_milan_len, &updated_milan_len) != 0 ||
+          updated_milan_len != normalized_milan_len)
+        {
+          g_free (unpacked);
+          g_free (updated_milan);
+          g_free (normalized_milan);
+          return GOODIX_SIGFM_TEMPLATE_INVALID;
+        }
+      g_free (normalized_milan);
+      normalized_milan = g_steal_pointer (&updated_milan);
+    }
+  g_free (unpacked);
   matched_milan = normalized_milan;
 
   if (goodix_milan_match_info_result (


### PR DESCRIPTION
## Summary
Match native Milan decoding of existing gallery partition endpoints before matching. When `b7 == record_count` and the record count is between 1 and 150, clamp the endpoint to `record_count - 1`.

Native extraction can legitimately produce this endpoint, but native decoding adjusts it only when loading an existing gallery. Apply the correction to the private writable gallery copy, not to extraction or the live probe, so caller-owned gallery bytes and newly extracted probe data remain unchanged.

- Leave type-zero templates and non-endpoint values unchanged.
- Repack the template and update its CRC only when an endpoint changes.
- Reject the transaction without publishing a template if patching or packing fails, or if the packed length changes.

Only `drivers/goodix53x5/milan/match/lifecycle.c` changes. Generic codecs, extraction, append behavior, thresholds, and queue policy are unchanged.

## Validation
- Focused native comparisons matched complete study candidates for the affected append case and an adjacent control.
- A positive-match control produced no candidate, as expected. One-record and three-record live probes retained their original endpoints byte-for-byte.
- Release build, all four existing test suites, touched-code formatting, and whitespace checks passed.
- The combined changes in #165, #166, and #168 passed comparison for all 2,698 recorded identify/verify operations across 14 corpora, with no failures or skipped selected operations.

Recorded comparisons used equivalent probe inputs and the established canonical boundary policy for undefined native anti-fake bytes. They do not establish raw-byte equality for allocator-dependent native data or cover enrollment replay and physical hardware behavior. No performance benchmark is claimed.

## Related PRs
Depends on #165; #168 builds on this change. Reverse-engineering documentation is maintained separately on `milan-dev` and is not included in these production changes.