### PR TITLE
Reuse immutable Milan recognition triangle edges

### DIFF
--- a/drivers/goodix53x5/milan/match/geometry.c
+++ b/drivers/goodix53x5/milan/match/geometry.c
@@ -547,101 +547,122 @@ goodix_milan_filter_recognition_pairs_internal (
       if (triangle_count >= MILAN_RECOGNITION_TRIANGLE_LIMIT)
         break;
       for (size_t second = first + 1; second + 1 < match_count; second++)
-        for (size_t third = second + 1; third < match_count; third++)
-          {
-            const size_t selected[3] = { first, second, third };
-            int32_t source[6];
-            int32_t target[6];
-            int32_t orientation_differences[3];
-            int32_t affine[6];
-            int inliers = 0;
-            int64_t residual_sum = 0;
-            uint8_t mask[MILAN_MATCH_MAX_PAIRS] = { 0 };
+        {
+          const size_t edge[2] = { first, second };
+          int32_t source[6];
+          int32_t target[6];
+          int32_t edge_orientations[2];
 
-            for (size_t i = 0; i < 3; i++)
+          for (size_t i = 0; i < 2; i++)
+            {
+              int32_t enrolled_index = pairs[edge[i] * 2];
+              int32_t probe_index = pairs[edge[i] * 2 + 1];
+
+              source[i * 2] =
+                (uint16_t) probe_records[probe_index].refined_x;
+              source[i * 2 + 1] =
+                (uint16_t) probe_records[probe_index].refined_y;
+              target[i * 2] =
+                (uint16_t) enrolled_records[enrolled_index].refined_x;
+              target[i * 2 + 1] =
+                (uint16_t) enrolled_records[enrolled_index].refined_y;
+              edge_orientations[i] = milan_normalize_orientation_difference (
+                enrolled_records[enrolled_index].orientation -
+                probe_records[probe_index].orientation,
+                MILAN_ORIENTATION_HALF_PERIOD, MILAN_ORIENTATION_PERIOD);
+            }
+          if (!milan_triangle_edge_is_consistent (
+                milan_triangle_distance_shift_then_add (
+                  source[0], source[1], source[2], source[3]),
+                milan_triangle_distance_shift_then_add (
+                  target[0], target[1], target[2], target[3])))
+            continue;
+          for (size_t third = second + 1; third < match_count; third++)
+            {
+              /* The orientation retry mutates its per-triangle scratch. */
+              int32_t orientation_differences[3] = {
+                edge_orientations[0], edge_orientations[1], 0
+              };
+              int32_t affine[6];
+              int inliers = 0;
+              int64_t residual_sum = 0;
+              uint8_t mask[MILAN_MATCH_MAX_PAIRS] = { 0 };
+
               {
-                int32_t enrolled_index = pairs[selected[i] * 2];
-                int32_t probe_index = pairs[selected[i] * 2 + 1];
+                int32_t enrolled_index = pairs[third * 2];
+                int32_t probe_index = pairs[third * 2 + 1];
 
-                source[i * 2] =
-                  (uint16_t) probe_records[probe_index].refined_x;
-                source[i * 2 + 1] =
-                  (uint16_t) probe_records[probe_index].refined_y;
-                target[i * 2] =
-                  (uint16_t) enrolled_records[enrolled_index].refined_x;
-                target[i * 2 + 1] =
-                  (uint16_t) enrolled_records[enrolled_index].refined_y;
-                orientation_differences[i] =
+                source[4] = (uint16_t) probe_records[probe_index].refined_x;
+                source[5] = (uint16_t) probe_records[probe_index].refined_y;
+                target[4] = (uint16_t) enrolled_records[enrolled_index].refined_x;
+                target[5] = (uint16_t) enrolled_records[enrolled_index].refined_y;
+                orientation_differences[2] =
                   milan_normalize_orientation_difference (
                     enrolled_records[enrolled_index].orientation -
                       probe_records[probe_index].orientation,
-                     MILAN_ORIENTATION_HALF_PERIOD, MILAN_ORIENTATION_PERIOD);
+                    MILAN_ORIENTATION_HALF_PERIOD, MILAN_ORIENTATION_PERIOD);
               }
-            if (!milan_triangle_edge_is_consistent (
-                  milan_triangle_distance_shift_then_add (
-                    source[0], source[1], source[2], source[3]),
-                  milan_triangle_distance_shift_then_add (
-                    target[0], target[1], target[2], target[3])) ||
-                !milan_triangle_edge_is_consistent (
-                  milan_triangle_distance_shift_then_add (
-                    source[0], source[1], source[4], source[5]),
-                  milan_triangle_distance_shift_then_add (
-                    target[0], target[1], target[4], target[5])) ||
-                !milan_triangle_edge_is_consistent (
-                  milan_triangle_distance_add_then_shift (
-                    source[2], source[3], source[4], source[5]),
-                  milan_triangle_distance_add_then_shift (
-                    target[2], target[3], target[4], target[5])) ||
-                !milan_triangle_orientations_are_consistent (
-                  orientation_differences))
-              continue;
-            triangle_count++;
-            milan_affine_from_three_points (source, target, affine);
-            if (!milan_triangle_affine_is_consistent (affine))
-              continue;
-            for (size_t i = 0; i < match_count; i++)
-              {
-                int32_t enrolled_index = pairs[i * 2];
-                int32_t probe_index = pairs[i * 2 + 1];
-                int32_t x = (uint16_t) probe_records[probe_index].refined_x;
-                int32_t y = (uint16_t) probe_records[probe_index].refined_y;
-                int64_t transformed_x =
-                  (((int64_t) affine[0] * x +
-                    (int64_t) affine[1] * y + 0x80) >> 8) + affine[2];
-                int64_t transformed_y =
-                  (((int64_t) affine[3] * x +
-                    (int64_t) affine[4] * y + 0x80) >> 8) + affine[5];
-                int64_t dx = transformed_x -
-                  (uint16_t) enrolled_records[enrolled_index].refined_x;
-                int64_t dy = transformed_y -
-                  (uint16_t) enrolled_records[enrolled_index].refined_y;
-                int64_t squared = dx * dx + dy * dy;
+              if (!milan_triangle_edge_is_consistent (
+                    milan_triangle_distance_shift_then_add (
+                      source[0], source[1], source[4], source[5]),
+                    milan_triangle_distance_shift_then_add (
+                      target[0], target[1], target[4], target[5])) ||
+                  !milan_triangle_edge_is_consistent (
+                    milan_triangle_distance_add_then_shift (
+                      source[2], source[3], source[4], source[5]),
+                    milan_triangle_distance_add_then_shift (
+                      target[2], target[3], target[4], target[5])) ||
+                  !milan_triangle_orientations_are_consistent (
+                    orientation_differences))
+                continue;
+              triangle_count++;
+              milan_affine_from_three_points (source, target, affine);
+              if (!milan_triangle_affine_is_consistent (affine))
+                continue;
+              for (size_t i = 0; i < match_count; i++)
+                {
+                  int32_t enrolled_index = pairs[i * 2];
+                  int32_t probe_index = pairs[i * 2 + 1];
+                  int32_t x = (uint16_t) probe_records[probe_index].refined_x;
+                  int32_t y = (uint16_t) probe_records[probe_index].refined_y;
+                  int64_t transformed_x =
+                    (((int64_t) affine[0] * x +
+                      (int64_t) affine[1] * y + 0x80) >> 8) + affine[2];
+                  int64_t transformed_y =
+                    (((int64_t) affine[3] * x +
+                      (int64_t) affine[4] * y + 0x80) >> 8) + affine[5];
+                  int64_t dx = transformed_x -
+                    (uint16_t) enrolled_records[enrolled_index].refined_x;
+                  int64_t dy = transformed_y -
+                    (uint16_t) enrolled_records[enrolled_index].refined_y;
+                  int64_t squared = dx * dx + dy * dy;
 
-                if (llabs (dx) < MILAN_RECOGNITION_INLIER_AXIS_LIMIT &&
-                    llabs (dy) < MILAN_RECOGNITION_INLIER_AXIS_LIMIT &&
-                    squared < MILAN_RECOGNITION_INLIER_SQUARED_LIMIT)
-                  {
-                    inliers++;
-                    residual_sum += squared;
-                    mask[i] = 1;
-                  }
-              }
-            int residual = inliers == 0
-                             ? MILAN_RECOGNITION_NO_MODEL_RESIDUAL
-                             : (int) ((residual_sum + (inliers >> 1)) /
-                                      inliers);
-            if ((inliers > best_inliers ||
-                 (inliers == best_inliers && residual < *best_residual)) &&
-                milan_affine_is_valid (affine))
-              {
-                best_inliers = inliers;
-                *best_residual = residual;
-                memcpy (best_affine, affine, 6 * sizeof(*best_affine));
-                memcpy (best_mask, mask, sizeof(best_mask));
-              }
-            if (best_inliers > MILAN_RECOGNITION_EARLY_INLIER_COUNT)
-              goto done;
-          }
+                  if (llabs (dx) < MILAN_RECOGNITION_INLIER_AXIS_LIMIT &&
+                      llabs (dy) < MILAN_RECOGNITION_INLIER_AXIS_LIMIT &&
+                      squared < MILAN_RECOGNITION_INLIER_SQUARED_LIMIT)
+                    {
+                      inliers++;
+                      residual_sum += squared;
+                      mask[i] = 1;
+                    }
+                }
+              int residual = inliers == 0
+                               ? MILAN_RECOGNITION_NO_MODEL_RESIDUAL
+                               : (int) ((residual_sum + (inliers >> 1)) /
+                                        inliers);
+              if ((inliers > best_inliers ||
+                   (inliers == best_inliers && residual < *best_residual)) &&
+                  milan_affine_is_valid (affine))
+                {
+                  best_inliers = inliers;
+                  *best_residual = residual;
+                  memcpy (best_affine, affine, 6 * sizeof(*best_affine));
+                  memcpy (best_mask, mask, sizeof(best_mask));
+                }
+              if (best_inliers > MILAN_RECOGNITION_EARLY_INLIER_COUNT)
+                goto done;
+            }
+        }
     }
 done:
   if (model_valid)


### PR DESCRIPTION
## Summary

Reuse immutable first/second-pair coordinates and normalized orientations, and evaluate their edge gate once per second index rather than once per third index. Reject an inconsistent first edge before entering the third-index loop, matching the native loop's placement.

The orientation retry still receives fresh per-triangle scratch. Surviving triangle order, nonuniform edge rounding, budget increments and checks, residual ties, strict greater-than-20 early exit, affine selection, orientation filtering and refinement remain unchanged. No new helper, persistent cache, allocation or borrowed lifetime.

Independent of #183, #184 and #185, and of extrema streaming. Native contract documentation was published separately on `milan-dev`; no RE notes are included here.

## Measured Benefit

Timed complete `goodix_milan_match_serialized_feature_result_queued` calls using existing runtime-suite probe pattern 0 and individual galleries for patterns 0-2. Actual extraction-produced records, metadata and caller-initialized queues are shared identically between implementations. Each complete match makes one geometry call; this is **not a repeated-gallery extrapolation**.

| Gallery Pattern | Baseline Median / p95 | Optimized Median / p95 | Median Paired Saving |
| --- | ---: | ---: | ---: |
| 0 | 0.722 / 0.744 ms | 0.722 / 0.744 ms | Within noise |
| 1 | 0.708 / 0.732 ms | 0.703 / 0.725 ms | 0.005 ms |
| 2 | 1.244 / 1.273 ms | 1.083 / 1.109 ms | **0.157 ms** |

The geometry-heavy pattern saves approximately **13% of its complete per-gallery matching time**. Its paired median savings range **0.092-0.165 ms across six runs**; pooled paired p05-p95 savings are 0.083-0.190 ms. Easy matches have little or no benefit.

Method: Intel Core i5-1135G7, GCC 16.2.1, actual production `-O2 -g -fPIC -fno-strict-aliasing` flags. CPU 2 pinned, settling and 40 warmup pairs per pattern/run, six runs of 300 adjacent alternating AB/BA pairs per pattern: **5,400 complete baseline/current pairs**. A shared lock serialized timing; all builds, native proofs and suites finished before measurement, with no concurrent agent benchmarks or builds.

Normal frequency scaling, SMT-sibling activity and background outliers remained, with no sample trimming or system-setting changes. In the faster-frequency run, pattern 2 medians were 0.712 -> 0.622 ms; absolute savings are not machine-independent. The measured boundary includes ordinary template handling and matching/after-match work but excludes extraction, setup/copying, output inspection, USB, study execution and the enclosing identify/verify lifecycle. These synthetic patterns are not a measured live-user/gallery distribution and do not establish end-to-end authentication latency savings.

## Native Parity And Validation

Fresh instruction review and approved DLL execution for sensor type 12 / profile 9 matched **1,280 complete native/current geometry cases with zero differences**: return count, six affine words, robust residual, pre-orientation validity, all 42 mask bytes including unused tails, and complete immutable record/pair inputs.

The existing proof covers 51,173 selected pairs, 103,762 ordered native fits, two exact count/residual ties, 32 budget exits, 738 above-20 exits, 270 orientation removals, 599 refinement calls (573 replacements and 26 no-write outcomes), and 197 no-model cases. ASan/UBSan replay passes the same boundary.

Every timed complete matching pair also compares status, result fields, after-match bytes, probe fields/template/records and full queue contents outside the timer. An untimed comparison checks the complete geometry boundary on the actual matching caller's inputs.

Passed the offline debug-disabled pinned build and the existing synthetic 8, state 6, runtime 7 and fpi-device 99 suites (**120 cases**). No new tests or dependencies. Only the existing upstream NBIS unused-variable warning was observed. Changed-line formatter and whitespace checks passed.

This is bounded geometry parity plus baseline/current complete matching equivalence, not full native matching or live-driver parity. Existing executable coverage excludes pair counts below 10, exact orientation-threshold neighbors and singular refinement. The strict recorded-operation corpus and fresh hardware UAT remain pre-merge gates; this PR is draft pending review and those integration gates.
