### PR TITLE
Reuse descriptor distances across correspondence passes

### DIFF
--- a/drivers/goodix53x5/milan/match/correspondence.c
+++ b/drivers/goodix53x5/milan/match/correspondence.c
@@ -223,15 +223,16 @@ milan_recognition_descriptor_distance (const GoodixMilanFeatureRecord *enrolled,
 
 int
 goodix_milan_match_correspondences_partitioned (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  int32_t                        *pairs,
-  size_t                          pair_capacity,
-  size_t                         *pair_count)
+  const GoodixMilanFeatureRecord    *enrolled_records,
+  size_t                             enrolled_record_count,
+  size_t                             enrolled_partition_count,
+  const GoodixMilanFeatureRecord    *probe_records,
+  size_t                             probe_record_count,
+  size_t                             probe_partition_count,
+  int32_t                           *pairs,
+  size_t                             pair_capacity,
+  size_t                            *pair_count,
+  const MilanMatchDistanceReduction *primary_reductions)
 {
   MilanFeatureMatch matches[MILAN_MATCH_MAX_PAIRS];
   size_t match_count = 0;
@@ -257,22 +258,33 @@ goodix_milan_match_correspondences_partitioned (
       int second_distance = 192;
       int best_index = -1;
 
-      for (size_t probe_index = probe_begin; probe_index < probe_end;
-           probe_index++)
+      if (primary_reductions)
         {
-          int distance = milan_recognition_descriptor_distance (
-            &enrolled_records[enrolled_index], &probe_records[probe_index]);
-
-          if (distance < 0)
-            continue;
-          if (distance < best_distance)
+          best_distance = primary_reductions[enrolled_index].best_distance;
+          second_distance = primary_reductions[enrolled_index].second_distance;
+          best_index = primary_reductions[enrolled_index].best_index;
+        }
+      else
+        {
+          for (size_t probe_index = probe_begin; probe_index < probe_end;
+               probe_index++)
             {
-              second_distance = best_distance;
-              best_distance = distance;
-              best_index = (int) probe_index;
+              int distance = milan_recognition_descriptor_distance (
+                &enrolled_records[enrolled_index], &probe_records[probe_index]);
+
+              if (distance < 0)
+                continue;
+              if (distance < best_distance)
+                {
+                  second_distance = best_distance;
+                  best_distance = distance;
+                  best_index = (int) probe_index;
+                }
+              else if (distance < second_distance)
+                {
+                  second_distance = distance;
+                }
             }
-          else if (distance < second_distance)
-            second_distance = distance;
         }
       if (best_index < 0 || best_distance * 40 >= second_distance * 38)
         continue;
@@ -366,10 +378,15 @@ goodix_milan_match_relaxed_correspondences (
   const GoodixMilanFeatureRecord *probe_records,
   size_t                          probe_record_count,
   size_t                          probe_partition_count,
-  int32_t                         pairs[62])
+  int32_t                         pairs[62],
+  MilanMatchDistanceReduction    *primary_reductions)
 {
   MilanFeatureMatch matches[31];
   size_t match_count = 0;
+
+  if (primary_reductions)
+    for (size_t i = 0; i < enrolled_record_count; i++)
+      primary_reductions[i] = (MilanMatchDistanceReduction){ 192, 192, -1 };
 
   for (size_t probe_index = 0; probe_index < probe_record_count; probe_index++)
     {
@@ -391,6 +408,23 @@ goodix_milan_match_relaxed_correspondences (
 
           if (distance < 0)
             continue;
+          /* Each enrolled record still sees probe indices in ascending order. */
+          if (primary_reductions)
+            {
+              MilanMatchDistanceReduction *primary =
+                &primary_reductions[enrolled_index];
+
+              if (distance < primary->best_distance)
+                {
+                  primary->second_distance = primary->best_distance;
+                  primary->best_distance = distance;
+                  primary->best_index = (int32_t) probe_index;
+                }
+              else if (distance < primary->second_distance)
+                {
+                  primary->second_distance = distance;
+                }
+            }
           if (distance < best_distance)
             {
               second_distance = best_distance;

--- a/drivers/goodix53x5/milan/match/correspondence.h
+++ b/drivers/goodix53x5/milan/match/correspondence.h
@@ -23,6 +23,13 @@ typedef struct
   int32_t second_distance;
 } MilanFeatureMatch;
 
+typedef struct
+{
+  int32_t best_distance;
+  int32_t second_distance;
+  int32_t best_index;
+} MilanMatchDistanceReduction;
+
 size_t goodix_milan_match_feature_records (
   const GoodixMilanFeatureRecord *prior,
   size_t                          prior_count,
@@ -30,25 +37,25 @@ size_t goodix_milan_match_feature_records (
   size_t                          current_count,
   MilanFeatureMatch              matches[31]);
 
-int goodix_milan_match_correspondences_partitioned (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  int32_t                        *pairs,
-  size_t                          pair_capacity,
-  size_t                         *pair_count);
+int goodix_milan_match_correspondences_partitioned (const GoodixMilanFeatureRecord    *enrolled_records,
+                                                    size_t                             enrolled_record_count,
+                                                    size_t                             enrolled_partition_count,
+                                                    const GoodixMilanFeatureRecord    *probe_records,
+                                                    size_t                             probe_record_count,
+                                                    size_t                             probe_partition_count,
+                                                    int32_t                           *pairs,
+                                                    size_t                             pair_capacity,
+                                                    size_t                            *pair_count,
+                                                    const MilanMatchDistanceReduction *primary_reductions);
 
-size_t goodix_milan_match_relaxed_correspondences (
-  const GoodixMilanFeatureRecord *enrolled_records,
-  size_t                          enrolled_record_count,
-  size_t                          enrolled_partition_count,
-  const GoodixMilanFeatureRecord *probe_records,
-  size_t                          probe_record_count,
-  size_t                          probe_partition_count,
-  int32_t                         pairs[62]);
+size_t goodix_milan_match_relaxed_correspondences (const GoodixMilanFeatureRecord *enrolled_records,
+                                                   size_t                          enrolled_record_count,
+                                                   size_t                          enrolled_partition_count,
+                                                   const GoodixMilanFeatureRecord *probe_records,
+                                                   size_t                          probe_record_count,
+                                                   size_t                          probe_partition_count,
+                                                   int32_t                         pairs[62],
+                                                   MilanMatchDistanceReduction    *primary_reductions);
 
 int goodix_milan_match_alternate_correspondences_internal (
   const GoodixMilanFeatureRecord *enrolled_records,

--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -152,6 +152,7 @@ typedef struct
 typedef struct
 {
   MilanMatchDirection                direction;
+  const MilanMatchDistanceReduction *primary_reductions;
   uint32_t                           sensor_type;
   int32_t                            image_quality;
   int32_t                            image_coverage;
@@ -522,10 +523,11 @@ milan_match_publish_candidate (
 
 static int
 milan_match_score_counts (
-  const MilanMatchDirection *direction,
-  size_t                     pair_capacity,
-  MilanMatchFeatureResult   *result,
-  GoodixMilanMatchCandidate *candidate)
+  const MilanMatchDirection         *direction,
+  size_t                             pair_capacity,
+  MilanMatchFeatureResult           *result,
+  GoodixMilanMatchCandidate         *candidate,
+  const MilanMatchDistanceReduction *primary_reductions)
 {
   int32_t pairs[MILAN_MATCH_MAX_PAIRS * 2];
   int32_t initial_transform[6];
@@ -546,7 +548,7 @@ milan_match_score_counts (
         direction->enrolled_records, direction->enrolled_record_count,
         direction->enrolled_partition_count, direction->probe_records,
         direction->probe_record_count, direction->probe_partition_count,
-        pairs, pair_capacity, &match_count) != 0)
+        pairs, pair_capacity, &match_count, primary_reductions) != 0)
     return -1;
   memcpy (initial_transform, result->transform, sizeof (initial_transform));
   goodix_milan_match_fit_affine_state (
@@ -897,7 +899,8 @@ milan_match_build_feature_candidate (
         direction,
         sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? 42 : 31,
         feature_result,
-        sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? &feature_result->candidate : NULL) != 0)
+        sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ? &feature_result->candidate : NULL,
+        context->primary_reductions) != 0)
     return 1;
   milan_match_apply_secondary (
     direction, feature_result,
@@ -1354,7 +1357,7 @@ milan_match_reverse_feature (const MilanMatchReverseContext *context)
   int32_t match_flag;
   int32_t candidate_flag;
 
-  if (milan_match_score_counts (&context->direction, 31, &reverse, NULL) != 0)
+  if (milan_match_score_counts (&context->direction, 31, &reverse, NULL, NULL) != 0)
     return;
   milan_match_apply_secondary (
     &context->direction, &reverse, 31,
@@ -1514,7 +1517,7 @@ milan_match_relaxed_feature (const MilanMatchDirection     *direction,
   pair_count = goodix_milan_match_relaxed_correspondences (
     direction->enrolled_records, direction->enrolled_record_count,
     direction->enrolled_partition_count, direction->probe_records,
-    direction->probe_record_count, direction->probe_partition_count, pairs);
+    direction->probe_record_count, direction->probe_partition_count, pairs, NULL);
   if (pair_count < 3 ||
       goodix_milan_filter_recognition_pairs (
         direction->enrolled_records, direction->probe_records, pairs,
@@ -2172,6 +2175,7 @@ milan_match_prepared_probe (
 
       GoodixMilanFeatureView feature;
       MilanMatchFeatureResult feature_result;
+      MilanMatchDistanceReduction primary_reductions[150];
       GoodixMilanMatchFallbackWorkspace *fallback_workspace = NULL;
       int32_t late_policy_state[3] = { 0 };
 #ifdef GOODIX53X5_DEBUG
@@ -2225,7 +2229,7 @@ milan_match_prepared_probe (
           fallback_pair_count = goodix_milan_match_relaxed_correspondences (
             enrolled_records, feature.record_count, enrolled_partition_count,
             probe_records, probe_record_count, probe_partition_count,
-            fallback_pairs);
+            fallback_pairs, primary_reductions);
           if (goodix_milan_match_fallback_store (
                 &match_fallback, (int32_t) feature_index, 0, fallback_pairs,
                 fallback_pair_count) != 0)
@@ -2258,6 +2262,9 @@ milan_match_prepared_probe (
             continue;
         }
       MilanMatchFeatureContext feature_context = {
+        .primary_reductions =
+          enrolled->metadata.sensor_type == GOODIX_MILAN_PRINT_SENSOR_TYPE ?
+          primary_reductions : NULL,
         .direction = {
           .enrolled_records = enrolled_records,
           .enrolled_record_count = feature.record_count,


### PR DESCRIPTION
## Change
The profile-9/type-12 matching path computes the same ordered enrolled/probe descriptor distances in its relaxed and primary correspondence passes. Accumulate the primary best/second-best/probe-index reductions during the existing relaxed scan, then consume them in the forward primary pass instead of evaluating those distances again.

The algorithms that select final correspondences remain separate and unchanged. This is local numeric reuse within one feature iteration, not a persistent cache, a validation shortcut or a change to matching policy. The layer follows #181 for review ordering; its correctness does not require that descriptor optimization.

## Equivalence
Both passes enumerate the same two partition rectangles. For each enrolled record, the producer sees eligible probes in ascending order, preserving the primary reduction sequence. Keep the asymmetric D(enrolled, probe), negative-distance rejection, 192/192/-1 sentinels, strict comparisons and duplicate-best handling exactly.

The summaries remain on the parent feature-iteration stack. The producer-to-consumer interval does not mutate either record array or invoke callbacks. Only the forward type-12 path receives summaries; reverse and other callers pass NULL and retain their existing computation. Existing validation precedes summary consumption. Actual counts are bounded by 150 and partitions by the corresponding counts.

Fallback-store failures, pre-primary exits, late-policy updates, spatial suppression/replacement, capacity ties and complete pair-output order are unchanged. No thresholds or public D-Bus behavior changes.

## Performance
One short interleaved release run, 31 measured pairs per existing workload, against immediate parent #181. All gallery sizes are acceptance workloads. Times below are milliseconds, baseline/candidate. CPU includes parsing through runtime completion; complete wall includes envelope setup and cleanup.

| Workload | Galleries | CPU median | CPU p95 | Complete wall median | Complete wall p95 | Paired wall saving |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Nonmatch | 1 | 26.655/24.898 | 29.403/27.538 | 27.624/26.055 | 30.236/28.787 | 1.951 |
| Nonmatch | 5 | 82.006/73.563 | 87.129/76.125 | 85.205/76.727 | 90.976/79.443 | 8.781 |
| Nonmatch | 10 | 151.426/135.133 | 161.121/146.246 | 158.084/141.378 | 168.056/153.539 | 16.795 |
| Winner-last | 1 | 21.329/20.660 | 23.415/24.548 | 21.606/20.976 | 23.611/25.019 | 0.551 |
| Winner-last | 5 | 78.657/70.001 | 82.612/73.618 | 81.721/73.045 | 85.761/76.889 | 9.155 |
| Winner-last | 10 | 146.047/128.909 | 158.088/142.259 | 152.492/134.353 | 164.147/148.248 | 18.172 |

CPU and complete-wall medians improve in every workload. Paired CPU savings are 1.627/8.910/16.878 ms for nonmatch and 0.428/9.096/17.523 ms for winner-last at 1/5/10 galleries. The fast one-gallery winner benefits less than 1 ms; this is not a universal minimum-gain requirement. Its p95 estimate worsens and is disclosed, but small noisy tails are not treated as blockers when medians improve across sizes. No extended tail campaign was run.

These are the existing synthetic repeated-gallery workloads on one host, not independent diverse fingers or measured lock-screen latency. The benefit depends on how many feature comparisons reach both passes. Computing reductions for a feature skipped before primary adds some bookkeeping without saving its second traversal; the measured complete results include that behavior.

## Resources And Validation
- A bounded 150-entry summary uses 1,800 bytes; measured prepared-probe frame grows 1,808 bytes, from 27,856 to 29,664. No distance matrix, heap allocation or persistent storage. Measured release text decreases 384 bytes.
- Two internal helper signatures gain an optional summary pointer. All in-tree callers are updated; out-of-tree direct helper callers would need updating.
- 624 executions passed complete exported-output comparisons, including warmups: 492 release and 132 debug. All 12 saved baseline/candidate snapshot pairs match byte-for-byte, including processed/gallery outputs in debug.
- Fresh isolated offline release build and all 120 existing cases passed: synthetic 8, state 6, runtime 7, fpi-device 99. No new tests or dependencies; no test caller updates were needed.
- Independent review found no issues in asymmetric distance, bounds, lifetime/aliasing, initialization, traversal/ties, failure ordering or output selection.
- Final source matches the measured candidate modulo formatter changes. All 103 driver files match the built overlay; diff checks pass. Only the upstream NBIS unused-variable warning remains in the build.

This is an exact current-to-current computation optimization, not a newly recovered native contract. Final integrated native parity and hardware UAT remain pre-merge gates. Installed software and the active capture were not changed.