### PR TITLE
Preserve enrollment scores without mutual anti-fake pairs

### DIFF
--- a/drivers/goodix53x5/milan/enrollment/template.c
+++ b/drivers/goodix53x5/milan/enrollment/template.c
@@ -561,17 +561,20 @@ goodix_milan_match_combine_templates (GPtrArray *templates)
             }
           if (prior_view.record_count > 40 && current_view.record_count > 40)
             {
-              gint32 pair_score;
+              gint32 pair_metrics[5];
 
-              if (goodix_milan_antifake_score_pair (
+              if (goodix_milan_antifake_pair_metrics (
                     prior_view.antifake, GOODIX_MILAN_ANTIFAKE_SIZE,
                     current_view.antifake, GOODIX_MILAN_ANTIFAKE_SIZE,
-                    candidate.values + 1, &pair_score) != 0)
+                    candidate.values + 1, pair_metrics) != 0)
                 goto out;
-              goodix_milan_match_update_antifake_score (
-                mutable_antifakes[prior], pair_score);
-              goodix_milan_match_update_antifake_score (
-                mutable_antifakes[i], pair_score);
+              if (pair_metrics[1] != 0)
+                {
+                  goodix_milan_match_update_antifake_score (
+                    mutable_antifakes[prior], pair_metrics[4]);
+                  goodix_milan_match_update_antifake_score (
+                    mutable_antifakes[i], pair_metrics[4]);
+                }
             }
           if (candidate.values[0] > best_inliers)
             {
@@ -919,19 +922,23 @@ goodix_enrollment_transaction_insert (
           if (transaction->features[prior].record_count > 40 &&
               transaction->features[current].record_count > 40)
             {
-              gint32 pair_score;
+              gint32 pair_metrics[5];
 
-              if (goodix_milan_antifake_score_pair (
+              if (goodix_milan_antifake_pair_metrics (
                     &transaction->features[prior].antifake,
                     GOODIX_MILAN_ANTIFAKE_SIZE,
                     &transaction->features[current].antifake,
                     GOODIX_MILAN_ANTIFAKE_SIZE, candidate.values + 1,
-                    &pair_score) != 0)
+                    pair_metrics) != 0)
                 return FALSE;
-              goodix_milan_match_update_antifake_score (
-                &transaction->features[prior].antifake, pair_score);
-              goodix_milan_match_update_antifake_score (
-                &transaction->features[current].antifake, pair_score);
+              /* Native leaves both scores untouched when no mutual pair exists. */
+              if (pair_metrics[1] != 0)
+                {
+                  goodix_milan_match_update_antifake_score (
+                    &transaction->features[prior].antifake, pair_metrics[4]);
+                  goodix_milan_match_update_antifake_score (
+                    &transaction->features[current].antifake, pair_metrics[4]);
+                }
             }
           if (candidate.values[0] > best_inliers)
             {


### PR DESCRIPTION
## Summary

Preserve both enrollment anti-fake endpoint scores when the native pair comparison finds no mutual descriptor pair. Apply the same contract to the device-facing transaction insertion and the template-combination helper.

## Native Contract And Effect

The native enrollment caller distinguishes the pair helper's Boolean result from its score output. Zero mutual pairs leave both previous scores unchanged while retaining the admitted direct relation. A successful comparison with score zero still updates both endpoints.

Previously the score-only wrapper converted the missing score to -1, which enrollment averaged into the retained scores. A three-stage accepted transaction published 28 where native retained 58. The corrected callers use the existing five-metric API and update only for a nonzero mutual-pair count. Error paths, record-count gates, graph routing, and averaging arithmetic are unchanged.

## Validation

- Seven fresh current-produced feature sequences, including accepted target/control and lower/higher propagation handoffs; native uses its real unpacker, insertion owner, and packer.
- 24 insertion boundaries: 21 accepted transaction attempts and three provisional fourth-stage stops before rollback.
- Optimized and ASan/UBSan runs each pass 72/72 artifact comparisons, covering 1,605,879 independently compared bytes per implementation, plus 24 exact combiner/publication checks.
- Target final endpoint scores are `[58,64,70]`; adjacent nonzero-pair control remains `[64,29,35]`, including valid zero-score updates. The second discriminator preserves 47 rather than writing 23.
- Entire packed publications and result artifacts match. Measured live state includes the graph matrix, orders, counters, feature fields, and pair scores; 160 unmapped neighbor-count bytes per boundary are explicitly excluded, not claimed as native equality.
- Fresh isolated offline non-debug full build and all 125 existing cases pass: synthetic 10, state 9, runtime 7, fpi-device 99. No new tests or dependencies.
- Independent caller/status/ownership review found no regressions. Changed blocks match formatter output; unrelated existing formatting is excluded. `git diff --check` passes. Only the existing upstream NBIS unused-variable warning remains.

## Scope

This is valid synthetic feature-boundary and accepted transaction evidence, not continuous hardware chronology, native preprocessing equivalence, full twelve-stage enrollment, or authentication outcomes. The separate deeper lower-propagation route question remains unresolved and is not changed here.

This independent PR does not depend on the calibration or queue-copy corrections. Native notes are published separately on `milan-dev`; no RE notes or private artifacts are included. Full strict-corpus and fresh hardware UAT gates remain pre-merge work.
