### PR TITLE
Reuse reflection indices during Milan feature filtering

### DIFF
--- a/drivers/goodix53x5/milan/feature/extraction.c
+++ b/drivers/goodix53x5/milan/feature/extraction.c
@@ -68,37 +68,42 @@ feature_filter_q16 (const uint16_t          *source,
 
   if (!horizontal)
     return -1;
-  for (size_t row = 0; row < rows; row++)
-    for (size_t column = 0; column < columns; column++)
-      {
-        uint64_t sum = 0;
+  for (size_t column = 0; rows != 0 && column < columns; column++)
+    {
+      size_t reflected[15];
 
-        for (size_t tap = 0; tap < kernel->length; tap++)
-          {
-            size_t x = goodix_milan_reflect101_index (
-              (ptrdiff_t) column + (ptrdiff_t) tap - (ptrdiff_t) radius,
-              columns);
+      for (size_t tap = 0; tap < kernel->length; tap++)
+        reflected[tap] = goodix_milan_reflect101_index (
+          (ptrdiff_t) column + (ptrdiff_t) tap - (ptrdiff_t) radius,
+          columns);
+      for (size_t row = 0; row < rows; row++)
+        {
+          uint64_t sum = 0;
 
-            sum += (uint64_t) source[row * columns + x] *
+          for (size_t tap = 0; tap < kernel->length; tap++)
+            sum += (uint64_t) source[row * columns + reflected[tap]] *
                    kernel->coefficients[tap];
-          }
-        horizontal[row * columns + column] = (uint16_t) (sum >> 16);
-      }
-  for (size_t row = 0; row < rows; row++)
-    for (size_t column = 0; column < columns; column++)
-      {
-        uint64_t sum = 0;
+          horizontal[row * columns + column] = (uint16_t) (sum >> 16);
+        }
+    }
+  for (size_t row = 0; columns != 0 && row < rows; row++)
+    {
+      size_t reflected[15];
 
-        for (size_t tap = 0; tap < kernel->length; tap++)
-          {
-            size_t y = goodix_milan_reflect101_index (
-              (ptrdiff_t) row + (ptrdiff_t) tap - (ptrdiff_t) radius, rows);
+      for (size_t tap = 0; tap < kernel->length; tap++)
+        reflected[tap] = goodix_milan_reflect101_index (
+          (ptrdiff_t) row + (ptrdiff_t) tap - (ptrdiff_t) radius, rows) *
+                         columns;
+      for (size_t column = 0; column < columns; column++)
+        {
+          uint64_t sum = 0;
 
-            sum += (uint64_t) horizontal[y * columns + column] *
+          for (size_t tap = 0; tap < kernel->length; tap++)
+            sum += (uint64_t) horizontal[reflected[tap] + column] *
                    kernel->coefficients[tap];
-          }
-        output[row * columns + column] = (uint16_t) (sum >> 16);
-      }
+          output[row * columns + column] = (uint16_t) (sum >> 16);
+        }
+    }
   free (horizontal);
   return 0;
 }


### PR DESCRIPTION
## Change
Hoist reflection-index calculations out of the per-pixel loops in `feature_filter_q16`. The horizontal pass computes tap indices once per column, then processes its rows. The vertical pass computes reflected row offsets once per row, then processes its columns.

For the existing 88x104 extraction workload this reduces reflection evaluations from 1,519,232 to 15,936 per extraction. The supported benefit is approximately 1 ms of fixed extraction CPU work, rather than a saving that depends on registering many fingers. This layer follows #178 for review ordering; the arithmetic optimization does not depend on its suspend behavior.

## Equivalence And Cost
Only independent pixel computations are reordered. Coefficients, tap order within each sum, uint64_t accumulation, both per-pass truncations, reflection multiplicities, validation, allocation and failure behavior remain unchanged. The complete horizontal pass still finishes before any output write, preserving source/output aliasing behavior.

All five direct call sites select from 13 static kernels with lengths 3/7/9/11/13/15. Each local scratch array has 15 size_t entries (120 bytes on x86-64), with disjoint pass lifetimes. There are no new heap allocations, persistent caches, CPU-specific instructions, target flags or dependencies. Zero-dimension inputs retain the existing malloc(0) outcome and perform no reflection or pixel access. Existing defined-input coordinate and allocation bounds are preserved. The largest kernel coefficient sum is 65,536, keeping the maximum sum at 4,294,901,760 within uint64_t.

## Measurements
Two complete runs reused the same six synthetic workloads with 31 alternating baseline/candidate release pairs after ten warmup pairs per workload. Baseline includes #177 and #178. Second-run print-parse-through-results measurements, milliseconds:

| Workload | Galleries | CPU median old/new | Wall median old/new | Wall p95 old/new |
| --- | ---: | ---: | ---: | ---: |
| Nonmatch | 1 | 27.745 / 26.607 | 27.799 / 26.654 | 41.620 / 28.499 |
| Nonmatch | 5 | 79.899 / 78.677 | 80.072 / 78.891 | 93.863 / 92.609 |
| Nonmatch | 10 | 145.207 / 144.462 | 145.477 / 144.851 | 163.722 / 163.499 |
| Winner-last | 1 | 22.731 / 21.700 | 22.763 / 21.735 | 25.993 / 23.373 |
| Winner-last | 5 | 74.536 / 73.382 | 74.693 / 73.621 | 89.245 / 76.803 |
| Winner-last | 10 | 140.398 / 138.065 | 140.660 / 138.280 | 152.628 / 144.348 |

The narrower extraction CPU interval saved 0.94-1.12 ms in this run and 1.03-1.49 ms in the first run. Host variation was substantial: first-run five-gallery nonmatch wall medians regressed 95.664 to 116.680 ms despite 26/31 paired improvements; ten-gallery winner-last wall p95 also regressed 151.846 to 152.979 ms. Second-run ten-gallery nonmatch CPU p95 regressed 161.701 to 163.058 ms. Uniform whole-operation or tail improvement is not established.

These are existing repeated synthetic galleries on one x86-64 host, not diverse enrolled fingers, a direct two-gallery measurement, or cross-laptop results. No reader-ready, hardware acquisition or lock-screen timing improvement is claimed. Changed horizontal traversal may have different cache behavior on other machines; portable correctness is separate from cross-machine speedup.

## Validation
- Exact complete exported-runtime comparisons passed for 492 release operation pairs (984 executions) and 78 debug pairs (156 executions), including warmups. Coverage includes processed/debug gallery bytes, templates, candidate, results, exposed queue/state, counts and errors.
- Final source matches the measured candidate except one formatter-only continuation indent. Built overlay driver bytes match the topic worktree.
- Isolated offline release build and all 120 existing C cases passed: synthetic 8, state 6, runtime 7 and fpi-device 99.
- Touched block is formatter-exact and diff checks pass. No Goodix compiler warnings; the existing upstream NBIS warning and optional missing introspection test coverage remain.
- No new tests, fixtures or dependencies. No changes to native contracts, matching policy, installed build, services or active UAT campaign.

This proves equivalence to the measured current implementation, not a fresh native-corpus certification. Final strict integrated corpus comparison and fresh hardware UAT remain pre-merge gates.