### PR TITLE
Report known Milan profiles and sensor types in the detector

### DIFF
--- a/scripts/goodix53x5-detect.c
+++ b/scripts/goodix53x5-detect.c
@@ -611,9 +611,24 @@ print_report (const ProbeReport *report,
   if (report->chip_id != 0)
     {
       g_print ("Chip 0x%08x", report->chip_id);
-      if ((report->chip_id & MILAN_CHIP_FAMILY_MASK) ==
-          MILAN_CHIP_FAMILY_PREFIX)
-        g_print (" | Milan profile 9 | sensor type 12");
+      /* Reference-driver profiles and algorithm sensor types are distinct enums. */
+      switch (report->chip_id & MILAN_CHIP_FAMILY_MASK)
+        {
+        case 0x00220200u:
+          g_print (" | Milan profile 0 | sensor type 0");
+          break;
+        case 0x00220700u:
+          g_print (" | Milan profile 1 | sensor type 6");
+          break;
+        case 0x00220800u:
+          g_print (" | Milan profile 2 | sensor type 7");
+          break;
+        case MILAN_CHIP_FAMILY_PREFIX:
+          g_print (" | Milan profile 9 | sensor type 12");
+          break;
+        default:
+          break;
+        }
       g_print ("\n");
     }
   if (system_name)


### PR DESCRIPTION
## Summary
Stacked above #188. Extend the corrected report formatting with informational labels for the four chip families identified by our approved 2.0.310.900 reference driver.

| Chip family | Milan profile | Algorithm sensor type |
| --- | --- | --- |
| `0x002202xx` | 0 | 0 |
| `0x002207xx` | 1 | 6 |
| `0x002208xx` | 2 | 7 |
| `0x00220cxx` | 9 | 12 |

These are distinct enums: the chip-family suffix is not the algorithm sensor type. Unknown families remain unlabeled. No mappings were imported from the older Dell package.

## Support Boundary
This is reporting only. The existing `0x00220cxx` compatibility gate, OTP and production-record checks, USB commands, and exit statuses are unchanged. The three other recognized families still report `NOT COMPATIBLE`; no USB IDs or hardware support are added.

The reference engine contains additional profile rows, but its recovered USB identification path does not select them. No chip IDs are guessed for those rows.

## Native Documentation
The full mapping, 13-row profile table, image dimensions, selection path, and failure behavior were independently reviewed and published separately on milan-dev in commit f71a33e9. See [CHIP-ID-PROFILE-MAPPING.md](https://github.com/seaweeduk/goodix53x5-libfprint/blob/f71a33e9/re/milan/CHIP-ID-PROFILE-MAPPING.md). No RE notes or private artifacts are included in this production PR.

## Validation
- Detector compiled using the wrapper flags: `-std=gnu11 -O2 -Wall -Wextra -Werror` and GUsb.
- Existing detector `--self-test` passed. It does not exercise report formatting.
- Independent code review confirmed all mappings and the unchanged admission and exit-status paths.
- `git diff --check` passed.
- No new tests or hardware access. Full driver/parity suites were not run because only standalone detector report formatting changed.