### PR TITLE
Reuse overlapping gradient-window sums

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -1417,31 +1417,49 @@ quality_threshold_gradient_window (const uint16_t *gradient,
   size_t selected = 0;
 
   for (size_t row = 0; row < rows; row++)
-    for (size_t column = 0; column < columns; column++)
-      {
-        uint32_t sum = 0;
+    {
+      uint32_t sum = 0;
 
-        for (ptrdiff_t y_offset = -7; y_offset <= 7; y_offset++)
-          {
-            size_t y = goodix_milan_reflect101_index (
-              (ptrdiff_t) row + y_offset, rows);
+      for (ptrdiff_t y_offset = -7; y_offset <= 7; y_offset++)
+        {
+          size_t y = goodix_milan_reflect101_index (
+            (ptrdiff_t) row + y_offset, rows);
 
-            for (ptrdiff_t x_offset = -7; x_offset <= 7; x_offset++)
-              {
-                size_t x = goodix_milan_reflect101_index (
-                  (ptrdiff_t) column + x_offset, columns);
+          for (ptrdiff_t x_offset = -7; x_offset <= 7; x_offset++)
+            {
+              size_t x = goodix_milan_reflect101_index (x_offset, columns);
 
-                sum += gradient[y * columns + x];
-              }
-          }
-        uint16_t average = (uint16_t) (
-          (sum * (uint32_t) MILAN_QUALITY_GRADIENT_WINDOW_RECIPROCAL_Q16) >>
-          MILAN_QUALITY_Q16_SHIFT);
-        size_t index = row * columns + column;
+              sum += gradient[y * columns + x];
+            }
+        }
+      for (size_t column = 0; column < columns; column++)
+        {
+          uint16_t average = (uint16_t) (
+            (sum * (uint32_t) MILAN_QUALITY_GRADIENT_WINDOW_RECIPROCAL_Q16) >>
+            MILAN_QUALITY_Q16_SHIFT);
+          size_t index = row * columns + column;
 
-        mask[index] = average > threshold ? mask_value : 0;
-        selected += mask[index] != 0;
-      }
+          mask[index] = average > threshold ? mask_value : 0;
+          selected += mask[index] != 0;
+          if (column + 1 < columns)
+            {
+              size_t leaving = goodix_milan_reflect101_index (
+                (ptrdiff_t) column - 7, columns);
+              size_t entering = goodix_milan_reflect101_index (
+                (ptrdiff_t) column + 8, columns);
+
+              /* Keep reflected samples with their original multiplicities. */
+              for (ptrdiff_t y_offset = -7; y_offset <= 7; y_offset++)
+                {
+                  size_t y = goodix_milan_reflect101_index (
+                    (ptrdiff_t) row + y_offset, rows);
+
+                  sum -= gradient[y * columns + leaving];
+                  sum += gradient[y * columns + entering];
+                }
+            }
+        }
+    }
   return selected;
 }
 


### PR DESCRIPTION
## Change
Compute each row’s first 15x15 gradient sum once, then slide horizontally by subtracting the departing column and adding the entering column. This replaces 225 reads per pixel with 225 initial reads plus 30 per subsequent pixel, without extra storage or allocation.

The change is confined to `quality_threshold_gradient_window`. Gradient production, mask thresholding, selected counts, validation, errors, and downstream decisions are unchanged. This layer follows #175.

## Portable Equivalence
Adjacent windows share fourteen columns. Subtracting and adding the two boundary columns preserves the exact sum, including multiplicities when reflect101 maps several coordinates to the same sample. Intermediate values remain nonnegative sums of at most 225 uint16_t samples, bounded by 14,745,375. The reciprocal multiplication retains its original unsigned wrapping, shift and cast.

The caller enforces dimensions at least two and total count at most INT_MAX, bounding signed offset arithmetic on supported 32/64-bit ABIs. Its separately allocated gradient cannot alias output mask writes. No CPU-specific instructions, architecture tuning flags, lookup caches, or hardware-dependent thresholds are introduced. The arithmetic and work reduction are generic; performance figures below are measurements on one laptop, not guarantees for other machines.

## Measurements
GCC/gprof attribution identified coverage-mask computation as 20.49% of sampled self CPU, with repeated gradient-window summation dominating that owner. Uninstrumented shared-library timing used the unchanged existing six workloads, CPU 3 affinity, 31 alternating release pairs after ten warmup pairs. Milliseconds:

| Workload | Baseline median | Sliding median | Reduction | Baseline p95 | Sliding p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Nonmatch, 1 gallery | 47.271 | 31.557 | 33.24% | 51.534 | 33.605 |
| Nonmatch, 5 galleries | 110.581 | 94.266 | 14.75% | 118.832 | 99.833 |
| Nonmatch, 10 galleries | 190.174 | 176.351 | 7.27% | 207.323 | 184.577 |
| Winner-last, 1 gallery | 41.954 | 25.660 | 38.84% | 44.999 | 29.647 |
| Winner-last, 5 galleries | 106.073 | 88.512 | 16.55% | 114.513 | 100.354 |
| Winner-last, 10 galleries | 181.464 | 162.973 | 10.19% | 202.307 | 171.354 |

182/186 measured pairs improved, with median paired savings of 14.2-17.9 ms. These repeated synthetic galleries and fixed setup/probe do not establish biometric-diversity or USB/PAM latency results. Profiling instrumentation perturbs attribution; reported timing is uninstrumented. CPU frequency and scheduling noise remain uncontrolled. No cross-machine speedup claim is made.

## Validation
- All 648 release/debug snapshots matched within their build mode, including warmups: complete runtime and gallery-result structures, errors, probe/final candidate, and debug processed/input/after-match bytes and exposed queue/lifecycle observations.
- Production core.c and built overlay are byte-identical to the measured candidate.
- Offline driver-debug-disabled build passed without compiler warnings. Existing Milan synthetic/state/runtime and fpi-device suites passed all 119 cases across four suites.
- Touched helper is formatter-exact; unrelated formatting preserved. `git diff --check` passed.
- No new tests/cases or dependencies. Optional introspection-dependent suites remain unavailable in the local configuration.

Supported-ABI and small-dimension behavior are established by the source invariant, not new boundary fixtures or separate 32-bit execution. No fresh DLL or hardware replay is claimed for this equivalent arithmetic change. Strict integration parity against the requested campaign set passed; fresh UAT remains required before merge. Native audit notes were committed and pushed separately to milan-dev before opening this draft.

## Integration Gate
All 2,698 selected identify/verify operations passed across the 14 requested campaigns on integration branch `milan-performance-integration-20260905` at `6cfc612`. Its tree equals the four-layer stack head. Zero selected failures; runtime v3, print schema 4, build seal v2, explicit selectors, natural queues, and complete current-vs-native comparison were enforced. Enrollment and other nonselected context are not claimed as full replay coverage. This establishes recorded-operation parity, not cross-hardware performance or fresh hardware UAT. Native notes are separately pushed on milan-dev. No PR merge is authorized by this gate.