### PR TITLE
Keep Milan anti-fake metrics zero without reciprocal pairs

### DIFF
--- a/drivers/goodix53x5/milan/antifake/pair.c
+++ b/drivers/goodix53x5/milan/antifake/pair.c
@@ -252,6 +252,9 @@ goodix_milan_antifake_pair_metrics (
                                                (size_t) current_index));
     }
   metrics[1] = (int32_t) distance_count;
+  if (distance_count == 0)
+    return 0;
+
   int32_t valid_total = prior_valid_count + current_valid_count;
 
   metrics[2] = valid_total == 0
@@ -262,11 +265,8 @@ goodix_milan_antifake_pair_metrics (
                  ? current_valid_count * 0x1000
                  : (prior_valid_count / 2 + current_valid_count * 0x1000) /
                      prior_valid_count;
-  if (distance_count != 0)
-    {
-      qsort (distances, distance_count, sizeof(distances[0]), compare_int32);
-      metrics[4] = distances[(distance_count - 1) / 2];
-    }
+  qsort (distances, distance_count, sizeof (distances[0]), compare_int32);
+  metrics[4] = distances[(distance_count - 1) / 2];
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Keep all five anti-fake comparison metrics zero when no reciprocal nearest pair
exists. Return before support aggregation in `goodix_milan_antifake_pair_metrics`
and remove the now-redundant conditional around lower-median selection.

This is a confirmed conditional profile-9/type-12 pair-boundary parity gap, not
an observed authentication failure. The public checked status convention and
`goodix_milan_antifake_score_pair` remain unchanged.

## Native Contract And Discriminator

Fresh instructions from the approved GoodixEngineAdapter.dll show that
`FUN_18003a3e0` branches past every store to metric words 2 through 4 when the
reciprocal pair count is zero (`0x18003a8ed..0x18003a951`). Its caller initializes
the output to zero. Current code previously published a nonzero directional
support ratio despite having no pair.

The focused proof uses full 88x104 support masks, identity Q8 affine, and
one-record blobs whose candidates and descriptors were produced by the actual
DLL helpers from synthetic residuals. Prior coordinate is (40,40).

| Current coordinate | Distance | Native metrics | Before | After | Scalar |
| --- | --- | --- | --- | --- | --- |
| (42,40) | 0x400 | [0,1,4096,4096,72] | same | same | 72 |
| (43,40) | 0x900 | [0,0,0,0,0] | [0,0,0,4096,0] | native-exact | -1 |

Native status reports pair presence (1/0); current status reports successful
evaluation (0 in both cases). The proof checks that correspondence explicitly,
as well as all five words, scalar status/value, output guards, both complete
input blobs, and the six-word affine.

## Validation

- 21,309/21,309 actual DLL/current comparisons match after correction, with no
  input mutations. Coverage includes all 10,000 populated count combinations
  for both paired and disjoint layouts, 1,283 signed Q8 translations, exact
  0x400/0x401 controls, reciprocal nearest ties, an unsupported first-record tie
  owner, packed-mask bits, lower medians, and signed/wrapped affine controls.
- The same 21,309 DLL-produced boundary fixtures match the Linux release-build
  pair object, and separately an ASan/UBSan build, with zero differences,
  mutations, or sanitizer findings.
- `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` passes
  using the existing pinned libfprint cache.
- `meson test -C .build/libfprint/builddir --print-errorlogs goodix53x5-milan-synthetic goodix53x5-milan-state goodix53x5-milan-runtime fpi-device` passes all four suites.
- Reviewed ownership, boundary behavior, dead code, performance opportunities,
  formatter output for the touched file, and the complete main-based diff;
  `git diff --check` passes. Pre-existing unrelated formatting is retained.

The initial build reports the existing NBIS unused-variable warning and skips
introspection-dependent driver tests because introspection is disabled. No
warning originates in the changed pair owner. The four explicitly selected
suites are built and run successfully. No tests or test cases were added.

## Scope And Limits

The finite controls prove the populated helper boundary, not all possible
affines, descriptor material, or ordinary image-to-authentication chronology.
The matcher forwards the five metrics to its blocker without overwriting the
support ratio, but no user-facing acceptance or study effect is claimed.
Downstream recognition/study owners, extraction, enrollment, and GTLS are not
changed. Candidate/descriptor producers were invoked only to establish valid
pair inputs.

The accepted `canonical-zero-v1` anti-fake policy and all-zero PSK Linux fallback
are preserved. Performance opportunities are documented locally only; no
optimization or benchmark is included. Final corpus and UAT gates are deferred
because this PR is not being merged. Full corpus and fresh UAT remain required before merge.

Native contract notes were published separately on `milan-dev` in `7809b302`.
This independent PR is based directly on `main` and contains only `pair.c`, no
reverse-engineering notes, local Markdown, proof harnesses, or private artifacts.