### PR TITLE
Match native Milan temporal threshold selection

### DIFF
--- a/drivers/goodix53x5/milan/preprocess/classification.c
+++ b/drivers/goodix53x5/milan/preprocess/classification.c
@@ -503,6 +503,7 @@ static void
 milan_profile9_histogram_thresholds (const uint16_t *image,
                                      const uint8_t  *valid,
                                      size_t          count,
+                                     int             primary,
                                      int            *low,
                                      int            *high)
 {
@@ -520,7 +521,8 @@ milan_profile9_histogram_thresholds (const uint16_t *image,
         if (value > maximum)
           maximum = value;
       }
-  if (maximum <= minimum)
+  if (maximum <= minimum ||
+      (!primary && (int16_t) (maximum - minimum) <= 0))
     {
       *low = minimum;
       *high = minimum;
@@ -582,6 +584,15 @@ milan_profile9_histogram_thresholds (const uint16_t *image,
          MILAN_HISTOGRAM_LAST_BIN + minimum;
   *high = (range * high_bin + MILAN_HISTOGRAM_MIDPOINT_BIN) /
           MILAN_HISTOGRAM_LAST_BIN + minimum;
+  if (!primary)
+    {
+      if (*high - *low > 500)
+        *low = *high;
+      if (*low > 9000)
+        *low = 9000;
+      return;
+    }
+
   if (*low > mode_limit)
     *low = mode_limit;
   if (*high > mode_limit)
@@ -1424,7 +1435,7 @@ milan_profile9_temporal_class3 (GoodixMilanPreprocessState *state,
   if (!gradient || !direction || !scores || !mask)
     goto out;
   milan_profile9_histogram_thresholds (
-    state->profile9_history_reference, qualified, count, &threshold, &unused);
+    state->profile9_history_reference, qualified, count, 0, &threshold, &unused);
   for (size_t row = 0; row < rows; row++)
     for (size_t column = 0; column < columns; column++)
       {
@@ -1887,7 +1898,7 @@ goodix_milan_profile9_build_broken_mask (
     prepared, rows, columns, primary_kernel, 3, blurred);
   primary_histogram_state = milan_profile9_histogram_state (
     blurred, valid, count, 1);
-  milan_profile9_histogram_thresholds (blurred, valid, count, &low, &high);
+  milan_profile9_histogram_thresholds (blurred, valid, count, 1, &low, &high);
   milan_profile9_primary_path_scores (
     blurred, valid, rows, columns, low, high, gradient, direction, scores);
   size_t severe_count = milan_profile9_build_severe_mask (


### PR DESCRIPTION
## Summary

Give populated profile-9 temporal classification its native threshold rule instead of reusing the primary classifier's histogram-mode cap.

- Derive the temporal threshold from the original histogram's 35th and 50th weighted percentiles: use the latter only when their difference is strictly greater than 500, then cap at 9000.
- Preserve the native early return for a nonpositive signed-word range, before applying that ceiling.
- Leave primary-classifier threshold semantics, adaptive seed arithmetic, flood behavior and metadata publication logic unchanged.

This is a standalone correction based on `main`; it does not depend on the configuration-default correction.

## Native Contract And Impact

The approved Windows 2.0.310.900 engine's temporal owner obtains one threshold from `FUN_18004ef90` and uses it for both score-start eligibility and the current-source floor. It does not apply the primary histogram-mode cap or the primary 8192 ceiling.

On a fixed, producer-generated normalized-image sequence, the native threshold is 7943 while the baseline threshold is 6483. The complete final class plane differs in 180 of 9504 bytes: native has 267 class-3 pixels and baseline has 447. This correction produces the same 267 pixels and zero differing class-plane bytes. Class coverage has downstream mask and metadata consumers; it is not merely unused threshold scratch.

Native contracts are documented separately on [milan-dev](https://github.com/seaweeduk/goodix53x5-libfprint/blob/milan-dev/re/milan/functions/FUN_18004e8c0.md); no reverse-engineering notes or private artifacts are included in this PR.

## Validation

- Compared actual native and current classifiers using three fixed 22-call image sequences: the target, a populated flood-growth control and a brightness adjacency. The classifiers themselves produced the retained history, ages and counts; final scores or decisions were not independently assigned.
- Executed 132 native classifier calls across baseline/corrected runs and 132 Linux ASan/UBSan replay calls. Corrected complete class planes, history references, ages and counts match throughout all three sequences.
- Target and brightness adjacency: final class-plane differences fall from 180 to zero. The populated control remains identical, including growth from 360 seeds to 3024 selected pixels.
- Checked native caller metadata explicitly, including sensor type 12. An initial six-pixel prelude discrepancy was traced to missing fixture metadata, corrected in the harness and excluded as a production finding.
- This standalone branch passes `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` and all 120 existing cases across the Milan synthetic, state, runtime and `fpi-device` suites.
- Focused harnesses remain temporary, as requested; no tracked tests or concurrent CI-test changes are included.

## Draft Limitations

This proves a conditional normalized-image classifier-boundary difference, not raw-capture or physical-sensor chronology. The 9000 ceiling and signed-range early return were verified in native instructions but were not independently exercised by every boundary case; the three sequences do exercise percentile-gap selection on both sides of 500. Arbitrary high-bit retained states are not covered.

Full strict-corpus replay and fresh hardware UAT remain outstanding before promotion or merge. The non-introspection build skips introspection-dependent driver replay tests; focused sanitizer checks are not a whole-library sanitizer run. The separate unresolved component FIFO-capacity question is not changed by this PR.
