### PR TITLE
Compute Milan descriptor transforms with integer butterflies

### DIFF
--- a/drivers/goodix53x5/milan/feature/materialization.c
+++ b/drivers/goodix53x5/milan/feature/materialization.c
@@ -435,11 +435,22 @@ feature_normalize_descriptor (const int32_t *samples,
         : (int16_t) clipped);
 }
 
-static int
-feature_hadamard_sign (size_t row,
-                       size_t column)
+static void
+feature_hadamard32 (const int16_t *normalized,
+                    int32_t        transformed[32])
 {
-  return __builtin_parityll (row & column) ? -1 : 1;
+  for (size_t i = 0; i < 32; i++)
+    transformed[i] = normalized[i];
+  for (size_t stride = 1; stride < 32; stride *= 2)
+    for (size_t base = 0; base < 32; base += stride * 2)
+      for (size_t i = 0; i < stride; i++)
+        {
+          int32_t a = transformed[base + i];
+          int32_t b = transformed[base + i + stride];
+
+          transformed[base + i] = a + b;
+          transformed[base + i + stride] = a - b;
+        }
 }
 
 static int16_t
@@ -474,24 +485,25 @@ feature_encode_descriptor_first (const int16_t normalized[128],
   };
   uint32_t transform[4] = { 0 };
   uint32_t median_bits = 0;
+  int16_t partial[4][32];
+
+  for (size_t block = 0; block < 4; block++)
+    {
+      int32_t transformed[32];
+
+      feature_hadamard32 (normalized + block * 32, transformed);
+      /* Narrow each block before the existing four-block combination. */
+      for (size_t bit = 0; bit < 32; bit++)
+        partial[block][bit] = (int16_t) transformed[bit];
+    }
 
   for (size_t bit = 0; bit < 32; bit++)
     {
-      int16_t partial[4];
-
-      for (size_t block = 0; block < 4; block++)
-        {
-          int32_t sum = 0;
-          for (size_t sample = 0; sample < 32; sample++)
-            sum += normalized[block * 32 + sample] *
-                   feature_hadamard_sign (bit, sample);
-          partial[block] = (int16_t) sum;
-        }
       for (size_t output = 0; output < 4; output++)
         {
           int32_t sum = 0;
           for (size_t block = 0; block < 4; block++)
-            sum += coefficients[output][block] * partial[block];
+            sum += coefficients[output][block] * partial[block][bit];
           if (sum > 0)
             transform[output] |= 1U << bit;
         }
@@ -512,13 +524,13 @@ feature_encode_descriptor_second (const int16_t normalized[32],
   uint32_t transform = 0;
   uint32_t median_bits = 0;
   int16_t median = feature_descriptor_median (normalized, 32);
+  int32_t transformed[32];
+
+  feature_hadamard32 (normalized, transformed);
 
   for (size_t bit = 0; bit < 32; bit++)
     {
-      int32_t sum = 0;
-      for (size_t sample = 0; sample < 32; sample++)
-        sum += normalized[sample] * feature_hadamard_sign (bit, sample);
-      if (sum > 0)
+      if (transformed[bit] > 0)
         transform |= 1U << bit;
       if (median < normalized[bit])
         median_bits |= 1U << bit;


### PR DESCRIPTION
## Performance Assessment
Performance review is complete for this layer under the maintainer acceptance criterion: seek improvements at all gallery sizes, accept small differences consistent with measurement variability, and do not sacrifice larger galleries for small-gallery gains. Controlled immediate-parent comparisons for #177, #180 and #181 improved paired CPU and wall medians in every tested workload in all four process repetitions. Inconsistent tail estimates and comparable identical-binary variation do not provide convincing evidence of a repeatable code-induced regression. This is not a universal no-regression guarantee. No further tail-timing campaign is required. Final integrated correctness/parity and hardware UAT gates remain.

## Change
Replace dense 32-point Hadamard sums in the two descriptor encoders with a shared five-stage integer butterfly transform. Five transforms per descriptor go from 5,120 dense accumulation terms to 800 additions/subtractions, eliminating repeated parity/sign calculations.

This removes approximately 1.2-2.0 ms of extraction CPU work in the existing workloads. The saving scales with extracted records, not gallery count for a fixed frame. This layer follows #180 for review ordering and measurements; it does not require that layer for mathematical correctness.

## Exact Arithmetic
The ascending-stride butterflies produce the same natural-order matrix H[r,c] = (-1)^popcount(r & c), without permutation or normalization. Each stage is a signed sum of distinct int16_t inputs; the maximum final magnitude is 1,048,576, safely within int32_t even for -32768 inputs.

The first encoder still narrows each block result to int16_t BEFORE the four-block combination. That combination remains bounded by 131,072. The second encoder retains full-width sums. Strict positive/median comparisons, ties, bit numbering, sorting and output ranges are unchanged. No validation, allocation, failure handling or matching policy changes.

Signed narrowing preserves the existing Linux GCC/Clang behavior, not a new assumption of universal modulo conversion on every C implementation. Cast traversal order changes; signal chronology on exotic implementations that signal on out-of-range narrowing is not claimed. Static callers provide separate local transform scratch; output writes still follow input consumption.

## Measurements
Two interleaved release rounds used the existing nonmatch and winner-last workloads with 1, 5 and 10 galleries, 31 measured pairs after ten warmup pairs per row. Baseline includes #180; compiler/options and CPU affinity are identical. Complete print-parse-through-results timings in milliseconds, baseline/candidate:

| Round | Workload | Galleries | CPU median | CPU p95 | Wall median | Wall p95 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 1 | Nonmatch | 1 | 29.308/28.022 | 33.687/32.127 | 30.009/28.624 | 35.175/32.294 |
| 1 | Nonmatch | 5 | 87.240/86.947 | 91.305/92.776 | 89.328/89.388 | 93.837/96.119 |
| 1 | Nonmatch | 10 | 160.443/158.932 | 165.390/168.245 | 164.362/163.194 | 169.859/172.470 |
| 1 | Winner-last | 1 | 23.180/21.771 | 28.029/22.715 | 24.088/22.213 | 29.058/23.478 |
| 1 | Winner-last | 5 | 79.255/76.600 | 84.075/80.902 | 80.839/78.200 | 86.395/83.074 |
| 1 | Winner-last | 10 | 150.287/148.787 | 161.241/158.279 | 153.440/152.113 | 165.978/161.881 |
| 2 | Nonmatch | 1 | 29.567/27.865 | 32.458/30.034 | 30.246/28.919 | 33.437/30.666 |
| 2 | Nonmatch | 5 | 87.028/85.406 | 92.494/88.891 | 89.186/87.921 | 95.269/91.377 |
| 2 | Nonmatch | 10 | 160.118/159.353 | 171.547/168.167 | 164.347/163.609 | 176.096/173.247 |
| 2 | Winner-last | 1 | 24.535/22.976 | 29.289/26.311 | 25.215/23.030 | 29.976/26.462 |
| 2 | Winner-last | 5 | 79.620/78.776 | 86.006/89.319 | 81.781/80.559 | 88.146/91.494 |
| 2 | Winner-last | 10 | 152.320/150.791 | 166.128/163.735 | 156.659/154.901 | 171.140/167.560 |

Observed regressions: round-1 nonmatch-5 wall median +0.060 ms and CPU/wall p95 +1.471/+2.282 ms; round-1 nonmatch-10 CPU/wall p95 +2.855/+2.611 ms; round-2 winner-last-5 CPU/wall p95 +3.313/+3.348 ms. These original adverse estimates were retained and assessed in the follow-ups below. No result is discarded.

Extraction paired CPU median savings were 1.19-1.98 ms; extraction median/p95 improved in all 12 rows, with 328/372 measured pairs faster. Kernel timing alone is insufficient; the completed whole-operation follow-ups are summarized below.

These are repeated synthetic galleries on one host, not independently enrolled diverse fingers. No 2-gallery case was measured. No reader/unlock latency improvement is established. All gallery sizes matter for acceptance.

## Cost And Validation
- Compiler-reported descriptor stack frame grew 1,312 to 1,456 bytes, with a 32-byte helper frame. Combined owner/helper function-body size grew 141 bytes. No new heap allocation, persistent cache, dependency, CPU-specific instruction or target flag.
- 1,140 complete exported outputs checked in release/debug, including warmups, with zero differences; 1,122 comparisons are non-self. All 12 saved baseline/candidate workload pairs match byte-for-byte. This is complete exported-output equivalence, not only score equivalence.
- Production, measured candidate and build-overlay source are byte-for-byte identical.
- Isolated offline release build and all 120 existing cases passed: synthetic 8, state 6, runtime 7, fpi-device 99. No new tests/cases/fixtures were added.
- Independent review found no issues in ordering, full-range bounds, narrowing, aliasing, initialization, ties or failure behavior. Formatter and diff checks passed. Only the existing upstream NBIS warning and missing optional introspection coverage remain.

This is an algebraically equivalent computation change, not a newly recovered native contract. Fresh integrated native-corpus validation and hardware UAT remain pre-merge gates. The installed UAT build was not changed.

## Controlled Follow-up
A predefined A/A, A/B, A/B, A/A sequence completed with 101 measured pairs plus ten warmups for each of the existing six 1/5/10-gallery workloads. A/A used byte-identical baseline libraries. No runs were discarded. All 5,484 exported-output checks passed.

The paired CPU median improved in all twelve A/B workload/round estimates, but larger-gallery tails remain uncertain. In the second A/B round, ten-gallery nonmatch CPU p95 rose 172.415 to 178.666 ms and wall p95 rose 176.093 to 183.692 ms. The wall p95 delta was +7.598 ms, with a pointwise paired-bootstrap 95% interval of -8.497 to +10.410 ms; block bootstrap was also inconclusive.

Identical-binary controls showed five-gallery nonmatch wall-p95 increases of 3.179 and 3.832 ms. All A/B p95-delta intervals spanned zero. This demonstrates measurement/attribution limits, not that the adverse A/B estimates can be ignored. This earlier follow-up did not resolve attribution. Its results remain included; the final assessment follows.

## Final All-Gallery Assessment
A final predefined campaign compared each of #177, #180 and #181 with its immediate parent. Four process repetitions each of A/A and A/B used all six existing 1/5/10-gallery workloads, randomized balanced order and reversed arm/library placement. Each workload had 208 measured pairs per comparison across repetitions. All 18,360 exported-output checks across the three layers passed. No runs were discarded.

Every layer and workload improved paired CPU and wall medians in all four process repetitions. This layer saved 1.357-1.603 ms of extraction CPU across workloads. Its earlier ten-gallery nonmatch and five-gallery winner-last adverse tail estimates did not persist: those tails improved in all four new processes.

Five-gallery nonmatch remained mixed: combined CPU p95 89.699 to 90.119 ms (+0.420 ms), wall p95 91.891 to 93.164 ms (+1.273 ms). Pointwise hierarchical bootstrap delta intervals were -8.624 to +4.464 ms CPU and -8.534 to +4.452 ms wall. Corresponding identical-binary controls shifted +3.847/+4.113 ms. This supports treating the small, inconsistent adverse estimate as non-blocking measurement variation under the stated acceptance criterion, not as proof that no tail regression can ever occur.

Larger galleries remain first-class acceptance workloads. Results are still limited to the existing synthetic repeated-gallery inputs on this host; no extra functional test cases or installed-system changes were introduced.