### PR TITLE
Deliver captured frames before arming finger removal

### DIFF
--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -84,7 +84,6 @@ typedef struct
   gboolean                      cycle_active;
   gboolean                      recovering_generation;
   gboolean                      release_settled;
-  gboolean                      capture_notified;
 } GoodixScanCoordinatorData;
 
 static void goodix_scan_coordinator_handler (FpiSsm *ssm, FpDevice *dev);
@@ -421,18 +420,6 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
           g_cancellable_cancel (data->event_cancel);
           return;
         }
-      if (data->cycle_active && !data->capture_notified)
-        {
-          if (!self->milan_generation || !self->captured_raw_image)
-            {
-              data->recovering_generation = TRUE;
-              break;
-            }
-          data->capture_notified = TRUE;
-          data->cpu_outstanding = TRUE;
-          goodix_milan_generation_prepare_setup (dev, self->milan_generation);
-          data->capture_ready (dev, data->user_data);
-        }
       break;
 
     case GOODIX_SCAN_COORD_DISPATCH_EVENT:
@@ -592,7 +579,22 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
       data->cycle_active = TRUE;
       data->release_settled = FALSE;
       data->cpu_done = FALSE;
-      data->capture_notified = FALSE;
+      if (!data->stop_requested)
+        {
+          if (!self->milan_generation || !self->captured_raw_image)
+            {
+              data->recovering_generation = TRUE;
+            }
+          else
+            {
+              /* Deliver the completed frame before up-arm. Dispatch ownership
+               * holds the coordinator until the command finishes; cleanup joins
+               * any worker even if that command fails. */
+              data->cpu_outstanding = TRUE;
+              goodix_milan_generation_prepare_setup (dev, self->milan_generation);
+              data->capture_ready (dev, data->user_data);
+            }
+        }
       fdt->wait_mode = GOODIX_PROFILE9_FDT_WAIT_UP;
       goodix_cmd_fdt_up_setup (ssm, dev, fdt->base_up);
       break;


### PR DESCRIPTION
## Summary

Deliver the completed frame to its processing worker before preparing the sensor for finger removal. Previously, failure of that later up-arm command prevented delivery of an already captured frame. Windows completes its separate capture request before that command.

Move the single capture-ready notification into `GOODIX_SCAN_COORD_ARM_UP`, after initializing the cycle and before sending the command. Remove the repeated-wait notification flag that is no longer needed. Recovery-only arms do not submit a frame, and an already requested stop suppresses submission.

## Ownership And Error Handling

The processing input owns copies of both frames and the runtime state. Dispatch ownership keeps the coordinator alive across notification and up-arm, including immediate input errors and fast worker completion. Cleanup cancels and joins outstanding work before releasing the operation.

This does not report success early or ignore transport errors. Authentication and enrollment results remain pending until their existing final error checks. An up-arm failure still fails the combined libfprint operation and discards pending results; cancellation likewise keeps its existing ownership. In-memory preprocessing updates made before a later error are not a complete rollback.

Windows exposes a separate capture request, while libfprint combines capture, processing and shutdown. The correction aligns frame delivery, not every final Windows/Linux operation result.

## Reference Evidence

Fresh inspection of the approved profile-9/type-12 reference confirms that `MilanHV_ReadImg` calls the frame callback before clearing it and freeing its temporary frame. `CaptureFramedone` completes the pending request before up-arm. Cancellation uses the request's unmark/completion ownership, so copied sample bytes alone do not establish successful completion. The profile-9 arm wrapper does not propagate its transport result to the already completed capture request.

## Validation And Limits

- Full isolated offline non-debug build passes, including the final formatted source.
- All 167 existing cases pass: synthetic 10, state 9, runtime 7, fpi-device 99, fpi-ssm 42.
- ASan/UBSan passes all 99 device and 42 SSM cases. The runtime suite passes its first five cases, then stops at the previously recorded negative left shift in unchanged `milan/match/overlap.c:364`; this is not a full runtime sanitizer pass.
- Parent reviewed callback reentrancy, dispatch ownership, copied worker input, cleanup and final error gates. Changed-block formatting and `git diff --check` pass. No new tests, dependencies or performance work.
- This is a source-level ordering and ownership correction. No new native/current execution or hardware comparison was performed. The existing runtime harness substitutes its scan coordinator and does not directly exercise this reordered up-arm failure path. No broad race or whole-operation parity claim is made.

Independent of PR201's separate refresh-reason change and the other audit PRs. Only `device/scan.c` changes. Native notes are published separately on `milan-dev`; no notes or private evidence are included. Full strict-corpus and fresh hardware UAT remain pre-merge work.
