### PR TITLE
Clarify Milan parity replay state and comparison scope

### DIFF
--- a/tools/milan-parity/README.md
+++ b/tools/milan-parity/README.md
@@ -125,8 +125,13 @@ There is no implicit whole-dump selection.
 The DLL path, its explicitly approved SHA-256, and an already initialized Wine
 prefix are mandatory. The tooling does not discover or create a DLL or prefix.
 
+Use `--compare-current` for the normal current-source parity gate. In a clean
+checkout, first run `GOODIX53X5_DEBUG=0 ./scripts/build-local.sh` to create the
+required `.build/libfprint/builddir` support directory.
+
 ```sh
 ./tools/milan-parity/milan-parity validate-dump \
+  --compare-current \
   --dump-dir /private/CAMPAIGN/debug-dump \
   --operation 01234567-89ab-4cde-8123-456789abcdef/identify/58 \
   --operation 01234567-89ab-4cde-8123-456789abcdef/verify/59 \
@@ -187,6 +192,7 @@ for operation in "${operations[@]}"; do
 done
 
 "$REPO/tools/milan-parity/milan-parity" validate-dump \
+  --compare-current --repo "$REPO" \
   --dump-dir "$DUMP_DIR" \
   --build-manifest "$BUILD_MANIFEST" \
   "${selectors[@]}" \
@@ -253,9 +259,82 @@ GOODIX53X5_DEBUG=0 ./scripts/build-local.sh
 This creates `.build/libfprint/builddir`. The Milan stack builder does not create
 that checkout-local directory for `--compare-current`.
 
+### Comparison Modes And Starting State
+
+| Invocation | Expected output | Native side | Meaning |
+| --- | --- | --- | --- |
+| `--compare-current` | Newly computed current-source output | Native replay | Source-parity gate at the reconstructed runner boundary |
+| Without the flag | Recorded live output | The same native replay | Diagnostic comparison; live starting-state equivalence is not established |
+
+Changing this flag does not select extra native paths or replay the device event
+loop. It changes which output is compared against the native result. Both modes
+retain the full exact comparison and all existing failure/availability rules.
+The shipped no-flag default is unchanged; it emits a warning explaining its
+diagnostic scope. A mismatch remains a mismatch, not a skip or a forced pass.
+
+Both runners initialize fresh preprocessing state before applying eligible
+same-generation frame history. The live driver can instead import persisted
+calibration and classification/history state at setup, or transfer process-owned
+state during refresh. Runtime-debug/v3 records frames and setup flags, but not
+that imported workspace. A clear `setup_initialized` flag does not prove an empty
+calibration, and a complete generation chronology does not supply state inherited
+from earlier generations or before capture began.
+
+Consequently, current and native replay can agree while both differ from the
+recorded live image. This is not by itself proof of a driver algorithm defect.
+Captured mode need not always fail: compatible initial states or convergent
+outputs can agree. Neither its pass nor structural replay admissibility proves
+that all live state was reconstructed. Taking another ordinary v3 capture does
+not add state that this schema does not record.
+
+Reports include additive `replay_scope` metadata: `purpose` is `source-parity` or
+`capture-diagnostic`; `preprocessing_origin` is
+`fresh-before-generation-prelude`; `history` is
+`eligible-same-generation-preprocessing`; `captured_initial_workspace` is
+`not-recorded`; and `live_state_equivalence` is `not-established` in both modes.
+These describe comparison capability, not an additional per-operation verdict.
+No claim about the actual imported sample count is inferred from v3 metadata.
+
+### Future Live-State Replay
+
+Faithful live replay needs a separate, versioned capture/runner contract. This
+is not implemented by the scope metadata above and cannot be retrofitted into
+sealed v3 dumps by inventing missing state.
+
+- Seal the full logical preprocessing/profile input state actually copied into
+  the runtime call, after restore/refresh transfer and before setup processing.
+  This includes sample/count fields, calibration and application/auxiliary gain
+  planes, retained classification, masks, reference/history planes and ages,
+  plus profile/setup flags. Record all fields that the supported path can read,
+  not only the subset currently stored on disk. Use typed, versioned data with
+  explicit widths, dimensions and byte order, never raw pointers or C struct
+  memory dumps.
+- Bind that state to the exact operation, generation, chronology, input frames,
+  purpose, build identity and sealed artifact hashes. Capture the same immutable
+  snapshot used by the worker, not a mutable device object later in the call.
+- For multi-call replay, either checkpoint each call's starting state or record
+  a proven initial snapshot plus every relevant update, restore, reset, refresh
+  transfer and commit/discard transition. State snapshots alone cannot prove
+  that the earlier persistence lifecycle selected the correct state; validating
+  that lifecycle also needs its inputs and events.
+- First prove that current replay reproduces the captured state and processed
+  output exactly. Then map that logical state through verified native import/setup
+  contracts and compare the complete native output. Never transplant a Linux
+  structure into the DLL or supply captured queue state as runner input.
+
+That mode would add useful checks on mature calibration, retained history,
+generation handoff and frame/state pairing against what actually ran on the
+device. The ordinary source gate can miss errors shared by both runners' simpler
+state reconstruction. It would still not reproduce physical USB acquisition,
+interrupt timing, suspend/resume or cancellation races without a separate event
+and ownership replay contract. Keep `--compare-current` as the routine source
+gate; add live reproduction as a separate integration check when the required
+state can be captured and verified.
+
 ## Active-Investigation Guarantee
 
-A v3 dump remains replayable throughout an active investigation while its
+A v3 dump remains usable for the reconstructed current-source replay boundary
+throughout an active investigation while its
 runtime, print, and replay contracts remain current. Ordinary production
 algorithm changes do not invalidate the recorded raw-frame and gallery boundary,
 so a mismatch can be fixed and replayed against the exact operation that exposed
@@ -266,8 +345,10 @@ This guarantee does not cover sensor acquisition, USB lifecycle, FDT/reference
 capture, suspend, or timing before the recorded raw-frame boundary; an input
 gallery already corrupted by an earlier bug; an incompatible print schema;
 uncaptured required process or hardware state; a changed native boundary policy;
-or a schema that is no longer current. These cases require a fresh capture, not
-a compatibility adapter.
+or a schema that is no longer current. These cases may require a new capture
+contract before taking fresh evidence. An ordinary recapture does not recover
+required state that the schema omits. Do not add a compatibility adapter or
+invent the missing state.
 
 Every explicitly selected, structurally replayable identify or verify operation
 from a current strict dump is executed against the approved DLL under the

--- a/tools/milan-parity/milan_parity.py
+++ b/tools/milan-parity/milan_parity.py
@@ -60,7 +60,14 @@ def build_parser() -> argparse.ArgumentParser:
     finish.add_argument("--user")
 
     validate = commands.add_parser(
-        "validate-dump", help="Validate runtime-debug/v3 and run natural native parity")
+        "validate-dump", help="Validate runtime-debug/v3 and run natural native parity",
+        description=(
+            "Use --compare-current for current-source parity with the native runner. "
+            "Both runners initialize fresh preprocessing state and replay eligible "
+            "same-generation history. Without the flag, recorded live outputs are "
+            "compared with native replay as a diagnostic: v3 does not capture the "
+            "imported preprocessing workspace, so live starting-state equivalence "
+            "is not established."))
     validate.add_argument("--dump-dir", required=True)
     validate.add_argument(
         "--build-manifest",
@@ -78,7 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
     tool = Path(__file__).resolve().parent
     validate.add_argument("--native-runner", default=str(tool / "native-runner"))
     validate.add_argument("--compare-current", action="store_true",
-                          help="Compare rebuilt current source with native for selected operations")
+                          help="Source-parity gate: compare current and native replay, not live outputs")
     validate.add_argument("--current-runner", default=str(tool / "current-runner"))
     validate.add_argument("--repo", default=str(Path(__file__).resolve().parents[2]))
     validate.add_argument("--state-root")

--- a/tools/milan-parity/milan_parity_validate.py
+++ b/tools/milan-parity/milan_parity_validate.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import re
 import stat
+import sys
 from typing import Any
 import uuid
 
@@ -835,6 +836,11 @@ def run_validate_dump(args: argparse.Namespace) -> None:
 
     current_identity = None
     repo = Path(args.repo).expanduser().resolve()
+    if not args.compare_current:
+        print("warning: capture-vs-native is a diagnostic comparison; runtime-debug/v3 "
+              "does not record the imported preprocessing workspace. Live starting-state "
+              "equivalence is not established. Use --compare-current for source parity.",
+              file=sys.stderr)
     if args.compare_current:
         current_runner = _regular_user_path(
             args.current_runner, "current runner", executable=True)
@@ -1066,6 +1072,13 @@ def run_validate_dump(args: argparse.Namespace) -> None:
             "operations": operations,
             "parity_mode": "natural",
             "policy": POLICY,
+            "replay_scope": {
+                "purpose": "source-parity" if args.compare_current else "capture-diagnostic",
+                "preprocessing_origin": "fresh-before-generation-prelude",
+                "history": "eligible-same-generation-preprocessing",
+                "captured_initial_workspace": "not-recorded",
+                "live_state_equivalence": "not-established",
+            },
             "schema": REPORT_SCHEMA,
             "selectors": [{"action": action, "epoch_u64": epoch, "session": session}
                           for session, action, epoch in selectors],

--- a/tools/milan-parity/native/CONTRACT.md
+++ b/tools/milan-parity/native/CONTRACT.md
@@ -113,6 +113,23 @@ operation, status, or presence of another result.
 
 ## Reports And Privacy
 
+The normal source-parity gate uses `--compare-current`: current and native
+runners initialize fresh preprocessing state and replay eligible same-generation
+history. Without the flag the expected output is the recorded live result, but
+the native execution is unchanged. Runtime-debug/v3 does not capture the imported
+preprocessing workspace or establish an empty-state origin. Default capture
+comparison is therefore diagnostic, not proof of equal live/native starting
+conditions; even a match does not establish live persistence replayability.
+
+The report's additive `replay_scope` object records the purpose (`source-parity`
+or `capture-diagnostic`), `preprocessing_origin`
+(`fresh-before-generation-prelude`), `history`
+(`eligible-same-generation-preprocessing`), `captured_initial_workspace`
+(`not-recorded`) and `live_state_equivalence` (`not-established`). Structural
+admissibility remains distinct from this state limitation. Exact differences,
+summary counts, exit status, schema versions and the shipped default are unchanged.
+Captured mode warns on stderr; stdout retains its summary/report-path format.
+
 The public report identifies the capture by its random 256-bit compile-time
 build ID, deterministic production source identity,
 `milan-parity-driver-build/v2` manifest SHA-256, sealed captured-library


### PR DESCRIPTION
## Summary

Make the supported source-parity workflow and the limitations of recorded-output comparisons explicit, without changing either replay implementation or hiding differences.

- Use `--compare-current` in the normal validation recipes and explain the required local support build.
- Explain both modes and their starting state in command help.
- Warn on stderr when comparing recorded live results with native replay: v3 does not record the imported preprocessing workspace, so equal live/native starting state is not established.
- Add report-level `replay_scope` metadata describing the comparison purpose, fresh state before generation history, and missing evidence of live-state equivalence. This is separate from structural input admissibility and existing per-operation verdicts.
- Document the future versioned state-capture/replay work needed to reproduce installed execution, its value and its limits.

## Why

The live driver can restore mature calibration and retained history that predate a capture, while both runners start fresh and replay eligible same-generation frames. Consequently, both offline implementations can match exactly while disagreeing with recorded live results. Setup flags and structurally complete input artifacts do not establish equal starting state. An ordinary recapture cannot supply fields omitted by the schema.

The no-flag comparison remains useful as a diagnostic, but its mismatches alone do not establish an equal-input algorithm defect. Its default, all exact differences, nonzero failure results, selected-operation handling, schema versions and stdout summary format are preserved. The new report object is additive metadata; it does not suppress or recategorize operation failures into passes or skips.

## Validation

- Python compilation and public `help validate-dump` pass.
- Replayed all eight selected operations from the same sealed UAT through the changed validator, using the pinned integration source and approved native runner.
- Current-source comparison still passes 8/8, exit0, without the captured-mode warning.
- Captured-output comparison still fails 8/8, exit1, now with the state-limitation warning.
- Compared every existing operation record, capture identity, selector, summary, comparison mode, policy and schema to the original reports: all unchanged. Verified new scope purpose and live-equivalence fields in both reports.
- `git diff --check` passes. No tests, dependencies, driver changes, capture-schema changes, hardware activity or service changes were added. The validator was exercised directly; the full driver suite was not rerun for help/report/documentation-only changes.

## Scope

This does not implement imported-state capture, change the native authority, or claim literal live-state parity. A future implementation must first reproduce the captured runtime input/output with current code, then establish an equivalent native state. Queue history remains naturally produced, never injected from captured occupancy.

Independent PR based on current main. No RE notes, internal plans, private reports or biometric artifacts are included.
