### PR TITLE
Preserve native order after match finalization

### DIFF
--- a/drivers/goodix53x5/milan/match/lifecycle.c
+++ b/drivers/goodix53x5/milan/match/lifecycle.c
@@ -180,7 +180,8 @@ goodix_milan_match_serialized_feature_result_internal (
           updated_milan = g_malloc (normalized_milan_len);
           if (goodix_milan_template_update_match_lifecycle (
                 matched_milan, normalized_milan_len,
-                match_result->lifecycle_update_feature_mask, updated_milan,
+                match_result->lifecycle_update_feature_mask,
+                match_result->direct_positive_feature_mask == 0, updated_milan,
                 normalized_milan_len, &updated_milan_len) != 0 ||
               updated_milan_len != normalized_milan_len)
             {

--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -404,7 +404,8 @@ goodix_milan_match_live_gallery_result (GoodixMatchInfo            *probe,
       updated_milan = g_malloc (current_milan_size);
       if (goodix_milan_template_update_match_lifecycle (
             current_milan, current_milan_size,
-            match_result->lifecycle_update_feature_mask, updated_milan,
+            match_result->lifecycle_update_feature_mask,
+            match_result->direct_positive_feature_mask == 0, updated_milan,
             current_milan_size, &updated_milan_size) != 0 ||
           updated_milan_size != current_milan_size)
         {

--- a/drivers/goodix53x5/milan/milan.h
+++ b/drivers/goodix53x5/milan/milan.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -501,6 +502,7 @@ int goodix_milan_template_update_match_lifecycle (
   const uint8_t *current_template,
   size_t         current_template_size,
   uint64_t       feature_mask,
+  bool           sort_order,
   uint8_t       *packed,
   size_t         packed_capacity,
   size_t        *packed_size);

--- a/drivers/goodix53x5/milan/private.h
+++ b/drivers/goodix53x5/milan/private.h
@@ -78,6 +78,7 @@ int goodix_milan_template_read_feature_scalar (const uint8_t *feature_element,
                                size_t         feature_element_size,
                                uint8_t        tag,
                                int32_t       *value);
+int goodix_milan_template_sort_type12_order (GoodixMilanUnpackedTemplate *unpacked);
 int goodix_milan_template_reference_transform (
   const GoodixMilanUnpackedTemplate *unpacked,
   size_t                              feature_index,

--- a/drivers/goodix53x5/milan/study/study.c
+++ b/drivers/goodix53x5/milan/study/study.c
@@ -255,8 +255,8 @@ milan_sort_legacy_template_order (GoodixMilanUnpackedTemplate *unpacked)
   return 0;
 }
 
-static int
-milan_sort_type12_template_order (GoodixMilanUnpackedTemplate *unpacked)
+int
+goodix_milan_template_sort_type12_order (GoodixMilanUnpackedTemplate *unpacked)
 {
   GoodixMilanStudyOrderKey keys[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
   uint32_t order[GOODIX_MILAN_TEMPLATE_FEATURE_CAPACITY];
@@ -294,7 +294,7 @@ static int
 milan_finalize_template_study_order (GoodixMilanUnpackedTemplate *unpacked)
 {
   if (unpacked->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE)
-    return milan_sort_type12_template_order (unpacked);
+    return goodix_milan_template_sort_type12_order (unpacked);
   return milan_sort_legacy_template_order (unpacked);
 }
 

--- a/drivers/goodix53x5/milan/template/lifecycle.c
+++ b/drivers/goodix53x5/milan/template/lifecycle.c
@@ -87,6 +87,7 @@ goodix_milan_template_update_match_lifecycle (
   const uint8_t *current_template,
   size_t         current_template_size,
   uint64_t       feature_mask,
+  bool           sort_order,
   uint8_t       *packed,
   size_t         packed_capacity,
   size_t        *packed_size)
@@ -143,6 +144,12 @@ goodix_milan_template_update_match_lifecycle (
                        lifecycle_count + UINT32_C(1));
       current->feature_elements[feature_index] = feature_copies[feature_index];
     }
+  /* Match finalization sorts the incremented keys without advancing generation. */
+  if (sort_order &&
+      current->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+      current->feature_count > 1 &&
+      goodix_milan_template_sort_type12_order (current) != 0)
+    goto out;
   result = goodix_milan_template_pack (
     current->feature_elements, current->feature_element_sizes,
     current->feature_count, current->relations, current->relation_count,

--- a/tests/test-goodix53x5-milan-state.c
+++ b/tests/test-goodix53x5-milan-state.c
@@ -1352,23 +1352,23 @@ test_template_state (void)
       g_assert_cmpmem (repacked, repacked_size, packed, packed_size);
 
       g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
-                         packed, packed_size, 0, updated, capacity,
+                         packed, packed_size, 0, false, updated, capacity,
                          &updated_size), ==, 0);
       g_assert_cmpuint (updated_size, ==, packed_size);
       g_assert_cmpmem (updated, updated_size, packed, packed_size);
       g_assert_cmpmem (packed, packed_size, input_before, packed_size);
       g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
-                         packed, packed_size, shape->lifecycle_mask, updated,
+                         packed, packed_size, shape->lifecycle_mask, false, updated,
                          capacity, &updated_size), ==, 0);
       g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
                          updated, updated_size, shape->lifecycle_mask,
-                         updated_twice, capacity, &updated_twice_size), ==, 0);
+                         false, updated_twice, capacity, &updated_twice_size), ==, 0);
       g_assert_cmpuint (updated_size, ==, packed_size);
       g_assert_cmpuint (updated_twice_size, ==, packed_size);
       g_assert_cmpmem (packed, packed_size, input_before, packed_size);
       g_assert_cmpint (goodix_milan_template_update_match_lifecycle (
                          packed, packed_size,
-                         UINT64_C (1) << shape->feature_count, repacked,
+                         UINT64_C (1) << shape->feature_count, false, repacked,
                          capacity, &rejected_size), ==, -1);
       g_assert_cmpmem (packed, packed_size, input_before, packed_size);
       memset (unpacked, 0, sizeof(*unpacked));


### PR DESCRIPTION
## Summary
Preserve native gallery traversal order after type-12 compact-validator match finalization. This branch increments contributor lifecycle counts, then sorts by descending signed `(b5, be, bc)` before packing. The current lifecycle updater increments those counts but omits the sort.

- Reuse the existing order-only selection sorter after increments, only when the lifecycle mask is nonzero and the direct-positive mask is zero.
- Keep native unstable tie behavior without advancing order generation or changing physical feature ownership.
- Leave acceptance, scoring, queue gates, direct-positive increments, rescue, fallback, legacy templates, and the zero-mask fast copy unchanged.
- Add no result fields or serialized-layout changes. Four existing test calls receive an explicit `false` argument; no new test cases or dependencies are added.

## Proof Scope
This is a **conditional native contract alignment**, reviewed under the maintainer's explicit exception for a small, isolated correction without ordinary branch-reachability proof. It is **not a reproduced ordinary identify defect**.

The lifecycle-boundary comparison uses one ordinarily generated 12-stage gallery. Contributor masks are explicit boundary inputs, not observed matcher outputs. Native execution isolates the increment boundary and runs the actual sorter and packer; it does not demonstrate entry through complete ordinary identify matching. The remaining obligation is a joint ordinary-producer chronology yielding a flag-zero contributor whose ranked record passes compact validation, without an earlier direct or rescue terminal result.

## Validation
- The parent differs from native by exactly 16 bytes: 12 order-entry bytes and four CRC bytes. The corrected complete 154,928-byte packed output is equal to native, with physical lifecycle increments and all four tail counters preserved.
- Complete direct-increment output remains equal to native and the parent. All-feature increments with sorting disabled remain equal to the parent; existing zero-mask coverage retains exact fast-copy behavior.
- Two ordinary full-runtime fixtures retain complete output equality against the parent: nonmatch score 0 / Action 0, and winner-last score 23 / Action 1, including candidate and queue outputs. These are unaffected-path controls, not proof of compact-finalization entry.
- Offline release build, all four existing suites (Milan synthetic, state, runtime, and fpi-device), standalone parity-runner compilation with warnings treated as errors, and whitespace checks passed. Optional introspection-dependent driver tests were skipped by the build configuration.

The slow full campaign remains deferred. The earlier 2,698-operation pass on the prior three-layer stack does not validate this expanded head. No long benchmark or complete inner-matcher parity claim is made.

## Related PRs
Depends on #170. Native policy, class, rescue, and lifecycle contracts were reviewed and published separately on `milan-dev` before this PR; no reverse-engineering notes, private artifacts, or CI changes are included here.


