### PR TITLE
Stream Milan extrema directly into materialization

### DIFF
--- a/drivers/goodix53x5/milan/feature/extrema.c
+++ b/drivers/goodix53x5/milan/feature/extrema.c
@@ -33,8 +33,6 @@ enum {
   HESSIAN_COUNT,
 };
 
-#define EXTREMA_SCAN_BORDER 6
-#define EXTREMA_FIRST_SCALE 1
 #define EXTREMA_SCALE_LIMIT 4
 #define EXTREMA_RESPONSE_THRESHOLD 0x148
 #define DERIVATIVE_LIMIT 0x8000
@@ -55,25 +53,24 @@ enum {
 #define REFINEMENT_SCALE_FACTOR 0x13333
 #define REFINEMENT_Q16_SHIFT 16
 
-size_t
-goodix_milan_feature_collect_extrema (
+int
+feature_next_extremum (
   const uint16_t             *scales,
   size_t                      rows,
   size_t                      columns,
-  GoodixMilanFeatureExtremum *extrema,
-  size_t                      capacity)
+  size_t                      cursor[3],
+  GoodixMilanFeatureExtremum *result)
 {
   size_t count;
-  size_t result_count = 0;
 
   count = rows * columns;
-  for (size_t scale = EXTREMA_FIRST_SCALE;
+  for (size_t scale = cursor[0];
        scale < EXTREMA_SCALE_LIMIT;
-       scale++)
-    for (size_t row = EXTREMA_SCAN_BORDER;
+       scale++, cursor[1] = EXTREMA_SCAN_BORDER)
+    for (size_t row = cursor[1];
          row + EXTREMA_SCAN_BORDER < rows;
-         row++)
-      for (size_t column = EXTREMA_SCAN_BORDER;
+         row++, cursor[2] = EXTREMA_SCAN_BORDER)
+      for (size_t column = cursor[2];
            column + EXTREMA_SCAN_BORDER < columns;
            column++)
         {
@@ -108,12 +105,36 @@ goodix_milan_feature_collect_extrema (
                 }
           if (!extremum)
             continue;
-          if (result_count < capacity && extrema)
-            extrema[result_count] = (GoodixMilanFeatureExtremum){
-              (int32_t) column, (int32_t) row, (int32_t) scale, response,
-            };
-          result_count++;
+          *result = (GoodixMilanFeatureExtremum){
+            (int32_t) column, (int32_t) row, (int32_t) scale, response,
+          };
+          cursor[0] = scale;
+          cursor[1] = row;
+          cursor[2] = column + 1;
+          return 1;
         }
+  cursor[0] = EXTREMA_SCALE_LIMIT;
+  return 0;
+}
+
+size_t
+goodix_milan_feature_collect_extrema (
+  const uint16_t             *scales,
+  size_t                      rows,
+  size_t                      columns,
+  GoodixMilanFeatureExtremum *extrema,
+  size_t                      capacity)
+{
+  size_t cursor[3] = FEATURE_EXTREMA_CURSOR_INIT;
+  GoodixMilanFeatureExtremum extremum;
+  size_t result_count = 0;
+
+  while (feature_next_extremum (scales, rows, columns, cursor, &extremum))
+    {
+      if (result_count < capacity && extrema)
+        extrema[result_count] = extremum;
+      result_count++;
+    }
   return result_count;
 }
 

--- a/drivers/goodix53x5/milan/feature/feature.h
+++ b/drivers/goodix53x5/milan/feature/feature.h
@@ -48,6 +48,19 @@ typedef struct
   int32_t response;
 } GoodixMilanFeatureExtremum;
 
+#define EXTREMA_SCAN_BORDER 6
+#define EXTREMA_FIRST_SCALE 1
+#define FEATURE_EXTREMA_CURSOR_INIT \
+  { EXTREMA_FIRST_SCALE, EXTREMA_SCAN_BORDER, EXTREMA_SCAN_BORDER }
+
+/* Cursor order is scale, row, column. Keep the planes and dimensions unchanged
+ * between calls; a zero return leaves the cursor exhausted. */
+int feature_next_extremum (const uint16_t             *scales,
+                           size_t                      rows,
+                           size_t                      columns,
+                           size_t                      cursor[3],
+                           GoodixMilanFeatureExtremum *extremum);
+
 size_t goodix_milan_feature_collect_extrema (const uint16_t             *scales,
                                              size_t                      rows,
                                              size_t                      columns,

--- a/drivers/goodix53x5/milan/feature/materialization.c
+++ b/drivers/goodix53x5/milan/feature/materialization.c
@@ -193,25 +193,18 @@ goodix_milan_feature_collect_materialized (
   GoodixMilanFeatureAux    *auxiliary,
   size_t                    capacity)
 {
-  size_t extrema_count = goodix_milan_feature_collect_extrema (
-    scales, rows, columns, NULL, 0);
-  GoodixMilanFeatureExtremum *extrema =
-    malloc (extrema_count * sizeof(*extrema));
+  size_t cursor[3] = FEATURE_EXTREMA_CURSOR_INIT;
+  GoodixMilanFeatureExtremum extremum;
   uint8_t *visited = calloc (rows * columns, 1);
   size_t count = 0;
 
-  if (!extrema || !visited)
-    {
-      free (visited);
-      free (extrema);
-      return 0;
-    }
-  goodix_milan_feature_collect_extrema (scales, rows, columns, extrema,
-                                        extrema_count);
-  for (size_t i = 0; i < extrema_count && count < capacity; i++)
+  if (!visited)
+    return 0;
+  while (count < capacity &&
+         feature_next_extremum (scales, rows, columns, cursor, &extremum))
     {
       GoodixMilanFeatureCandidate candidate = {
-        extrema[i].x, extrema[i].y, extrema[i].scale, extrema[i].response,
+        extremum.x, extremum.y, extremum.scale, extremum.response,
         0, 0, 0,
       };
       uint32_t curvature = 0;
@@ -229,7 +222,6 @@ goodix_milan_feature_collect_materialized (
       count++;
     }
   free (visited);
-  free (extrema);
   return count;
 }
 


### PR DESCRIPTION
## Summary

Stream extrema directly into materialization instead of scanning the scale planes twice and allocating an intermediate extrema array. Stop discovery only when accepted, unique materializations reach capacity; rejected and duplicate candidates do not consume capacity.

The existing count-query/prefix-fill collector retains its full-count and ordered-prefix contract. Refinement, materialization, duplicate ownership, candidate initialization and immutable input ownership remain unchanged. The remaining visited allocation is checked before output writes and freed on every completion path. Removing the extrema allocation also removes its possible allocation-failure outcome.

Independent of #183, #184 and #185, and of the geometry performance change.

## Measured Benefit

Timed the complete `goodix_milan_match_extract_native_result` call, including internal allocations and complete result construction, on four existing runtime-suite synthetic images with their actual preprocessing-produced caller state. These are extraction timings, **not end-to-end finger-scan or authentication latency**.

| Existing Image | Baseline Median | Streaming Median | Median Paired Saving | Baseline / Streaming p95 |
| --- | ---: | ---: | ---: | ---: |
| 0 | 8.471 ms | 8.146 ms | 0.303 ms | 14.650 / 14.268 ms |
| 1 | 8.303 ms | 8.002 ms | 0.313 ms | 11.593 / 9.833 ms |
| 2 | 8.276 ms | 7.978 ms | 0.293 ms | 9.816 / 9.353 ms |
| 3 | 8.339 ms | 8.002 ms | 0.304 ms | 9.875 / 9.469 ms |

Approximately **0.3 ms, or 3.5-3.8%, saved per measured extraction**. All 24 image/repetition median comparisons favored streaming.

Method: Intel Core i5-1135G7, GCC 16.2.1, actual debug-disabled production `-O2` flags, CPU 3 pinned. Six repetitions with adjacent alternating AB/BA calls, warmup and settling; 720 measured calls per image per implementation, 5,760 extractions total. All agent builds/proofs finished before timing and no other agent benchmark ran concurrently. A shared lock serialized timing. Caller-state reset, output inspection, logging and caller-side freeing were outside the timer.

The four related dense images contain 564-597 extrema; all reach 300 materializations and produce 150 records. This is not a measured live/sparse-image distribution. Normal background activity, SMT-sibling use and automatic CPU-frequency changes remained enabled. Baseline/current sample variances ranged 1.210-6.034 / 0.569-6.018 ms squared; no reliable tail-latency claim is made. Paired savings are reported separately from differences between pooled medians.

## Native Parity And Validation

Fresh approved GoodixEngineAdapter.dll execution for sensor type 12 / profile 9 matched the changed implementation across **1,024 image/pass comparisons, 87,404 complete refinements and 61,638 ordered candidate handoffs**. The 5,120 capacity calls cover 1, 2, 7, 299 and 300, including 484 duplicate suppressions and complete visited planes. Existing count/full-fill/prefix values and overwrite guards also match. Fresh outputs pass ASan/UBSan replay.

Complete baseline/current extraction comparisons cover result metadata, full serialized templates, records, caller-state mutations and inputs for all four timed image families. These comparisons are separate from the native pre-orientation handoff proof; they do not establish complete native extraction parity. Inputs were checked immutable on every timed call.

Passed the offline debug-disabled build using the pinned existing dependency cache and all four existing suites: synthetic 8, state 6, runtime 7, fpi-device 99 (**120 cases**). No new tests or dependencies. Changed-line formatter and whitespace checks passed.

Existing native cases do not exercise derivative-range rejection; allocation failures received ownership review, not new fault-injection cases. The strict recorded-operation corpus and fresh hardware UAT remain pre-merge gates. This PR is draft pending review and those integration gates.
