### PR TITLE
Preserve prior Milan direct affine when rescue omits replacement

### DIFF
--- a/drivers/goodix53x5/milan/match/match.c
+++ b/drivers/goodix53x5/milan/match/match.c
@@ -1716,6 +1716,11 @@ milan_match_finalize (MilanMatchFinalizationContext *context)
         memcpy (result->match_transform,
                 context->rescue_result->selected_transform,
                 sizeof (context->rescue_result->selected_transform));
+      else if (context->enrolled->metadata.sensor_type ==
+               GOODIX_MILAN_PRINT_SENSOR_TYPE &&
+               selection->selected_feature >= 0)
+        memcpy (result->match_transform, selection->selected_transform,
+                sizeof (selection->selected_transform));
       if (goodix_milan_match_selection_blocking_override (selection))
         result->score = -65536;
       return 0;


### PR DESCRIPTION
## Summary

Preserve the prior type-12 direct affine when successful aggregate rescue supplies no replacement. Native rescue may replace the selected index and score while retaining the earlier direct affine; current finalization instead left the outgoing transform at initialized identity.

Publication now follows the native ownership order:

1. Use an explicit rescue replacement when present.
2. Otherwise preserve a valid prior type-12 direct selection transform.
3. Retain initialized identity when there is no prior selection.

The selected-feature guard is required because the reset selection object contains a zero matrix, not identity. Scores, acceptance, relation ownership, lifecycle and study gates are unchanged.

## Validation

- Offline non-debug build and all eight existing Milan/device suites pass for this branch and the combined integration build.
- Integration build containing #210 and #211 passes the strict native/current parity checker across **14 campaigns and all 2,698 selected operations**:
  - **1,278 identify passed**
  - **1,420 verify passed**
  - **0 failed; 0 selected unavailable**
- Complete processed images, probes, gallery after-match outputs, candidates, natural queues, counts and lifecycle outputs are compared.

This is a conditional caller-publication parity correction. Ordinary positive-rescue reachability with a prior nonidentity affine remains unproven; no score or authentication impact is claimed. The campaign gate is integration coverage, not proof that it exercises this specific branch.

The gate excludes 528 enrollment context records and 22 no-gallery context records and compares reconstructed preprocessing state. This change is independent of #210.