### PR TITLE
Use original source for coarse calibration admission

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -751,7 +751,7 @@ median3x3_core (const uint16_t *source,
 }
 
 static int
-profile9_calibration_admit (const uint32_t             *ratio,
+profile9_calibration_admit (const uint16_t             *source,
                             size_t                      rows,
                             size_t                      columns,
                             GoodixMilanPreprocessState *state)
@@ -767,7 +767,7 @@ profile9_calibration_admit (const uint32_t             *ratio,
         for (size_t column = 0; column < coarse_columns; column++)
           {
             uint16_t current =
-              (uint16_t) ratio[(row * 2) * columns + column * 2];
+              source[(row * 2) * columns + column * 2];
             uint16_t previous =
               state->coarse_reference[row * coarse_columns + column];
 
@@ -785,7 +785,7 @@ profile9_calibration_admit (const uint32_t             *ratio,
     for (size_t row = 0; row < coarse_rows; row++)
       for (size_t column = 0; column < coarse_columns; column++)
         state->coarse_reference[row * coarse_columns + column] =
-          (uint16_t) ratio[(row * 2) * columns + column * 2];
+          source[(row * 2) * columns + column * 2];
 
   if (state->stable_count > 3)
     return 0;
@@ -958,7 +958,7 @@ profile9_update_calibration_state (
 {
   size_t count = rows * columns;
   int calibration_admitted =
-    profile9_calibration_admit (ratio, rows, columns, state);
+    profile9_calibration_admit (difference, rows, columns, state);
 
   if (calibration_admitted)
     {


### PR DESCRIPTION
## Summary

Use the original signed-baseline source plane for profile-9/type-12 coarse calibration admission and retained-reference updates. Do not substitute the later gain-adjusted ratio plane.

## Native Contract And Effect

Native temporary-gain production and coarse admission receive the same source pointer. The gain producer writes a separate gain plane; coarse admission still compares and retains the original source samples. Otherwise gain correction can hide a real source change from the stability calculation.

The correction changes the gate to accept its actual `uint16_t` source, uses that source for both coarse reads, and passes the caller's existing `difference` plane. The strict mean/stability thresholds, counter rules, gains, maps, allocation, and ordering are unchanged.

## Focused Proof

Four actual warm-up update calls establish source/reference 9000 and stability count 3. The next target has twelve isolated raw-source changes to 15000. Both actual native/current gain producers produce 13653 there, reducing the later ratio back to 9000.

Native sees coarse mean change 30, refreshes twelve reference samples, resets stability, and admits calibration. The old current path sees no ratio change, increments stability to four, and rejects calibration. Workspace/auxiliary counts become native 5/5 versus current 4/4, with the difference retained through two subsequent calls.

- Eleven changed samples give the adjacent mean-27 rejection control; forty unity-gain changes give the mean-30 admitted control. Both already match before correction.
- Real native/current masks, temporary-gain producers, full update callers, retained-state chronology, and next calls execute. No state or admission flags are injected; every mask admits all 9,504 pixels.
- Corrected optimized and ASan/UBSan runs each match 21/21 complete snapshots, 4,890,480 bytes per implementation.
- Complete source/median/gain/ratio planes, coarse reference, stability/admission/counts, calibration/auxiliary maps, and rendered outputs are compared. Rendered planes and maps were already equal in this discriminator; the demonstrated defect is retained reference and admission/count publication, not a claimed visible-image change.
- Fresh isolated offline non-debug full build and all 125 existing split-suite cases pass: synthetic 10, state 9, runtime 7, fpi-device 99. No new tests or dependencies.
- Independent type/domain/ownership/caller review found no regressions. Exact changed-function formatter review and `git diff --check` pass; unrelated pre-existing formatting is excluded.

## Scope

This proves the valid normalized-update caller boundary, not acquisition, setup-normalization chronology, hardware frequency, persistence/reload, or authentication outcomes. Full strict-corpus and fresh hardware UAT gates remain pre-merge work.

The four-line correction is independent of PR196-199: it changes source provenance, not calibration-sample admission or auxiliary arithmetic. Native notes are published separately on `milan-dev`; no RE notes or private artifacts are included.
