### PR TITLE
Only label supported chip families in the Goodix detector

### DIFF
--- a/scripts/goodix53x5-detect.c
+++ b/scripts/goodix53x5-detect.c
@@ -609,8 +609,13 @@ print_report (const ProbeReport *report,
   if (report->firmware && report->firmware[0] != '\0')
     g_print ("Firmware %s\n", report->firmware);
   if (report->chip_id != 0)
-    g_print ("Chip 0x%08x | Milan profile 9 | sensor type 12\n",
-             report->chip_id);
+    {
+      g_print ("Chip 0x%08x", report->chip_id);
+      if ((report->chip_id & MILAN_CHIP_FAMILY_MASK) ==
+          MILAN_CHIP_FAMILY_PREFIX)
+        g_print (" | Milan profile 9 | sensor type 12");
+      g_print ("\n");
+    }
   if (system_name)
     g_print ("System %s | Linux %s\n", system_name, kernel_release);
 


### PR DESCRIPTION
## Summary
- Print the chip ID for every nonzero chip response, but append Milan profile 9 / sensor type 12 only when `(chip_id & 0xffffff00u) == 0x00220c00u`.
- Reuse the existing detector family constants, matching the Linux driver chip-family gate.
- Leave other families unlabeled rather than importing incompatible enum numbering from other Windows driver versions. Compatibility decisions and USB probing are unchanged.

## Validation
- Compiled with the wrapper flags: `-std=gnu11 -O2 -Wall -Wextra -Werror` and GUsb.
- Existing `--self-test` passed; it does not exercise report formatting.
- `git diff --check` passed.
- No hardware access or new tests. The PR contains only the detector source change; local investigation notes and driver binaries are excluded.