### PR TITLE
Initialize adaptive history defaults when restoring Milan state

### DIFF
--- a/drivers/goodix53x5/device/persistence.c
+++ b/drivers/goodix53x5/device/persistence.c
@@ -498,6 +498,9 @@ goodix_milan_persistence_restore (FpDevice              *dev,
 
   restored = g_new (GoodixMilanPreprocessState, 1);
   goodix_milan_preprocess_reset (restored);
+  /* Native import retains these fresh-DLL defaults, not persisted values. */
+  restored->profile9_history_mask_threshold = 60;
+  restored->profile9_history_mask_average = 60;
   restored->sample_count = goodix_milan_read_u32 (
     contents + GOODIX_MILAN_STATE_SAMPLE_COUNT_OFFSET);
   for (gsize i = 0; i < GOODIX_MILAN_SENSOR_PIXELS; i++)


### PR DESCRIPTION
## Summary

Initialize the nonpersisted adaptive reference threshold and running coverage average to 60 when publishing successfully restored Milan preprocessing state.

The profile-9/type-12 native importer restores retained counts, age planes, history planes, and the reconstructed reference, but leaves both adaptive scalars at their fresh-DLL initialized values of 60. Current restore instead zeroed both via `goodix_milan_preprocess_reset`. These fields feed the subsequent retained-reference update gate and running average.

This is a confirmed conditional persistence-publication parity gap, not an observed live-device regression. The change is confined to successful restore. It does not change the persisted format, reference arithmetic, validation, missing-state behavior, source ownership, or refresh scheduling.

## Validation

- Fresh approved-DLL serializer/importer execution against 366 valid retained-state cases generated by actual current producer helpers from synthetic planes, including empty and populated history and capped counts.
- Complete comparison of 869,616 downsampled words and 3,478,464 reconstructed words, including every edge; all retained counts, history/age planes, descriptor mutations, untouched native workspace ranges, and source ownership checked.
- Current save/restore executed with in-memory filesystem shims; all 202,324 state bytes checked per case. Before correction, all 366 publications had adaptive 0/0 rather than 60/60. After correction, no differences. The no-identity no-publication control remains unchanged.
- 729,151 finite signed-arithmetic and valid packed-field checks; focused ASan/UBSan replay clean.
- Offline debug-disabled build using the existing pinned libfprint cache passed. Existing Milan synthetic/state/runtime and fpi-device suites passed: 8/6/7/99 cases, 120 total. No new maintained tests or dependencies.
- Exact-file formatter comparison confirms the added block is formatter-stable; pre-existing formatting differences were left untouched. `git diff --check` passed. The build emitted the existing upstream NBIS unused-variable warning.

## Scope And Limits

The evidence covers the real retained-state helper boundary through semantic persistence publication, not Windows/Linux file-byte equivalence, complete native preprocessing, live sensor chronology, or subsequent matching. Calibration/sample publication is checked as current passthrough, not a new native calibration audit. Filesystem/security behavior, malformed inputs, OTP, refresh consumption timing, and deferred policy questions are excluded. Full strict corpus and fresh UAT remain pre-merge gates; no such pass is claimed.

Native contracts were published separately on `milan-dev` in `cdab0d27`. This independent main-based PR contains only the production restore change. Existing PRs #183 and #184 are unchanged.
