### PR TITLE
Match native auxiliary gain fallback and narrowing

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -882,24 +882,25 @@ profile9_update_auxiliary_map (uint16_t       *map,
 {
   for (size_t i = 0; i < count; i++)
     {
+      uint16_t candidate = MILAN_FIXED_ONE;
+      int32_t deviation;
+
       if (gaussian[i] != 0)
+        candidate =
+          ((uint32_t) adjusted[i] * MILAN_FIXED_ONE + gaussian[i] / 2) /
+          gaussian[i];
+      deviation = (int32_t) candidate - (int32_t) MILAN_FIXED_ONE;
+
+      if (deviation < 0)
+        deviation = -deviation;
+      if (deviation < 328)
         {
-          uint32_t candidate =
-            ((uint32_t) adjusted[i] * MILAN_FIXED_ONE + gaussian[i] / 2) /
-            gaussian[i];
-          int32_t deviation = (int32_t) candidate - (int32_t) MILAN_FIXED_ONE;
+          uint32_t divisor = samples + 1;
 
-          if (deviation < 0)
-            deviation = -deviation;
-          if (deviation < 328)
-            {
-              uint32_t divisor = samples + 1;
-
-              map[i] =
-                (uint16_t) (((divisor >> 1) + (uint32_t) map[i] * samples +
-                             candidate) /
-                            divisor);
-            }
+          map[i] =
+            (uint16_t) (((divisor >> 1) + (uint32_t) map[i] * samples +
+                         candidate) /
+                        divisor);
         }
     }
 }


### PR DESCRIPTION
## Summary

Match the native profile-9/type-12 auxiliary gain update at zero Gaussian and at quotient narrowing. Keep the same strict deviation gate, rounded running average, map ownership, and caller ordering.

## Native Contract And Effect

- A zero Gaussian selects candidate 8192 (unity), which passes admission and participates in the running average. It does not leave the retained sample untouched.
- A nonzero Gaussian produces a rounded quotient that narrows to unsigned 16 bits before deviation and averaging. Admission is therefore `7865 <= quotient modulo 65536 <= 8519`, not a range check on the full quotient.

The correction initializes a `uint16_t` candidate to unity, replaces it with the quotient when the divisor is nonzero, and applies the existing gate and average once. It changes only `profile9_update_auxiliary_map`, not the coarse gate or the separate calibration admission correction in PR196.

## Focused Proof

The actual native helper first produces retained center value 8093 from initialized unity; no non-unity retained map is seeded. Four second-call target/control scenarios then isolate both rules:

| Source / Gaussian | Candidate | Native retained result | Previous result |
| --- | --- | --- | --- |
| 0 / 0 | Unity fallback | 8143 | 8093 |
| 3 / 3 | 8192 | 8143 | 8143 |
| 9 / 1 | 73728 narrows to 8192 | 8143 | 8093 |
| 6 / 1 | 49152, rejected | 8093 | 8093 |

A zero-only intermediate correction leaves exactly one map-sample difference in the narrowing target, isolating that second rule from neighboring zero-divisor samples.

- Final optimized and ASan/UBSan runs each match 8/8 complete helper returns, 912,480 bytes per implementation, with no diagnostics.
- Full map, Gaussian, gain, source, normalized-ratio planes, counters, and admission counts are compared. Actual native/current mask producers admit all 9,504 warm-up pixels and 9,383 target pixels, above 90%.
- Fresh isolated offline non-debug build passes all 190 steps; all 125 existing split-suite cases pass (synthetic 10, state 9, runtime 7, fpi-device 99).
- Independent arithmetic/caller review found no regressions. Exact changed-function formatter review and `git diff --check` pass. No Goodix compiler warnings, new tests, or dependencies; the existing upstream NBIS unused-variable warning remains.

## Scope

This is complete valid secondary-auxiliary helper-boundary evidence. Sources derive from valid normalized setup/live values; retained maps and counts come from prior helper calls. Unity temporary gain is justified by its producer contract and verified through the actual current producer, not separately executed through the native gain producer.

The native coarse gate, downstream rendering, primary optional-application path, raw acquisition, and authentication were not executed in this proof. Those limits do not prevent correcting the observed helper output. Full strict-corpus and fresh hardware UAT gates remain pre-merge work.

This PR is independent of PR196, PR197, and PR198, with a disjoint owner even though PR196 also edits `core.c`. Native notes are published separately on `milan-dev`; no notes or private evidence are included here.
