### PR TITLE
Return zero Milan low-bitmap metrics for empty support

### DIFF
--- a/drivers/goodix53x5/milan/match/overlap.c
+++ b/drivers/goodix53x5/milan/match/overlap.c
@@ -521,12 +521,13 @@ goodix_milan_match_low_bitmap_metrics (
 
   if (!metrics || milan_match_low_bitmap_compute (
         enrolled_bitmap, enrolled_inline_mask, probe_bitmap, probe_inline_mask,
-        transform, NULL, classes, NULL, NULL) != 0 ||
-      classes[4] == 0)
+        transform, NULL, classes, NULL, NULL) != 0)
     return -1;
 
-  metrics[0] = (classes[4] / 2 + (classes[0] + classes[3]) * 0x100) /
-               classes[4];
+  metrics[0] = classes[4] > 0 ?
+               (classes[4] / 2 + (classes[0] + classes[3]) * 0x100) /
+               classes[4] :
+               0;
   int32_t zero_total = classes[0] + classes[1] + classes[2];
   int32_t one_total = classes[1] + classes[2] + classes[3];
   metrics[1] = zero_total > 0


### PR DESCRIPTION
## Summary

Return a successful zero-valued low-bitmap metric triple when valid image owners produce an empty shared classification. Keep actual computation failures as failures and preserve positive-support integer arithmetic.

Previously, a successful classification with zero support returned an error without writing the metric destination. Native instead writes three zeros and returns success. Remove that extra rejection and guard the first ratio's denominator, matching the other two ratios.

## Functional Evidence

This is a conditional helper-boundary proof, not a claim that an ordinary complete matcher transaction reaches this case. The helper requires valid image owners, masks, dimensions, affine and output storage; records and admission metadata are not inputs, and positive shared mask support is not a precondition.

Two image pairs use actual base-map producer output, nonempty masks, identity geometry and actual native/current crop and classification. A one-mask-block texture-boundary change distinguishes zero support from an adjacent positive-support control. Both retain a full 52x44 crop.

- Zero classes and total: all zero; expected metrics `[0, 0, 0]` with success.
- Control classes: `[18, 0, 0, 69]`, total87; metrics `[256, 256, 256]` with success.
- Four wrapper calls cover zeroed and dirty destinations: two differences before, none after.
- Eight bitmap/validity matrices, totaling18,304 active bytes, match exactly.
- Full guarded metric workspace compared; only the three designated words change. Input owners, affine and mode remain immutable.
- Two existing complete-feature positive comparisons also match.

The native contract note was published separately on milan-dev. This PR contains production code only.

## Validation

- Offline debug-disabled release build using the existing pinned libfprint cache.
- All four existing suites passed: Milan synthetic8, state6, runtime7 and fpi-device99, totaling120 cases.
- Direct-source focused proof passed ASan/UBSan and matched optimized output.
- Changed-hunk formatting and `git diff --check` passed; no changed-driver compiler warnings.
- Reviewed aggregate overlap, study duplicate-metric and fallback consumers for status/output ownership.

No maintained tests, dependency changes, optimization or policy changes. Ordinary matcher reachability, candidate/policy implications and full-corpus UAT remain unproven/deferred.
