### PR TITLE
Load Milan calibration when refreshed setup is consumed

### DIFF
--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -345,6 +345,28 @@ goodix_milan_replace_raw_frame (guint16 **owner,
 #include "device/persistence.h"
 #include "device/transport.h"
 
+void
+goodix_milan_generation_prepare_setup (FpDevice              *dev,
+                                       GoodixMilanGeneration *generation)
+{
+  g_autofree GoodixMilanGeneration *restored = NULL;
+
+  g_return_if_fail (generation != NULL);
+  if (generation->profile_state.setup_initialized &&
+      !generation->profile_state.setup_refresh_pending)
+    return;
+
+  /* Select disk workspace at sample delivery, retaining process-owned state
+   * across a refresh. Setup admission and its flags remain runtime-owned. */
+  restored = g_new0 (GoodixMilanGeneration, 1);
+  goodix_milan_generation_reset_preprocess (restored);
+  goodix_milan_persistence_restore (dev, restored);
+  if (generation->profile_state.setup_initialized ||
+      generation->profile_state.setup_refresh_pending)
+    goodix_milan_generation_transfer_process_state (restored, generation);
+  generation->state = restored->state;
+}
+
 typedef enum
 {
   GOODIX_BASE_UPLOAD_CONFIG = 0,
@@ -762,7 +784,6 @@ goodix_base_ssm_handler (FpiSsm   *ssm,
             return;
           }
 
-        goodix_milan_persistence_restore (dev, generation);
         if (data->forced_refresh && self->milan_generation)
           goodix_milan_generation_transfer_process_state (
             generation, self->milan_generation);

--- a/drivers/goodix53x5/device/base.c
+++ b/drivers/goodix53x5/device/base.c
@@ -361,8 +361,7 @@ goodix_milan_generation_prepare_setup (FpDevice              *dev,
   restored = g_new0 (GoodixMilanGeneration, 1);
   goodix_milan_generation_reset_preprocess (restored);
   goodix_milan_persistence_restore (dev, restored);
-  if (generation->profile_state.setup_initialized ||
-      generation->profile_state.setup_refresh_pending)
+  if (generation->profile_state.setup_initialized)
     goodix_milan_generation_transfer_process_state (restored, generation);
   generation->state = restored->state;
 }

--- a/drivers/goodix53x5/device/base.h
+++ b/drivers/goodix53x5/device/base.h
@@ -162,6 +162,8 @@ gboolean goodix_milan_base_attempt_publish (GoodixMilanBaseAttempt  *attempt,
                                              GError                 **error);
 
 void goodix_milan_generation_reset_preprocess (GoodixMilanGeneration *generation);
+void goodix_milan_generation_prepare_setup (FpDevice              *dev,
+                                            GoodixMilanGeneration *generation);
 void goodix_milan_generation_free (GoodixMilanGeneration *generation);
 void goodix_milan_generation_invalidate (GoodixMilanGeneration **generation);
 guint64 goodix_milan_generation_note_use (GoodixMilanGeneration *generation);

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -430,6 +430,7 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
             }
           data->capture_notified = TRUE;
           data->cpu_outstanding = TRUE;
+          goodix_milan_generation_prepare_setup (dev, self->milan_generation);
           data->capture_ready (dev, data->user_data);
         }
       break;


### PR DESCRIPTION
## Summary
Load persisted Milan calibration when a delivered sample needs preprocessing setup, rather than when a new image reference is published.

The final enrollment sample can trigger a lift refresh before enrollment completion saves its calibration. Loading during that refresh picks up the older file, leaving the next sample with stale calibration even though the new file is available by then. Native setup reads the file when it consumes the marked sample.

- Move the load to the shared sample-delivery path, before debug metadata and runtime inputs are captured, for both enrollment and authentication.
- Combine the latest persisted workspace with existing process-owned gains, histories, ages, and classification state across refresh. Keep setup admission and retry flags under runtime ownership.
- Return immediately for initialized samples without a pending refresh, with no calibration-file I/O or temporary allocation.

Only `drivers/goodix53x5/device/base.c`, `base.h`, and `scan.c` change. The persistence format and calibration algorithms are unchanged.

## Validation
- A focused current transaction completed 12 accepted enrollment stages in 16 attempts, including four real rollback retries, and saved its final accepted calibration after refresh. The first two complete processed images and probes now match the save-before-refresh control, with sample counts 17 and 18.
- Initial load, missing-file fallback, process-state preservation, ordinary-sample no-I/O, setup retry, and failed-refresh checks passed.
- A separate comparison matched the first two complete images from the prior native setup-bridge execution. This is not a native replay of the 16-attempt adapter enrollment; the outer callback ordering is established from source rather than a complete callback-loop replay.
- Release build, all four existing test suites, and whitespace checks passed.

The slow recorded-probe campaign gate is intentionally deferred until the expanded stack is ready; the previous three-layer gate does not validate this new layer.

## Related PRs
Depends on #168, following #165 and #166. Native contracts are documented separately on `milan-dev` and are not included in this production PR.

