### PR TITLE
Invalidate idle Goodix state before system suspend

### DIFF
--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -107,6 +107,12 @@ goodix_suspend (FpDevice *dev)
 }
 
 static void
+goodix_suspend_idle_notify (FpDevice *dev)
+{
+  FPI_DEVICE_GOODIX53X5 (dev)->needs_reinit = TRUE;
+}
+
+static void
 goodix_resume (FpDevice *dev)
 {
   goodix_session_resume (dev);
@@ -171,4 +177,5 @@ fpi_device_goodix53x5_class_init (FpiDeviceGoodix53x5Class *klass)
   dev_class->cancel = goodix_cancel;
   dev_class->suspend = goodix_suspend;
   dev_class->resume  = goodix_resume;
+  dev_class->suspend_idle_notify = goodix_suspend_idle_notify;
 }

--- a/patches/libfprint/README.md
+++ b/patches/libfprint/README.md
@@ -31,3 +31,30 @@ Regenerate it deterministically from a modified worktree at the pinned commit:
 The generator writes a base-revision header into the patch. The verifier
 enforces that revision before running `git apply --check`; `git apply` alone
 does not enforce patch metadata.
+
+## Idle Suspend Notification
+
+`libfprint-idle-suspend-notify.patch` targets the same exact revision and adds
+the nullable internal `FpDeviceClass.suspend_idle_notify` callback. Core calls
+it synchronously only for an accepted suspend of an open, idle device, before
+completing suspend. The callback may only invalidate driver-owned memory: no
+I/O, asynchronous work, blocking, main-loop reentrancy, action start or
+completion calls. It has no paired resume callback.
+
+Goodix opts in only to set `needs_reinit`; its existing next-action SSM performs
+reinitialization. Closed devices and drivers that do not opt in retain their
+existing behavior. Interactive hooks and the short-action suspend path are
+unchanged. This does not establish physical S3, s2idle or S4 recovery.
+
+Both local build routes verify and apply the patch, and include it in overlay
+and production source identities. The stack manifest also seals its digest.
+All drivers must be rebuilt against the changed internal class layout. Check
+the patch against a pristine checkout with:
+
+```sh
+./patches/libfprint/verify-idle-suspend-notify-patch.sh /path/to/pristine/libfprint
+```
+
+One additional `fpi-device` case, `/driver/identify/suspend_idle_notify`, checks
+notification ordering/counts, repeated cycles, and closed/non-opted-in controls.
+The existing idle and interactive suspend compatibility cases are unchanged.

--- a/patches/libfprint/libfprint-idle-suspend-notify.patch
+++ b/patches/libfprint/libfprint-idle-suspend-notify.patch
@@ -1,0 +1,160 @@
+Libfprint-Idle-Suspend-Notify-Patch: 1
+Base-Revision: 0c97a47d8ef405cd577b87058c1e89cae9d242e7
+Base-Tag: v1.94.10
+
+diff --git a/libfprint/fpi-device.h b/libfprint/fpi-device.h
+--- a/libfprint/fpi-device.h
++++ b/libfprint/fpi-device.h
+@@ -112,6 +112,13 @@
+  *    IDENTIFY or CAPTURE) and the system is about to go into suspend.
+  * @resume: Called to resume an ongoing interactive action after the system has
+  *    resumed from suspend.
++ * @suspend_idle_notify: Optional synchronous notification when an open device
++ *    has no current action and a system suspend request has been accepted.
++ *    Called before core completes suspend, allowing drivers to invalidate
++ *    retained state for the next action. Must only update driver-owned memory:
++ *    no I/O, asynchronous work, blocking or main-loop reentrancy is permitted.
++ *    Must not start an action or call a completion function; core owns suspend
++ *    completion. Closed devices are not notified. There is no paired callback.
+  *
+  * NOTE: If your driver is image based, then you should subclass #FpImageDevice
+  * instead. #FpImageDevice based drivers use a different way of interacting
+@@ -173,6 +180,7 @@ struct _FpDeviceClass
+   void (*cancel)   (FpDevice *device);
+   void (*suspend)  (FpDevice *device);
+   void (*resume)   (FpDevice *device);
++  void (*suspend_idle_notify) (FpDevice *device);
+ };
+ 
+ void fpi_device_class_auto_initialize_features (FpDeviceClass *device_class);
+diff --git a/libfprint/fpi-device.c b/libfprint/fpi-device.c
+--- a/libfprint/fpi-device.c
++++ b/libfprint/fpi-device.c
+@@ -1615,6 +1615,8 @@ fpi_device_suspend (FpDevice *device)
+   switch (priv->current_action)
+     {
+     case FPI_DEVICE_ACTION_NONE:
++      if (priv->is_open && FP_DEVICE_GET_CLASS (device)->suspend_idle_notify)
++        FP_DEVICE_GET_CLASS (device)->suspend_idle_notify (device);
+       fpi_device_suspend_complete (device, NULL);
+       break;
+ 
+diff --git a/tests/test-fpi-device.c b/tests/test-fpi-device.c
+--- a/tests/test-fpi-device.c
++++ b/tests/test-fpi-device.c
+@@ -2330,5 +2330,107 @@ test_driver_identify_suspend_while_idle (void)
+ }
+ 
++typedef struct
++{
++  guint notifications;
++  guint expected_notifications;
++  guint suspend_completions;
++  guint resume_completions;
++} IdleSuspendNotifyData;
++
++static void
++fake_device_suspend_idle_notify (FpDevice *device)
++{
++  IdleSuspendNotifyData *data = FPI_DEVICE_FAKE (device)->user_data;
++
++  g_assert_true (fp_device_is_open (device));
++  g_assert_cmpint (fpi_device_get_current_action (device), ==, FPI_DEVICE_ACTION_NONE);
++  g_assert_cmpuint (data->suspend_completions, ==, data->resume_completions);
++  data->notifications++;
++  g_assert_cmpuint (data->notifications, ==, data->expected_notifications);
++}
++
++static void
++idle_suspend_notify_suspend_cb (GObject      *source,
++                                GAsyncResult *result,
++                                gpointer      user_data)
++{
++  IdleSuspendNotifyData *data = user_data;
++
++  g_autoptr(GError) error = NULL;
++
++  g_assert_true (fp_device_suspend_finish (FP_DEVICE (source), result, &error));
++  g_assert_no_error (error);
++  g_assert_cmpuint (data->notifications, ==, data->expected_notifications);
++  data->suspend_completions++;
++}
++
++static void
++idle_suspend_notify_resume_cb (GObject      *source,
++                               GAsyncResult *result,
++                               gpointer      user_data)
++{
++  IdleSuspendNotifyData *data = user_data;
++
++  g_autoptr(GError) error = NULL;
++
++  g_assert_true (fp_device_resume_finish (FP_DEVICE (source), result, &error));
++  g_assert_no_error (error);
++  data->resume_completions++;
++}
++
++static void
++test_driver_identify_suspend_idle_notify (void)
++{
++  g_autoptr(FpAutoResetClass) dev_class = auto_reset_device_class ();
++  g_autoptr(FpAutoCloseDevice) device = g_object_new (FPI_TYPE_DEVICE_FAKE, NULL);
++  FpiDeviceFake *fake_dev = FPI_DEVICE_FAKE (device);
++  IdleSuspendNotifyData data = {0};
++
++  g_assert_null (dev_class->suspend_idle_notify);
++  fake_dev->user_data = &data;
++  dev_class->suspend_idle_notify = fake_device_suspend_idle_notify;
++
++  /* Closed opt-in, open default, then two open opt-in sleep cycles. */
++  for (guint i = 0; i < 4; i++)
++    {
++      if (i == 1)
++        {
++          g_assert_true (fp_device_open_sync (device, NULL, NULL));
++          dev_class->suspend_idle_notify = NULL;
++        }
++      else if (i == 2)
++        {
++          dev_class->suspend_idle_notify = fake_device_suspend_idle_notify;
++        }
++
++      fake_dev->last_called_function = NULL;
++      while (g_main_context_iteration (NULL, FALSE))
++        continue;
++      g_assert_cmpuint (data.notifications, ==, data.expected_notifications);
++      g_assert_null (fake_dev->last_called_function);
++
++      if (i >= 2)
++        data.expected_notifications++;
++      fp_device_suspend (device, NULL, idle_suspend_notify_suspend_cb, &data);
++      g_assert_cmpuint (data.notifications, ==, data.expected_notifications);
++      g_assert_cmpuint (data.suspend_completions, ==, i);
++      while (g_main_context_iteration (NULL, FALSE))
++        continue;
++      g_assert_cmpuint (data.suspend_completions, ==, i + 1);
++      g_assert_null (fake_dev->last_called_function);
++
++      fp_device_resume (device, NULL, idle_suspend_notify_resume_cb, &data);
++      while (g_main_context_iteration (NULL, FALSE))
++        continue;
++      g_assert_cmpuint (data.resume_completions, ==, i + 1);
++      g_assert_cmpuint (data.suspend_completions, ==, i + 1);
++      g_assert_cmpuint (data.notifications, ==, data.expected_notifications);
++      g_assert_null (fake_dev->last_called_function);
++      g_assert_cmpint (fp_device_is_open (device), ==, i > 0);
++      g_assert_cmpint (fpi_device_get_current_action (device), ==, FPI_DEVICE_ACTION_NONE);
++    }
++}
++
+ static void
+ test_driver_identify_warmup_cooldown (void)
+ {
+@@ -3465,6 +3567,7 @@ main (int argc, char *argv[])
+   g_test_add_func ("/driver/identify/suspend_succeeds", test_driver_identify_suspend_succeeds);
+   g_test_add_func ("/driver/identify/suspend_busy_error", test_driver_identify_suspend_busy_error);
+   g_test_add_func ("/driver/identify/suspend_while_idle", test_driver_identify_suspend_while_idle);
++  g_test_add_func ("/driver/identify/suspend_idle_notify", test_driver_identify_suspend_idle_notify);
+ 
+   g_test_add_func ("/driver/identify/warmup_cooldown", test_driver_identify_warmup_cooldown);
+ 

--- a/patches/libfprint/verify-idle-suspend-notify-patch.sh
+++ b/patches/libfprint/verify-idle-suspend-notify-patch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+expected_revision="0c97a47d8ef405cd577b87058c1e89cae9d242e7"
+expected_sha256="ec357fef155b2b6a0be6d91e697e4c4cbd3f5f4cec5218cd95b94008d7e7e548"
+source_dir="${1:?usage: $0 PRISTINE_LIBFPRINT_SOURCE}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+patch_path="$script_dir/libfprint-idle-suspend-notify.patch"
+
+actual_revision="$(git -C "$source_dir" rev-parse HEAD)"
+[[ "$actual_revision" == "$expected_revision" ]] || {
+  printf 'refusing to apply: expected %s, got %s\n' "$expected_revision" "$actual_revision" >&2
+  exit 1
+}
+[[ -z "$(git -C "$source_dir" status --porcelain --untracked-files=no)" ]] || {
+  printf 'refusing to check patch against tracked source changes\n' >&2
+  exit 1
+}
+grep -Fxq "Base-Revision: $expected_revision" "$patch_path"
+actual_sha256="$(sha256sum "$patch_path" | cut -d ' ' -f 1)"
+[[ "$actual_sha256" == "$expected_sha256" ]] || {
+  printf 'refusing to apply: expected patch SHA-256 %s, got %s\n' \
+    "$expected_sha256" "$actual_sha256" >&2
+  exit 1
+}
+git -C "$source_dir" apply --check "$patch_path"
+
+printf 'patch applies cleanly to %s\n' "$expected_revision"

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -71,10 +71,13 @@ git -C "$libfprint_dir" reset --hard --quiet "$libfprint_ref"
 # The verifier rejects both the wrong commit and any context drift.
 "$repo_dir/patches/libfprint/verify-update-result-patch.sh" "$libfprint_dir"
 "$repo_dir/patches/libfprint/verify-goodix53x5-usb-persist-patch.sh" "$libfprint_dir"
+"$repo_dir/patches/libfprint/verify-idle-suspend-notify-patch.sh" "$libfprint_dir"
 git -C "$libfprint_dir" apply \
   "$repo_dir/patches/libfprint/libfprint-update-result.patch"
 git -C "$libfprint_dir" apply \
   "$repo_dir/patches/libfprint/libfprint-goodix53x5-usb-persist.patch"
+git -C "$libfprint_dir" apply \
+  "$repo_dir/patches/libfprint/libfprint-idle-suspend-notify.patch"
 
 rm -rf "$libfprint_dir/libfprint/drivers/goodix53x5"
 mkdir -p "$libfprint_dir/libfprint/drivers/goodix53x5"

--- a/scripts/build-milan-stack-local.sh
+++ b/scripts/build-milan-stack-local.sh
@@ -62,6 +62,7 @@ fi
 milan_verify_git_pristine "$fprintd_pristine" "$MILAN_FPRINTD_REVISION" "fprintd"
 "$repo_dir/patches/libfprint/verify-update-result-patch.sh" "$libfprint_pristine"
 "$repo_dir/patches/libfprint/verify-goodix53x5-usb-persist-patch.sh" "$libfprint_pristine"
+"$repo_dir/patches/libfprint/verify-idle-suspend-notify-patch.sh" "$libfprint_pristine"
 "$repo_dir/patches/fprintd/verify-update-save-patch.sh" "$fprintd_pristine"
 
 mkdir -p "$MILAN_STACK_ROOT/builds"
@@ -93,6 +94,8 @@ git -C "$libfprint_source" apply --reverse --check \
   "$repo_dir/patches/libfprint/libfprint-update-result.patch"
 git -C "$libfprint_source" apply --reverse --check \
   "$repo_dir/patches/libfprint/libfprint-goodix53x5-usb-persist.patch"
+git -C "$libfprint_source" apply --reverse --check \
+  "$repo_dir/patches/libfprint/libfprint-idle-suspend-notify.patch"
 milan_run_stage "configure paired shadow libfprint" meson setup "$libfprint_build" \
   "$libfprint_source" --reconfigure --prefix="$MILAN_PREFIX" --libdir=lib \
   -Ddrivers=goodix53x5 -Dudev_hwdb=disabled -Dudev_rules=disabled \
@@ -146,6 +149,7 @@ FPRINTD_REVISION=$MILAN_FPRINTD_REVISION
 FPRINTD_SOURCE_TREE=$(git -C "$fprintd_pristine" rev-parse HEAD^{tree})
 LIBFPRINT_PATCH_SHA256=$MILAN_LIBFPRINT_PATCH_SHA256
 LIBFPRINT_USB_PERSIST_PATCH_SHA256=$MILAN_LIBFPRINT_USB_PERSIST_PATCH_SHA256
+LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256=$MILAN_LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256
 FPRINTD_PATCH_SHA256=$MILAN_FPRINTD_PATCH_SHA256
 OVERLAY_REVISION=$overlay_revision
 OVERLAY_INPUT_SHA256=$overlay_input_sha256

--- a/scripts/lib/milan-stack-common.sh
+++ b/scripts/lib/milan-stack-common.sh
@@ -6,6 +6,7 @@ MILAN_LIBFPRINT_SOURCE_TREE="2d08bc33d953cd17b315c5f5199aa7a0d0504506"
 MILAN_FPRINTD_SOURCE_TREE="ff82f8c3c2ab936ddafec9e88e650c04cd6f4f1d"
 MILAN_LIBFPRINT_PATCH_SHA256="fa9a4a89df02894a01013dc787d06cdbb74a4908b8e3cdc5da745e0265fb2f72"
 MILAN_LIBFPRINT_USB_PERSIST_PATCH_SHA256="743c13782228869b8b5ea834caa096abadd38e5542303d7af8bc7acb4c925ae0"
+MILAN_LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256="ec357fef155b2b6a0be6d91e697e4c4cbd3f5f4cec5218cd95b94008d7e7e548"
 MILAN_FPRINTD_PATCH_SHA256="5d87cd806587fa5f035847a38ba3155b38f9a612a3070d9abfa6f83114e58db8"
 MILAN_PREFIX="/opt/goodix53x5-milan"
 MILAN_SYSTEMD_DIR="/etc/systemd/system/fprintd.service.d"
@@ -144,6 +145,7 @@ milan_overlay_input_sha256() {
     sha256sum meson-integration.patch scripts/build-local.sh \
       patches/libfprint/libfprint-update-result.patch \
       patches/libfprint/libfprint-goodix53x5-usb-persist.patch \
+      patches/libfprint/libfprint-idle-suspend-notify.patch \
       patches/fprintd/1.94.5-milan-update-save.patch
   ) | sha256sum | cut -d ' ' -f 1
 }
@@ -160,12 +162,15 @@ milan_verify_repo_inputs() {
   local repo_dir="$1"
   local lib_patch="$repo_dir/patches/libfprint/libfprint-update-result.patch"
   local persist_patch="$repo_dir/patches/libfprint/libfprint-goodix53x5-usb-persist.patch"
+  local idle_suspend_patch="$repo_dir/patches/libfprint/libfprint-idle-suspend-notify.patch"
   local daemon_patch="$repo_dir/patches/fprintd/1.94.5-milan-update-save.patch"
 
   [[ "$(milan_sha256 "$lib_patch")" == "$MILAN_LIBFPRINT_PATCH_SHA256" ]] ||
     milan_die "libfprint patch digest mismatch"
   [[ "$(milan_sha256 "$persist_patch")" == "$MILAN_LIBFPRINT_USB_PERSIST_PATCH_SHA256" ]] ||
     milan_die "libfprint USB persist patch digest mismatch"
+  [[ "$(milan_sha256 "$idle_suspend_patch")" == "$MILAN_LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256" ]] ||
+    milan_die "libfprint idle suspend notification patch digest mismatch"
   [[ "$(milan_sha256 "$daemon_patch")" == "$MILAN_FPRINTD_PATCH_SHA256" ]] ||
     milan_die "fprintd patch digest mismatch"
   (cd "$(dirname "$daemon_patch")" && sha256sum --check "$(basename "$daemon_patch").sha256" >/dev/null) ||
@@ -247,6 +252,7 @@ milan_verify_manifest() {
   [[ "$(milan_manifest_value "$manifest" FPRINTD_SOURCE_TREE)" == "$MILAN_FPRINTD_SOURCE_TREE" ]] || milan_die "fprintd source tree mismatch"
   [[ "$(milan_manifest_value "$manifest" LIBFPRINT_PATCH_SHA256)" == "$MILAN_LIBFPRINT_PATCH_SHA256" ]] || milan_die "libfprint patch manifest mismatch"
   [[ "$(milan_manifest_value "$manifest" LIBFPRINT_USB_PERSIST_PATCH_SHA256)" == "$MILAN_LIBFPRINT_USB_PERSIST_PATCH_SHA256" ]] || milan_die "libfprint USB persist patch manifest mismatch"
+  [[ "$(milan_manifest_value "$manifest" LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256)" == "$MILAN_LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256" ]] || milan_die "libfprint idle suspend notification patch manifest mismatch"
   [[ "$(milan_manifest_value "$manifest" FPRINTD_PATCH_SHA256)" == "$MILAN_FPRINTD_PATCH_SHA256" ]] || milan_die "fprintd patch manifest mismatch"
   [[ "$(milan_manifest_value "$manifest" OVERLAY_INPUT_SHA256)" == "$(milan_overlay_input_sha256 "$repo_dir")" ]] || milan_die "overlay input mismatch"
   debug="$(milan_manifest_value "$manifest" GOODIX53X5_DEBUG)"

--- a/scripts/tests/test-milan-stack-tools.sh
+++ b/scripts/tests/test-milan-stack-tools.sh
@@ -124,6 +124,7 @@ overlay_input_sha256="$(
     sha256sum meson-integration.patch scripts/build-local.sh \
       patches/libfprint/libfprint-update-result.patch \
       patches/libfprint/libfprint-goodix53x5-usb-persist.patch \
+      patches/libfprint/libfprint-idle-suspend-notify.patch \
       patches/fprintd/1.94.5-milan-update-save.patch
   ) | sha256sum | cut -d ' ' -f 1
 )"
@@ -137,6 +138,7 @@ FPRINTD_REVISION=b54a007ccf58ac0ae074c7151b223f35cbd17306
 FPRINTD_SOURCE_TREE=ff82f8c3c2ab936ddafec9e88e650c04cd6f4f1d
 LIBFPRINT_PATCH_SHA256=fa9a4a89df02894a01013dc787d06cdbb74a4908b8e3cdc5da745e0265fb2f72
 LIBFPRINT_USB_PERSIST_PATCH_SHA256=743c13782228869b8b5ea834caa096abadd38e5542303d7af8bc7acb4c925ae0
+LIBFPRINT_IDLE_SUSPEND_NOTIFY_PATCH_SHA256=ec357fef155b2b6a0be6d91e697e4c4cbd3f5f4cec5218cd95b94008d7e7e548
 FPRINTD_PATCH_SHA256=5d87cd806587fa5f035847a38ba3155b38f9a612a3070d9abfa6f83114e58db8
 OVERLAY_REVISION=fixture
 OVERLAY_INPUT_SHA256=$overlay_input_sha256

--- a/tools/milan-parity/milan_parity_common.py
+++ b/tools/milan-parity/milan_parity_common.py
@@ -221,7 +221,10 @@ def locked_state(path_value: str | None) -> Iterator[Path]:
 def source_identity(repo: Path) -> str:
     repo = repo.expanduser().resolve()
     roots = [repo / "drivers" / "goodix53x5"]
-    fixed = [repo / "meson-integration.patch", repo / "scripts" / "build-local.sh"]
+    fixed = [repo / "meson-integration.patch", repo / "scripts" / "build-local.sh",
+             repo / "patches" / "libfprint" / "libfprint-update-result.patch",
+             repo / "patches" / "libfprint" / "libfprint-goodix53x5-usb-persist.patch",
+             repo / "patches" / "libfprint" / "libfprint-idle-suspend-notify.patch"]
     paths = sorted(path for root in roots for path in root.rglob("*") if path.is_file())
     paths.extend(fixed)
     digest = hashlib.sha256()


### PR DESCRIPTION
## Change
Add an optional synchronous, memory-only internal libfprint notification for accepted suspend requests when a device is open but has no running action. Goodix opts in only to set `needs_reinit = TRUE`; its existing next-action state machine performs USB reset/reclaim, GTLS and reference initialization.

The previous libfprint idle path completed suspend without invoking a driver hook. A retained client claim could therefore bypass proactive invalidation and rely on a later USB error to trigger recovery. Closed devices, non-opted-in drivers, interactive suspend/resume and short-action handling are unchanged. Core retains ownership of suspend completion. The callback must not perform I/O, block, reenter the main loop, launch asynchronous work or start/complete an action. There is no paired resume callback.

This follows #177 for integration/review ordering, not because checksum processing is required by the notifier.

## Linux Lifecycle
The existing USB-persist rule and Goodix libfprint exception preserve attachment where possible across hibernate, not firmware-session continuity. This change neither keeps an interface claimed after client Release nor caches state across close/open. It is a Linux framework reliability correction, not an attempt to equate libfprint callbacks with Windows device-object lifetime. Native acquisition and matching behavior are unchanged. No cold-open latency reduction is claimed.

## Build Integration
The revision/digest-pinned overlay is applied by both local build routes. Its digest is sealed in stack manifests and included in overlay and production source identities; the source identity also covers the existing libfprint overlays. The internal class layout changes, so drivers must be rebuilt together. No public D-Bus interface or external dependency is added.

## Validation
- Offline release build and 120 C cases passed: fpi-device 99, Milan synthetic 8, state 6, runtime 7.
- One explicitly approved test extends the existing idle-suspend suite, checking closed opt-in/open non-opt-in controls, two open opt-in cycles, exact notification/completion counts, and notification before async completion. Existing compatibility tests remain unchanged.
- Existing mocked stack install/rollback suite passed 10/10. Fresh independent review found no issues.
- Patch revision/digest/application checks, reverse-application checks, touched C formatting, shell syntax and diff checks passed.
- Fresh local debug integration contained exactly #177 and this layer. Its build, four suites, preflight and installed identity checks passed. Optional introspection/dbusmock suites remain unavailable; the existing upstream NBIS warning remains.

## Targeted Hardware UAT
A persistent normal-user Gio client claimed the reader without starting verification, retained that claim through sleep, then started verification after resume. Two s2idle runs and one hibernate run showed immediate reinitialization within the first verification, without another client open or preceding stale-device failure, followed by successful matches with no runtime or learning errors.

The hibernate run exercised expected EINVAL handling when releasing a claim already dropped by the kernel, then successfully reset/reclaimed and initialized. Reinit durations were approximately 582/578 ms for s2idle and 522 ms for hibernate; these are single-laptop debug observations, not performance comparisons. General enrollment/verification and sleep/hibernate smoke UAT also passed. One earlier hibernate attempt omitted the finger touch and was cancelled; it is not counted as a successful match.

## Limits And Remaining Gates
No baseline hardware failure reproduction, physical S3 coverage, other-laptop validation, or automatic suspend-to-hibernate transition is claimed. The targeted case does not prove every client or queued short-action chronology. Full strict native-corpus and finalized-campaign parity gates remain outstanding before merge. Native lifecycle notes were already pushed separately to milan-dev before publication. The integration branch was local-only; no private evidence or RE notes are included in this diff.