### PR TITLE
Retain enrollment traversal child across missing edges

### DIFF
--- a/drivers/goodix53x5/milan/enrollment/propagation.c
+++ b/drivers/goodix53x5/milan/enrollment/propagation.c
@@ -34,6 +34,7 @@ goodix_milan_enrollment_propagate_lower (
       for (size_t position = worklist_count; position-- > 0;)
         {
           size_t node = worklist[position];
+          size_t child = position;
           GoodixMilanRelationSlot *slot =
             goodix_milan_enrollment_relation_slot (matrix, candidate, node);
           int32_t overlap;
@@ -46,15 +47,19 @@ goodix_milan_enrollment_propagate_lower (
               overlap <= threshold)
             continue;
           memcpy (path, slot->values + 1, sizeof(path));
+          /* An absent edge leaves the accumulated path at the same child. */
           for (size_t route = position; route-- > 0;)
             {
               GoodixMilanRelationSlot *route_slot =
                 goodix_milan_enrollment_relation_slot (
-                  matrix, worklist[route], worklist[route + 1]);
+                  matrix, worklist[route], worklist[child]);
 
               if (route_slot && route_slot->values[0] >= 0)
-                goodix_milan_transform_compose (
-                  route_slot->values + 1, path, path);
+                {
+                  goodix_milan_transform_compose (
+                    route_slot->values + 1, path, path);
+                  child = route;
+                }
             }
           if (goodix_milan_transform_invert (
                 path, candidate_to_pivot) != 0)


### PR DESCRIPTION
## Summary

Keep the current child node when enrollment traversal skips a missing connection. Advance it only after composing an existing connection, matching the native lower-propagation routine.

## Why

The traversal carries two related pieces of state: an accumulated transform and the node associated with it. A missing connection changes neither. Previously, the next lookup used the immediately preceding worklist entry even after a connection was skipped, while the transform still belonged to the last retained node. That can select a connection for the wrong transform endpoint.

The native routine explicitly retains the child on its missing-edge branch and updates it only after composition. The patch implements that same recurrence: initialize `child` at the selected position, look up each earlier node against `worklist[child]`, and update `child` inside the successful-composition block.

The caller permits attachment to any earlier worklist node, not necessarily the previous one; publishing reference connections does not fill missing worklist connections. Where every consecutive connection exists, old and corrected code perform the same operations in the same order. Short paths remain unchanged. The ordinary differing route requires at least six live features.

## Scope Of Evidence

This is a source-level traversal correction justified by the reference instructions, loop invariant, and existing caller contracts. It is not based on a newly reproduced device failure or a successful enrollment campaign. No biometric input construction or authentication experiment was performed for this correction.

There is no new runtime discriminator for the specific missing-edge branch, and no claim of complete native/current runtime matrix parity, hardware incidence, or authentication impact. The source recurrence is aligned without waiting for such a campaign. Fixed-point composition order, normalization, inversion, thresholds, errors, publication and higher propagation remain unchanged.

## Validation

- Full isolated offline non-debug build passes all 190 steps.
- All 125 existing cases pass: synthetic 10, state 9, runtime 7, fpi-device 99.
- The existing synthetic and state suites additionally pass under ASan/UBSan: 19 cases.
- Parent reviewed the coupled transform/child state and unchanged caller/arithmetic ownership. Formatter output agrees with changed lines; unrelated existing formatting is excluded. `git diff --check` passes.
- No new tests, dependencies, performance work or API changes.

Independent of the other audit PRs, including PR197's separate enrollment score fix and PR201's recovery fix. Only `enrollment/propagation.c` changes here. Native notes were published separately on `milan-dev`; no notes or private artifacts are included. Full strict-corpus and fresh hardware UAT remain pre-merge work.
