### PR TITLE
Compute recognition descriptor popcounts by word

### DIFF
--- a/drivers/goodix53x5/milan/match/correspondence.c
+++ b/drivers/goodix53x5/milan/match/correspondence.c
@@ -149,9 +149,31 @@ goodix_milan_match_feature_records (const GoodixMilanFeatureRecord *prior,
 }
 
 static int
+milan_descriptor_hamming64 (const uint8_t *source,
+                            const uint8_t *target)
+{
+  uint64_t a, b;
+
+  memcpy (&a, source, sizeof (a));
+  memcpy (&b, target, sizeof (b));
+  return __builtin_popcountll (a ^ b);
+}
+
+static int
+milan_descriptor_hamming32 (const uint8_t *source,
+                            const uint8_t *target)
+{
+  uint32_t a, b;
+
+  memcpy (&a, source, sizeof (a));
+  memcpy (&b, target, sizeof (b));
+  return __builtin_popcount (a ^ b);
+}
+
+static int
 milan_recognition_descriptor_details (const GoodixMilanFeatureRecord *enrolled,
                                       const GoodixMilanFeatureRecord *probe,
-                                      int                           *normal_layout)
+                                      int                            *normal_layout)
 {
   const uint8_t *source = (const uint8_t *) enrolled;
   const uint8_t *target = (const uint8_t *) probe;
@@ -160,13 +182,11 @@ milan_recognition_descriptor_details (const GoodixMilanFeatureRecord *enrolled,
   int normal_tail = 0;
   int shifted_tail = 0;
 
-  for (size_t i = 0; i < 8; i++)
-    first += __builtin_popcount ((unsigned) (source[16 + i] ^ target[16 + i]));
+  first = milan_descriptor_hamming64 (source + 16, target + 16);
   if (first > 23)
     return -1;
 
-  for (size_t i = 0; i < 8; i++)
-    second += __builtin_popcount ((unsigned) (source[24 + i] ^ target[24 + i]));
+  second = milan_descriptor_hamming64 (source + 24, target + 24);
 
   int shifted = first - second + 64;
   if (first + second > 47)
@@ -177,25 +197,15 @@ milan_recognition_descriptor_details (const GoodixMilanFeatureRecord *enrolled,
     }
   else
     {
-      for (size_t i = 0; i < 4; i++)
-        {
-          normal_tail += __builtin_popcount (
-            (unsigned) (source[32 + i] ^ target[32 + i]));
-          normal_tail += __builtin_popcount (
-            (unsigned) (source[40 + i] ^ target[40 + i]));
-        }
+      normal_tail = milan_descriptor_hamming32 (source + 32, target + 32) +
+                    milan_descriptor_hamming32 (source + 40, target + 40);
       if (shifted > 47)
         shifted_tail = 192;
     }
 
   if (shifted_tail != 192)
-    for (size_t i = 0; i < 4; i++)
-      {
-        shifted_tail += __builtin_popcount (
-          (unsigned) (source[32 + i] ^ target[36 + i]));
-        shifted_tail += __builtin_popcount (
-          (unsigned) (source[40 + i] ^ target[48 + i]));
-      }
+    shifted_tail = milan_descriptor_hamming32 (source + 32, target + 36) +
+                   milan_descriptor_hamming32 (source + 40, target + 48);
 
   int normal_distance = first + second + normal_tail;
   int shifted_distance = shifted + shifted_tail;


### PR DESCRIPTION
## Change
Replace repeated byte-sized population counts in the recognition descriptor helper with exact-width 64-bit and 32-bit XOR/popcount operations. Small reused local helpers use `memcpy`, so neither alignment nor strict aliasing assumptions are added.

No matching thresholds, early returns, branch-dependent field reads, sentinels, tie handling, or layout decisions change. This is an equivalent Hamming-distance implementation, not a policy correction. The review layer follows #173.

## Equivalence
Population count is additive over disjoint byte bit positions. Loading both byte strings with the same endian mapping preserves XOR and merely permutes those bits. Therefore a word popcount equals the previous sum for every initialized input byte string, without requiring descriptor correlations.

Every read interval is unchanged: eight bytes at 16/16 and 24/24; four bytes at 32/32, 40/40, 32/36, and 40/48 (enrolled/probe offsets). Maximum ends remain 44 and 52 within the 56-byte records. The same branch guards precede the reads. No source writes, allocation, read-ahead, or adjacent-field overread is introduced. Rejection still leaves the optional layout output untouched.

## Performance
101 alternating release pairs per workload after ten warm-up pairs, GCC 16.2.1 `-O2`, CPU 3 affinity on an i5-1135G7. Baseline already includes #172 and #173. Milliseconds:

| Workload | Baseline median | Word median | Reduction | Baseline p95 | Word p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Nonmatch, 1 gallery | 60.196 | 45.011 | 25.2% | 65.071 | 49.055 |
| Nonmatch, 5 galleries | 182.065 | 105.589 | 42.0% | 307.624 | 179.465 |
| Nonmatch, 10 galleries | 335.482 | 182.133 | 45.7% | 366.514 | 216.589 |
| Winner-last, 1 gallery | 48.581 | 40.467 | 16.7% | 55.663 | 46.437 |
| Winner-last, 5 galleries | 166.760 | 99.158 | 40.5% | 278.331 | 167.115 |
| Winner-last, 10 galleries | 320.820 | 174.453 | 45.6% | 365.733 | 203.204 |

Candidate won 604/606 timed pairs in both release and debug. Debug medians/p95 also improved in all six workloads. Generic-target GCC uses software `__popcountdi2`, not hardware POPCNT; there is no new CPU feature requirement. Library text grows 456 bytes due to inlining/layout, while data/BSS and heap allocation remain unchanged.

These are repeated existing synthetic galleries and one fixed setup/probe, not distinct enrolled fingers or USB/PAM latency. Timing covers print parsing through runtime completion. CPU frequency and concurrent host activity were uncontrolled, and tail measurements show noise.

## Validation
- All 2,664 release/debug executions, including warmups, passed exact complete-snapshot comparison. Covered runtime status/counts/results/errors, probe/candidate, gallery results, and debug processed/input/after-match bytes, lifecycle flags and exposed queue observations. Private unexposed queue contents follow from side-effect-free substitution, not an additional empirical dump.
- Production equals the measured candidate except one formatter-required parameter-alignment space. All 102 other driver files match the frozen snapshot; the build overlay matches production exactly.
- Offline driver-debug-disabled build passed. Existing Milan synthetic/state/runtime and fpi-device suites passed 4/4; cheap debug rerun passed another 156 complete outputs.
- No compiler warnings. Frozen paired builds use `-Wall -Wextra -Werror`. Touched functions are formatter-exact; unrelated pre-existing formatting preserved. `git diff --check` passed.
- No new project tests/cases or dependencies. Optional introspection-based tests remain skipped by the local configuration.

No fresh DLL or hardware replay is claimed for this equivalent arithmetic substitution. The requested strict integration gate passed; fresh UAT remains required before merge.

## Integration Gate
All 2,698 selected identify/verify operations passed across the 14 requested campaigns on integration branch `milan-performance-integration-20260905` at `6cfc612`. Its tree equals the four-layer stack head. Zero selected failures; runtime v3, print schema 4, build seal v2, explicit selectors, natural queues, and complete current-vs-native comparison were enforced. Enrollment and other nonselected context are not claimed as full replay coverage. This establishes recorded-operation parity, not cross-hardware performance or fresh hardware UAT. Native notes are separately pushed on milan-dev. No PR merge is authorized by this gate.