### PR TITLE
Match native signed-word Milan centering before clamping

### DIFF
--- a/drivers/goodix53x5/milan/core.c
+++ b/drivers/goodix53x5/milan/core.c
@@ -1216,7 +1216,7 @@ preprocess_refine_core (const uint16_t *source,
           if (valid_percent < 96 && mask[index] == 0)
             value = 5000;
           else
-            value = (int) source[index] - mean + 5000;
+            value = (int16_t) ((int) source[index] - mean + 5000);
           centered[index] = (uint16_t) (value > 0 ? value : 0);
         }
     }
@@ -2710,7 +2710,7 @@ milan_profile9_center_rows (const uint16_t *source,
           if (mask_percent < 96 && render_mask[index] == 0)
             value = 5000;
           else
-            value = (int) source[index] - mean + 5000;
+            value = (int16_t) ((int) source[index] - mean + 5000);
           centered[index] = (uint16_t) (value > 0 ? value : 0);
         }
     }
@@ -2841,7 +2841,7 @@ milan_profile9_rerender (const uint16_t *source,
           if (mask_percent < 96 && render_mask[index] == 0)
             value = 5000;
           else
-            value = (int) source[index] - mean + 5000;
+            value = (int16_t) ((int) source[index] - mean + 5000);
           centered[index] = (uint16_t) (value > 0 ? value : 0);
         }
     }


### PR DESCRIPTION
## Summary

Match the native signed-word arithmetic in profile-9/type-12 image centering. Narrow `source - row_mean + 5000` to signed 16 bits before applying the positive clamp in refined rendering, diagnostic centering and quality rerendering.

The working image is unsigned-word data produced after gain division. Raw12 input bounds do not guarantee signed16-centered output, and calibration publication can switch individual samples to the divided path within the same call. Clamping the wider integer first can therefore produce different centered words and rendered pixels.

The change preserves row means, mask handling, selection policy and buffer ownership.

## Validation

- Offline non-debug build and all eight existing Milan/device suites pass for this branch and the combined integration build.
- Arithmetic verification covers all 131,071 unsigned-word source-minus-mean differences.
- Integration build containing #210 and #211 passes the strict native/current parity checker across **14 campaigns and all 2,698 selected operations**:
  - **1,278 identify passed**
  - **1,420 verify passed**
  - **0 failed; 0 selected unavailable**
- Complete processed images, probes, gallery after-match outputs, candidates, natural queues, counts and lifecycle outputs are compared.

The campaign gate excludes 528 enrollment context records and 22 no-gallery context records. It validates current/native source parity under reconstructed preprocessing state, not literal reproduction of imported live state. No new tests or performance changes are included.