### PR TITLE
Keep native type-12 calibration admission strict

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -819,8 +819,7 @@ profile9_update_calibration (const uint32_t             *ratio,
 
       if (deviation < 0)
         deviation = -deviation;
-      if (deviation < 6400 ||
-          (state->sample_count < 30 && deviation < 8192))
+      if (deviation < 6400)
         {
           uint32_t divisor = state->sample_count + 1;
 


### PR DESCRIPTION
## Summary

Keep the native strict calibration deviation threshold for profile 9 / sensor type 12 at every sample count. Remove the early-count alternative that belongs only to other native subtype selectors.

## Native Contract And Effect

The approved engine admits a calibration sample only when its absolute deviation from 8000 is below 6400 for type 12. The additional below-30-count relaxation requires a subtype permission bit that is clear for type 12. No other calibration arithmetic, count handling, map normalization, or publication order changes.

Before this correction, a valid synthetic normalized-input sequence accepted samples that native rejected. The differing retained calibration changed the application map and the following update's rendered output. The change is confined to the first differing admission predicate; it does not add smoothing or alter another profile's behavior.

## Validation

- Fresh actual native/current mask producers and consecutive initialized updates, rather than injected mature counters or independently chosen admission flags.
- Target after 29 warm-up calls, nearby admitted-value control, and entry-count-30 control: 94 complete update boundaries, 12,956,960 compared bytes per corrected run, zero differences.
- Complete calibration/application/auxiliary maps, coarse references, counters, ready state, working output, optional output, and next-call reciprocal plane compared. Before correction the target differs; both controls already match.
- Optimized and ASan/UBSan focused runs pass.
- Fresh isolated `GOODIX53X5_DEBUG=0 GOODIX_LIBFPRINT_OFFLINE=1 ./scripts/build-local.sh` passes.
- All 125 existing cases pass: synthetic 10, state 9, runtime 7, and fpi-device 99. No tests or dependencies added.
- Changed predicate matches the formatter output; unrelated pre-existing whole-file formatting differences are intentionally excluded. `git diff --check` passes. No Goodix compiler warnings; the build retains the upstream NBIS unused-variable warning.

## Scope

This proves the initialized normalized-update boundary and its retained-state chronology, not physical acquisition, observed hardware incidence, or authentication outcomes. Broader coarse-source/auxiliary-map questions remain outside this correction. Full strict-corpus and fresh hardware UAT gates have not been run for this PR and remain pre-merge work.

Native contracts were documented separately on `milan-dev`; this independent PR contains only the production predicate correction and has no dependency on another PR.
