### PR TITLE
Initialize queued Milan copies with native lifecycle state

### DIFF
--- a/drivers/goodix53x5/milan/match/study.c
+++ b/drivers/goodix53x5/milan/match/study.c
@@ -57,8 +57,45 @@ static GoodixStudyQueueEnqueueResult
 goodix_milan_match_enqueue_queue_candidate (GoodixStudyQueue      *queue,
                                       const GoodixMatchInfo *probe_info)
 {
+  g_autofree GoodixMilanUnpackedTemplate *unpacked = NULL;
+  g_autofree guint8 *feature_copy = NULL;
+  g_autofree guint8 *packed = NULL;
+
+  g_autoptr(GBytes) queued_template = NULL;
+  GoodixMatchInfo queued;
+  const guint8 *template_data;
+  gsize template_size;
+  size_t packed_size = 0;
+
+  if (!goodix_milan_match_info_is_complete (probe_info))
+    return GOODIX_STUDY_QUEUE_INVALID;
+  template_data = g_bytes_get_data (probe_info->template, &template_size);
+  unpacked = g_new (GoodixMilanUnpackedTemplate, 1);
+  if (goodix_milan_template_unpack (template_data, template_size, unpacked) != 0 ||
+      unpacked->metadata.sensor_type != GOODIX_MILAN_PRINT_SENSOR_TYPE ||
+      unpacked->feature_count != 1 || unpacked->relation_count != 0)
+    return GOODIX_STUDY_QUEUE_INVALID;
+
+  /* Native enqueue owns a ba=-1 copy, not the original probe's lifecycle state. */
+  feature_copy = g_memdup2 (unpacked->feature_elements[0],
+                            unpacked->feature_element_sizes[0]);
+  if (goodix_milan_template_patch_feature_scalar (
+        feature_copy, unpacked->feature_element_sizes[0], 0xba, -1) != 0)
+    return GOODIX_STUDY_QUEUE_INVALID;
+  unpacked->feature_elements[0] = feature_copy;
+  packed = g_malloc (template_size);
+  if (goodix_milan_template_pack (
+        unpacked->feature_elements, unpacked->feature_element_sizes,
+        unpacked->feature_count, unpacked->relations, unpacked->relation_count,
+        &unpacked->metadata, unpacked->tail_state, sizeof (unpacked->tail_state),
+        packed, template_size, &packed_size) != 0 || packed_size != template_size)
+    return GOODIX_STUDY_QUEUE_INVALID;
+
+  queued_template = g_bytes_new_take (g_steal_pointer (&packed), packed_size);
+  queued = *probe_info;
+  queued.template = queued_template;
   return goodix_milan_study_queue_enqueue (
-    queue, probe_info, goodix_milan_match_queue_duplicate_metric, NULL);
+    queue, &queued, goodix_milan_match_queue_duplicate_metric, NULL);
 }
 
 GoodixSigfmTemplateStatus
@@ -616,8 +653,8 @@ goodix_milan_match_study_feature_queued (
           probe_info->extraction_metadata.quality > 15 &&
           probe_info->extraction_metadata.coverage > 65)
         {
-          enqueue_result = goodix_milan_study_queue_enqueue (
-            queue, probe_info, goodix_milan_match_queue_duplicate_metric, NULL);
+          enqueue_result = goodix_milan_match_enqueue_queue_candidate (
+            queue, probe_info);
           if (enqueue_result == GOODIX_STUDY_QUEUE_INVALID)
             {
               status = GOODIX_SIGFM_TEMPLATE_INVALID;


### PR DESCRIPTION
## Summary

Give queued Milan probe copies the native lifecycle sentinel `ba=-1` instead of retaining the original probe's `ba=0`. Use the same queue-specific producer for match-time enqueue and late-study enqueue.

## Native Contract And Correction

Native enqueue makes an independent live owner and explicitly assigns its lifecycle state to -1. Fresh naturally produced enqueue/retention sequences demonstrated that current queued-owner observations instead contained zero, with the associated CRC difference.

The correction creates an independent queue template, patches only `ba`, and repacks through the existing codec to regenerate the CRC. The synchronous existing queue copier retains its own template and complete live record data. General info-copy and generic queue-container semantics are unchanged, as are the original probe, duplicate decisions, and rank updates. Validation or packing errors occur before queue mutation.

The complete natural queue-owner boundary is sufficient to correct this parity difference; successful action-5 continuation or a captured campaign is not a prerequisite.

## Validation

- Four fresh native/current operation pairs: cleanup/reload controls and a retained-handle sequence, using actual image/enrollment/match producers and natural enqueue behavior, not injected queue state or acceptance flags.
- Before: 32/36 exact artifact pairs. After: 36/36 exact, 332,704 bytes per implementation, zero differing bytes.
- Full queued/probe live records, processed images, packed probes, after-match galleries, ranks, and status/count summaries are unchanged. Only the queued owner's lifecycle bytes and CRC change; the retained owner stays stable on the duplicate operation.
- Focused fully ASan/UBSan-instrumented natural enqueue replay passes 36/36 comparisons with leak detection.
- Full offline non-debug build and all 125 existing normal cases pass: synthetic 10, state 9, runtime 7, fpi-device 99. No new tests or dependencies.
- Additional sanitized synthetic, state, and fpi-device suites pass. Sanitized runtime stops in unchanged `milan/match/overlap.c:364` on a negative-value left shift. This broader sanitizer limitation is recorded, not described as a clean all-suite sanitizer run or independently proven baseline issue.
- Independent ownership/codec/duplicate/caller review found no regressions. Changed-function formatter review and `git diff --check` pass; unrelated pre-existing formatting is excluded.

## Scope

Natural enqueue and retained-owner behavior are verified. The generated matches return score zero, so positive primary/queued selection, action-5 continuation, consumption, finalization, and candidate publication remain dynamically unverified. No authentication decision or native residual stack input was manufactured. The ordinary adapter discards transient queues; retained live-handle continuation is a distinct boundary.

This independent PR contains one production file, no RE notes or private evidence, and does not depend on the calibration or enrollment corrections. Native contracts are published separately on `milan-dev`. Full strict-corpus and fresh hardware UAT gates remain pre-merge work.
