### PR TITLE
Preserve Milan configuration defaults for absent calibration

### DIFF
--- a/drivers/goodix53x5/device/calibration.c
+++ b/drivers/goodix53x5/device/calibration.c
@@ -220,6 +220,7 @@ goodix_device_parse_otp (const guint8      *otp,
     {
       params->dac_h = ((guint16) otp[17] << 8 ^ otp[22]) & 0x1FF;
       params->dac_l = ((otp[17] & 0x40) << 2) ^ otp[31];
+      params->dac_from_otp = TRUE;
     }
 
   if (params->tcode != 0)
@@ -293,17 +294,23 @@ goodix_device_fix_config_checksum (guint8 *config,
  * Apply calibration parameters to the config buffer.
  */
 void
-goodix_device_patch_config (guint8              *config,
-                            gsize                config_len,
+goodix_device_patch_config (guint8                  *config,
+                            gsize                    config_len,
                             const GoodixCalibParams *params)
 {
-  replace_value_in_section (config, config_len, 2, TCODE_TAG, params->tcode);
-  replace_value_in_section (config, config_len, 3, TCODE_TAG, params->tcode);
-  replace_value_in_section (config, config_len, 4, TCODE_TAG, params->tcode);
-  replace_value_in_section (config, config_len, 2, DAC_L_TAG,
-                            (params->dac_l << 4) | 8);
-  replace_value_in_section (config, config_len, 3, DAC_L_TAG,
-                            (params->dac_l << 4) | 8);
+  if (params->tcode != 0)
+    {
+      replace_value_in_section (config, config_len, 2, TCODE_TAG, params->tcode);
+      replace_value_in_section (config, config_len, 3, TCODE_TAG, params->tcode);
+      replace_value_in_section (config, config_len, 4, TCODE_TAG, params->tcode);
+    }
+  if (params->dac_from_otp)
+    {
+      replace_value_in_section (config, config_len, 2, DAC_L_TAG,
+                                (params->dac_l << 4) | 8);
+      replace_value_in_section (config, config_len, 3, DAC_L_TAG,
+                                (params->dac_l << 4) | 8);
+    }
   replace_value_in_section (config, config_len, 2, DELTA_DOWN_TAG,
                             (params->delta_down << 8) | 0x80);
 

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -50,15 +50,16 @@
 /* --- Calibration parameters (from OTP) --- */
 typedef struct
 {
-  guint16 tcode;
-  guint16 delta_fdt;
-  guint16 delta_down;
-  guint16 delta_up;
-  guint16 delta_img;
-  guint16 delta_nav;
-  guint16 dac_h;
-  guint16 dac_l;
-  guint16 dac_delta;
+  guint16  tcode;
+  guint16  delta_fdt;
+  guint16  delta_down;
+  guint16  delta_up;
+  guint16  delta_img;
+  guint16  delta_nav;
+  guint16  dac_h;
+  guint16  dac_l;
+  guint16  dac_delta;
+  gboolean dac_from_otp;
 } GoodixCalibParams;
 
 /* --- Command descriptor for sub-SSM --- */


### PR DESCRIPTION
## Summary

Preserve the native profile-9 configuration defaults when calibration does not authorize replacing them.

- Leave the three template TCODE values unchanged when the initialized TCODE is zero.
- Retain whether the DAC values came from packed OTP fields, and replace the two configuration low-DAC values only when that provenance is present.
- Keep all numeric calibration calculations, fallback DAC values, delta-down patching and checksum arithmetic unchanged.

This is a standalone correction based on `main`; it does not depend on the temporal-threshold correction.

## Native Contract And Impact

The approved Windows 2.0.310.900 USB driver's `Milan_DlCfg` preserves template fields behind two explicit guards: nonzero TCODE and packed-DAC validity. The current driver overwrites both fields unconditionally.

Successful calibration can produce TCODE zero. It can also produce numeric low DAC `0xd0` either from a valid packed OTP value or from fallback. The numeric DAC alone therefore cannot recover the native validity predicate. The new private `dac_from_otp` field is cleared by the existing calibration initialization and set only by the packed-DAC branch.

Both differences survive into the complete 256-byte configuration handed to the download consumer. The fallback-DAC case changes two bytes without changing the checksum, so checksum equality alone does not establish configuration parity.

The calibration struct is private and is not the persisted-state encoding. Its numeric field offsets remain unchanged, and no persistence or runtime-debug schema migration is needed. The full library rebuild covers its changed private layout.

Native contracts are documented separately on [milan-dev](https://github.com/seaweeduk/goodix53x5-libfprint/blob/milan-dev/re/milan/functions/usbinterface-FUN_180005094.md); no reverse-engineering notes or private artifacts are included in this PR.

## Validation

- Executed the real native calibration producer, selected-template copier and configuration serializer with sensor/file input and download capture stubbed locally. No hardware I/O occurred.
- Compared complete native/current configuration records across 776 focused cases and finite single-byte slices. Baseline: eight mismatches. Corrected: 776/776 exact matches.
- Confirmed all nine numeric calibration fields remain unchanged and match native output; checked provenance, poisoned initialization, input preservation and destination canaries.
- Corrected ASan/UBSan output matches all 776 native records.
- This standalone branch passes `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` and all 120 existing cases across the Milan synthetic, state, runtime and `fpi-device` suites.
- Focused harnesses remain temporary, as requested; no tracked tests or concurrent CI-test changes are included.

## Draft Limitations

This proves a conditional, valid synthetic producer-to-configuration difference, not its frequency on physical sensors or a demonstrated user-visible device failure. Warm retained calibration and complete device-open chronology are outside the focused proof.

Full strict-corpus replay and fresh hardware UAT remain outstanding before promotion or merge. The non-introspection build skips introspection-dependent driver replay tests; focused sanitizer checks are not a whole-library sanitizer run.
