### PR TITLE
Avoid copying immutable Milan print payloads during parsing

### DIFF
--- a/drivers/goodix53x5/milan/print.c
+++ b/drivers/goodix53x5/milan/print.c
@@ -172,7 +172,6 @@ goodix_milan_print_parse_data (GVariant *data,
 {
   g_autoptr(GVariant) payload = NULL;
   g_autoptr(GBytes) parsed = NULL;
-  const guint8 *bytes;
   gsize size;
   guint32 schema;
   guint32 profile;
@@ -222,12 +221,12 @@ goodix_milan_print_parse_data (GVariant *data,
       error, GOODIX_MILAN_PRINT_ERROR_INCOMPATIBLE,
       "Milan print envelope fields are incompatible");
 
-  bytes = g_variant_get_fixed_array (payload, &size, sizeof(*bytes));
+  size = g_variant_get_size (payload);
   if (size > GOODIX_MILAN_PRINT_MAX_SIZE)
     return goodix_milan_print_fail (
       error, GOODIX_MILAN_PRINT_ERROR_TOO_LARGE,
       "Milan print envelope payload is too large");
-  parsed = g_bytes_new (bytes, size);
+  parsed = g_variant_get_data_as_bytes (payload);
   if (!goodix_milan_print_validate_template (parsed, NULL, error))
     return FALSE;
   *template_bytes = g_steal_pointer (&parsed);


### PR DESCRIPTION
## Change
Retain the serialized byte-array storage with `g_variant_get_data_as_bytes()` instead of allocating and copying the whole template during print parsing. The already-checked `ay` payload has identical serialized size and content. GLib retains its backing storage for the returned `GBytes`, including after the envelope is released.

All envelope checks, size limits, CRC checks, canonical repacking, errors, and runtime validation remain unchanged. This is a storage optimization, not a native matching-policy correction.

## Validation
- Offline release build passed; existing Milan synthetic, state, runtime, and fpi-device suites passed 4/4. No new tests or dependencies.
- Baseline and current release/debug builds used identical sources except this change, with `-O2 -Wall -Wextra -Werror`.
- Reused six synthetic workloads: nonmatch and winner-last with 1, 5, and 10 repeated galleries. All 648 complete runtime snapshots agreed, including debug processed images, probe, gallery after-match, candidate, queue observations, counts, lifecycle fields, and errors.
- All 3,456 payload parses preserved exact bytes after envelope release. Address checks confirmed baseline copying and current storage sharing.
- Formatter inspected on the touched file: changed lines are unchanged by formatting; unrelated pre-existing formatting differences were left alone. `git diff --check` passed. Optional introspection-dependent tests remain disabled by the local build configuration.

## Performance And Limits
One full payload copy is eliminated per parsed gallery: about 104-408 KB for the two inputs, or 3.77-4.08 MB for the ten-gallery workloads. Other allocations and validation copies remain.

31 alternating release pairs per workload followed ten warm-up pairs. Times are median / nearest-rank p95 milliseconds:

| Workload | Baseline parse | Shared parse | Baseline full | Shared full |
| --- | ---: | ---: | ---: | ---: |
| Nonmatch, 1 | 6.152 / 6.592 | 6.117 / 6.607 | 64.754 / 95.276 | 65.018 / 70.886 |
| Nonmatch, 5 | 30.997 / 40.948 | 30.140 / 31.840 | 209.320 / 234.295 | 208.309 / 219.820 |
| Nonmatch, 10 | 61.931 / 73.686 | 60.602 / 64.173 | 388.476 / 419.595 | 392.068 / 415.514 |
| Winner-last, 1 | 1.543 / 1.760 | 1.511 / 1.712 | 50.124 / 59.469 | 50.163 / 61.329 |
| Winner-last, 5 | 26.277 / 28.742 | 25.677 / 27.389 | 193.392 / 221.825 | 193.146 / 226.780 |
| Winner-last, 10 | 74.757 / 97.581 | 72.882 / 101.087 | 483.940 / 641.208 | 482.146 / 640.998 |

Full timing includes parsing, ownership assertions, envelope release, input construction, and runtime execution; it excludes envelope construction, output comparison, and input/output destruction. Host conditions were uncontrolled. Full medians range from 0.48% faster to 0.92% slower and tails are mixed: no general end-to-end latency gain is claimed. Repeated synthetic galleries are not distinct enrolled fingers. Shared bytes can retain a larger parent serialization buffer; no RSS reduction is claimed.

No fresh DLL replay or hardware UAT was needed for the GLib storage contract. The requested strict integration gate passed; fresh UAT remains required before merge. No native notes changed.

## Integration Gate
All 2,698 selected identify/verify operations passed across the 14 requested campaigns on integration branch `milan-performance-integration-20260905` at `6cfc612`. Its tree equals the four-layer stack head. Zero selected failures; runtime v3, print schema 4, build seal v2, explicit selectors, natural queues, and complete current-vs-native comparison were enforced. Enrollment and other nonselected context are not claimed as full replay coverage. This establishes recorded-operation parity, not cross-hardware performance or fresh hardware UAT. Native notes are separately pushed on milan-dev. No PR merge is authorized by this gate.