### PR TITLE
Recover Milan manual and configuration response transactions

### DIFF
--- a/drivers/goodix53x5/device/commands.c
+++ b/drivers/goodix53x5/device/commands.c
@@ -347,12 +347,9 @@ goodix_cmd_parse_mcu_reply (FpDevice      *dev,
 gboolean
 goodix_cmd_parse_config_reply (FpDevice *dev)
 {
-  const guint8 *payload;
-  gsize payload_len;
-
-  return goodix_parse_reply_exact (dev, 0x9, 0x0, &payload, &payload_len,
-                                   NULL) &&
-         payload_len > 0 && payload[0] == 1;
+  /* Transport validated the packet and published native selector 1. Its
+   * payload is scratch, not a retained configuration success byte. */
+  return (FPI_DEVICE_GOODIX53X5 (dev)->command_response_ready & 2) != 0;
 }
 
 gboolean
@@ -361,18 +358,16 @@ goodix_cmd_parse_fdt_manual_reply (FpDevice      *dev,
                                    gsize         *out_payload_len,
                                    GError       **error)
 {
-  if (!goodix_parse_reply_exact (dev, GOODIX_PROTO_CATEGORY_FDT,
-                                 GOODIX_PROTO_CMD_FDT_MANUAL,
-                                 out_payload, out_payload_len, error))
-    return FALSE;
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
 
-  if (*out_payload_len < 4 + GOODIX_FDT_BASE_LEN)
+  if (!(self->command_response_ready & 1))
     {
-      g_set_error (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
-                   "Manual FDT reply is too short: %zu", *out_payload_len);
+      g_set_error_literal (error, FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                           "Manual FDT response is not ready");
       return FALSE;
     }
-
+  *out_payload = self->manual_response;
+  *out_payload_len = sizeof (self->manual_response);
   return TRUE;
 }
 

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -430,7 +430,10 @@ goodix_scan_coordinator_handler (FpiSsm   *ssm,
 
         data->receive_active = FALSE;
         g_clear_object (&data->event_cancel);
-        if (!goodix_cmd_parse_fdt_event (dev, fdt->wait_mode,
+        /* A queued notification retains its receive identity even when a
+         * subsequent arm has changed the worker's current wait mode. */
+        if (!goodix_cmd_parse_fdt_event (dev, data->event_preparsed ?
+                                         self->pending_fdt_mode : fdt->wait_mode,
                                          &data->event_type, &fdt->event,
                                          &error))
           {

--- a/drivers/goodix53x5/device/transport.c
+++ b/drivers/goodix53x5/device/transport.c
@@ -631,6 +631,7 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
                * latest worker notification, including during config/manual. */
               goodix_recv_apply_fdt_event (dev, type, &event);
               self->pending_fdt_packet_len = self->rx.expected;
+              self->pending_fdt_mode = mode;
               memcpy (self->pending_fdt_packet, self->rx.buf, self->rx.expected);
               goodix_proto_rx_reset (&self->rx);
               goto receive_more;

--- a/drivers/goodix53x5/device/transport.c
+++ b/drivers/goodix53x5/device/transport.c
@@ -69,6 +69,7 @@ typedef struct
   FpiSsm                   *parent_ssm;
   GoodixProfile9FdtWaitMode cancelled_fdt_mode;
   gboolean                  retry_mode;
+  guint8                    response_bit;
   guint                     attempt;
   GoodixCmdState            phase;
   gint64                    ack_deadline_us;
@@ -124,6 +125,12 @@ goodix_mode_ack_bit (guint8 cmd_byte)
     case 0x60:
       return 4;
 
+    case 0x36:
+      return 8;
+
+    case 0x90:
+      return 16;
+
     default:
       return 0;
     }
@@ -168,7 +175,8 @@ goodix_cmd_retry (FpDevice *dev,
   if (self->cmd_owner != operation->parent_ssm ||
       !operation->retry_mode || operation->attempt != 1 ||
       (operation->phase != GOODIX_CMD_SEND &&
-       operation->phase != GOODIX_CMD_RECV_ACK) ||
+       operation->phase != GOODIX_CMD_RECV_ACK &&
+       !(operation->response_bit && operation->phase == GOODIX_CMD_RECV_DATA)) ||
       !(g_error_matches (error, G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_TIMED_OUT) ||
         (operation->phase == GOODIX_CMD_SEND &&
          g_error_matches (error, G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_IO))))
@@ -567,6 +575,68 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
       gsize payload_len;
       gboolean expected_ack = FALSE;
 
+      if (goodix_proto_rx_parse (&self->rx, &category, &command,
+                                 &payload, &payload_len))
+        {
+          guint8 bit = category == 3 && command == 3 ? 1 :
+                       category == 9 && command == 0 ? 2 : 0;
+          GoodixCmdOperation *current = self->cmd_ssm == transfer->ssm ?
+                                        fpi_ssm_get_data (transfer->ssm) : NULL;
+
+          if (bit)
+            {
+              if (bit == 1)
+                {
+                  if (payload_len < sizeof (self->manual_response))
+                    {
+                      goodix_recv_operation_finish (dev, transfer->ssm, operation);
+                      goodix_recv_operation_free (operation);
+                      fpi_ssm_mark_failed (transfer->ssm, fpi_device_error_new_msg (
+                        FP_DEVICE_ERROR_PROTO, "Manual FDT reply is too short"));
+                      return;
+                    }
+                  memcpy (self->manual_response, payload, sizeof (self->manual_response));
+                }
+              /* Configuration publishes only an event, never a success byte.
+               * Both response slots are independent of ACK reception. */
+              self->command_response_ready |= bit;
+              if (!current || current->response_bit != bit ||
+                  current->phase != GOODIX_CMD_RECV_DATA)
+                {
+                  goodix_proto_rx_reset (&self->rx);
+                  goto receive_more;
+                }
+            }
+          else if (current && category == 3 && (command == 1 || command == 2) &&
+                   (current->response_bit ||
+                    (current->cmd.category == 3 && current->cmd.command <= 2)))
+            {
+              GoodixFdtEventType type;
+              GoodixProfile9FdtEvent event;
+              GoodixProfile9FdtWaitMode mode = command == 1 ?
+                GOODIX_PROFILE9_FDT_WAIT_DOWN : GOODIX_PROFILE9_FDT_WAIT_UP;
+              g_autoptr(GError) event_error = NULL;
+
+              if (payload_len != GOODIX_FDT_EVENT_PAYLOAD_LEN)
+                event_error = fpi_device_error_new_msg (FP_DEVICE_ERROR_PROTO,
+                                                        "Unexpected FDT event length");
+              if (event_error || !goodix_cmd_parse_fdt_event (dev, mode, &type, &event, &event_error))
+                {
+                  goodix_recv_operation_finish (dev, transfer->ssm, operation);
+                  goodix_recv_operation_free (operation);
+                  fpi_ssm_mark_failed (transfer->ssm, g_steal_pointer (&event_error));
+                  return;
+                }
+              /* Every native parser mutation precedes replacement of the
+               * latest worker notification, including during config/manual. */
+              goodix_recv_apply_fdt_event (dev, type, &event);
+              self->pending_fdt_packet_len = self->rx.expected;
+              memcpy (self->pending_fdt_packet, self->rx.buf, self->rx.expected);
+              goodix_proto_rx_reset (&self->rx);
+              goto receive_more;
+            }
+        }
+
       /* Native EC has no response event. Optional category-A/command-7 data
        * is ignored independently of the command or event currently awaited. */
       if (goodix_proto_rx_parse (&self->rx, &category, &command,
@@ -705,6 +775,10 @@ goodix_cmd_ssm_handler (FpiSsm   *ssm,
     {
     case GOODIX_CMD_SEND:
       operation->attempt++;
+      FPI_DEVICE_GOODIX53X5 (dev)->command_response_ready &= ~operation->response_bit;
+      if (operation->response_bit)
+        FPI_DEVICE_GOODIX53X5 (dev)->retried_mode_acks |= goodix_mode_ack_bit (
+          GOODIX_PROTO_CMD_BYTE (cmd->category, cmd->command));
       goodix_send_message (ssm, dev, cmd->category, cmd->command,
                            cmd->payload, cmd->payload_len, cmd->use_checksum);
       break;
@@ -732,36 +806,7 @@ goodix_cmd_ssm_handler (FpiSsm   *ssm,
     case GOODIX_CMD_VALIDATE_ACK:
       {
         g_autoptr(GError) error = NULL;
-        FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
-        guint8 category, command;
-        const guint8 *payload;
-        gsize payload_len;
         guint8 status;
-
-        /* Native applies EVERY event's base updates before replacing its one
-         * worker notification. Keep these updates even across ACK failure;
-         * the outstanding command still retries its original copied payload. */
-        if (operation->retry_mode && cmd->category == GOODIX_PROTO_CATEGORY_FDT &&
-            goodix_proto_rx_parse (&self->rx, &category, &command, &payload, &payload_len) &&
-            category == GOODIX_PROTO_CATEGORY_FDT && command == cmd->command &&
-            payload_len == GOODIX_FDT_EVENT_PAYLOAD_LEN)
-          {
-            GoodixFdtEventType type;
-            GoodixProfile9FdtEvent event;
-            GoodixProfile9FdtWaitMode mode = cmd->command == GOODIX_PROTO_CMD_FDT_DOWN ?
-                                             GOODIX_PROFILE9_FDT_WAIT_DOWN : GOODIX_PROFILE9_FDT_WAIT_UP;
-
-            if (!goodix_cmd_parse_fdt_event (dev, mode, &type, &event, &error))
-              {
-                fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
-                return;
-              }
-            goodix_recv_apply_fdt_event (dev, type, &event);
-            self->pending_fdt_packet_len = self->rx.expected;
-            memcpy (self->pending_fdt_packet, self->rx.buf, self->rx.expected);
-            fpi_ssm_jump_to_state (ssm, GOODIX_CMD_RECV_ACK);
-            return;
-          }
 
         if (operation->cancelled_fdt_mode != GOODIX_PROFILE9_FDT_WAIT_NONE &&
             goodix_try_drain_cancelled_fdt (dev, operation, &error))
@@ -791,7 +836,10 @@ goodix_cmd_ssm_handler (FpiSsm   *ssm,
       break;
 
     case GOODIX_CMD_RECV_DATA:
-      goodix_recv_start (ssm, dev, operation->response_timeout_ms, NULL);
+      if (operation->response_bit & FPI_DEVICE_GOODIX53X5 (dev)->command_response_ready)
+        fpi_ssm_next_state (ssm);
+      else
+        goodix_recv_start (ssm, dev, operation->response_timeout_ms, NULL);
       break;
     }
 }
@@ -853,10 +901,13 @@ goodix_run_cmd_full (FpiSsm                    *parent_ssm,
   operation = g_new0 (GoodixCmdOperation, 1);
   operation->parent_ssm = parent_ssm;
   operation->cancelled_fdt_mode = cancelled_mode;
-  operation->retry_mode = !expect_data &&
-                          ((category == GOODIX_PROTO_CATEGORY_FDT &&
-                            (command == GOODIX_PROTO_CMD_FDT_DOWN || command == GOODIX_PROTO_CMD_FDT_UP)) ||
-                           (category == 0x06 && command == 0));
+  operation->response_bit = expect_data ?
+                            (category == 3 && command == 3 ? 1 :
+                             category == 9 && command == 0 ? 2 : 0) : 0;
+  operation->retry_mode = operation->response_bit || (!expect_data &&
+                         ((category == GOODIX_PROTO_CATEGORY_FDT &&
+                           (command == GOODIX_PROTO_CMD_FDT_DOWN || command == GOODIX_PROTO_CMD_FDT_UP)) ||
+                          (category == 0x06 && command == 0)));
   cmd = &operation->cmd;
   cmd->category = category;
   cmd->command = command;

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -95,9 +95,13 @@ struct _FpiDeviceGoodix53x5
   FpiSsm *cmd_owner;
   FpiSsm *cmd_ssm;
 
-  /* Known repeated mode ACK slots. Kept for the device lifetime: there is no
-   * wire generation or reliable count of ACKs left after a timed-out send. */
+  /* Repeated mode and issued manual/config ACK slots. Kept for the device
+   * lifetime: the wire has no generation or reliable remaining ACK count. */
   guint8 retried_mode_acks;
+  /* Native response events reset per send; the manual cache survives reset.
+   * Retain its four metadata bytes for existing Linux touch-flag consumers. */
+  guint8 command_response_ready;
+  guint8 manual_response[4 + GOODIX_FDT_BASE_LEN];
   /* Parser mutations precede coalesced notification. The latest reverse event
    * retains the down base installed by its predecessor, not the arm payload. */
   guint16 fdt_prior_down[GOODIX_PROFILE9_FDT_AREA_COUNT];

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -107,6 +107,7 @@ struct _FpiDeviceGoodix53x5
   guint16 fdt_prior_down[GOODIX_PROFILE9_FDT_AREA_COUNT];
   guint8  pending_fdt_packet[4 + 4 + GOODIX_FDT_BASE_LEN];
   gsize   pending_fdt_packet_len;
+  GoodixProfile9FdtWaitMode pending_fdt_mode;
 
   /* Profile-9 FDT state persists across actions and hardware reinitialization. */
   GoodixProfile9FdtState profile9_fdt;

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -70,6 +70,7 @@ typedef enum {
   RESPONSE_STATUS,
   RESPONSE_DUPLICATE,
   RESPONSE_ASYNC,
+  RESPONSE_HANDOFF,
 } EventOrder;
 
 typedef struct {
@@ -301,6 +302,7 @@ complete_usb (gpointer unused)
   /* Request stop with the up-arm ACK still outstanding, except for the
    * separately controlled event-completion/cancellation boundary. */
   if (!scenario->standalone_arm && !rearm_case (scenario) && !io.disposition_sent &&
+      scenario->event_order != RESPONSE_HANDOFF &&
       scenario->event_order != EVENT_BEFORE_ARM_ACK &&
       transfer->endpoint == GOODIX_EP_IN &&
       io.command == 0x34 &&
@@ -385,7 +387,8 @@ complete_usb (gpointer unused)
       test_clock_us += 75 * 1000;
     }
   else if (scenario->event_order >= RESPONSE_EARLY &&
-           io.command == scenario->standalone_arm)
+           io.command == (scenario->event_order == RESPONSE_HANDOFF ?
+                          scenario->timeout_command : scenario->standalone_arm))
     {
       guint8 payload[4 + GOODIX_FDT_BASE_LEN];
       gboolean early = scenario->event_order == RESPONSE_EARLY ||
@@ -395,7 +398,8 @@ complete_usb (gpointer unused)
         payload[i] = i + 1;
       if (io.command == 0x90)
         payload[0] = scenario->ec_status;
-      if (scenario->event_order == RESPONSE_ASYNC && io.events < 2)
+      if ((scenario->event_order == RESPONSE_ASYNC ||
+           scenario->event_order == RESPONSE_HANDOFF) && io.events < 2)
         reverse_event (transfer, io.events);
       else if (early && !io.ec_data && io.early_attempt != io.sends[io.command])
         {
@@ -689,7 +693,10 @@ boundary_handler (FpiSsm *ssm, FpDevice *dev)
 {
   GoodixScanCoordinatorData *data = fpi_ssm_get_data (ssm);
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
-  if (fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_WAIT_CPU && rearm_case (io.scenario))
+  gboolean handoff = io.scenario->event_order == RESPONSE_HANDOFF;
+
+  if (fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_WAIT_CPU &&
+      (rearm_case (io.scenario) || handoff))
     {
       io.wait_cpu_count++;
       memcpy (io.settled_down, self->profile9_fdt.base_down, sizeof (io.settled_down));
@@ -699,7 +706,38 @@ boundary_handler (FpiSsm *ssm, FpDevice *dev)
       g_assert_true (data->cpu_outstanding);
     }
   if (fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_DISPATCH_EVENT)
-    io.dispatches++;
+    {
+      io.dispatches++;
+      if (handoff)
+        {
+          g_assert_cmpuint (self->profile9_fdt.wait_mode, ==, GOODIX_PROFILE9_FDT_WAIT_UP);
+          g_assert_true (data->event_preparsed);
+        }
+    }
+  /* Model the completed-capture boundary after a response command. Both
+   * reverse events arrive during that command; the real coordinator then
+   * arms UP and consumes the latest DOWN notification, before CPU settlement. */
+  if (handoff && fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_ENSURE_REFERENCE)
+    {
+      self->profile9_fdt.wait_mode = GOODIX_PROFILE9_FDT_WAIT_DOWN;
+      if (io.scenario->timeout_command == 0x36)
+        goodix_cmd_fdt_manual (ssm, dev, TRUE, self->profile9_fdt.base_manual);
+      else
+        {
+          gsize len;
+          const guint8 *config = goodix_device_get_default_config (&len);
+          g_autofree guint8 *patched = g_memdup2 (config, len);
+
+          goodix_device_patch_config (patched, len, &self->calib);
+          goodix_cmd_upload_config (ssm, dev, patched, len);
+        }
+      return;
+    }
+  if (handoff && fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_POWER_ON)
+    {
+      fpi_ssm_jump_to_state (ssm, GOODIX_SCAN_COORD_ARM_UP);
+      return;
+    }
   if (fpi_ssm_get_cur_state (ssm) == GOODIX_SCAN_COORD_ENSURE_REFERENCE)
     fpi_ssm_jump_to_state (ssm, (rearm_case (io.scenario) || down_drain_case (io.scenario))
                            ? GOODIX_SCAN_COORD_REARM_DOWN : GOODIX_SCAN_COORD_ARM_UP);
@@ -963,7 +1001,8 @@ test_scenario (gconstpointer user_data)
   for (guint step = 0; io.completions == 0 && step < 48; step++)
     {
       gboolean completed = FALSE;
-      if (!io.pending && rearm_case (scenario) && io.wait_cpu_count && !io.disposition_sent)
+      if (!io.pending && (rearm_case (scenario) || scenario->event_order == RESPONSE_HANDOFF) &&
+          io.wait_cpu_count && !io.disposition_sent)
         stop_after_capture (dev);
       if (!io.pending && !scenario->standalone_arm && self->profile9_fdt.owner &&
           fpi_ssm_get_cur_state (self->profile9_fdt.owner) >= GOODIX_SCAN_COORD_CLEANUP_JOIN &&
@@ -1086,7 +1125,7 @@ test_scenario (gconstpointer user_data)
       (io.sends[scenario->standalone_arm] != (scenario->event_order == RESPONSE_DEADLINE ? 2 : 1) ||
        io.data_chunks != (scenario->event_order == RESPONSE_DEADLINE ? 2 : 1) || io.events || io.dispatches))
     g_test_fail ();
-  if (scenario->event_order >= RESPONSE_EARLY &&
+  if (scenario->event_order >= RESPONSE_EARLY && scenario->event_order != RESPONSE_HANDOFF &&
       (io.sends[scenario->standalone_arm] !=
        (scenario->event_order == RESPONSE_RETRY || scenario->event_order == RESPONSE_EARLY_RESET ? 2 : 1) ||
        io.events != (scenario->event_order == RESPONSE_ASYNC ? 2 : 0) || io.dispatches))
@@ -1101,6 +1140,27 @@ test_scenario (gconstpointer user_data)
           self->profile9_fdt.base_manual[2 * i + 1] != 50 + i ||
           self->fdt_prior_down[i] != 50 + i || !self->pending_fdt_packet_len)
         g_test_fail ();
+  if (scenario->event_order == RESPONSE_HANDOFF)
+    {
+      if (io.events != 2 || io.dispatches != 1 || io.wait_cpu_count != 1 ||
+          io.sends[scenario->timeout_command] != 1 || io.sends[0x32] != 1 ||
+          self->pending_fdt_packet_len || self->profile9_fdt.event.irq != 0x80)
+        g_test_fail ();
+      for (guint i = 0; i < GOODIX_PROFILE9_FDT_AREA_COUNT; i++)
+        if (io.settled_prior[i] != 50 + i ||
+            io.settled_manual[2 * i] != 50 + i ||
+            io.settled_manual[2 * i + 1] != 50 + i ||
+            io.settled_down[2 * i] != 51 + i ||
+            io.settled_down[2 * i + 1] != 51 + i ||
+            io.last_down_payload[2 * i] != 51 + i ||
+            io.last_down_payload[2 * i + 1] != 51 + i ||
+            self->profile9_fdt.event.raw[2 * i] != 102 + 2 * i ||
+            self->profile9_fdt.event.raw[2 * i + 1] != 0)
+          g_test_fail ();
+      g_test_message ("handoff dispatch=%u wait_cpu=%u prior/manual/down=%u/%u/%u",
+                      io.dispatches, io.wait_cpu_count, io.settled_prior[0],
+                      io.settled_manual[0], io.settled_down[0]);
+    }
   if (polling_case (scenario) &&
       (io.even_followups != io.sends[scenario->timeout_command] ||
        (scenario->timeout_command == 0xae && io.sends[0xae] != 1)))
@@ -1217,12 +1277,15 @@ main (int argc, char **argv)
     { 0, 0, 0, 1, TRUE, RESPONSE_DUPLICATE, 0x90 },
     { 0, 0, 0, 1, TRUE, RESPONSE_ASYNC, 0x36 },
     { 0, 0, 0, 1, TRUE, RESPONSE_ASYNC, 0x90 },
+    { 0x36, 0, 1, 1, TRUE, RESPONSE_HANDOFF },
+    { 0x90, 0, 1, 1, TRUE, RESPONSE_HANDOFF },
   };
   const char *response_names[] = {
     "manual-early", "config-early", "manual-response-retry", "config-response-retry",
     "manual-ready-reset", "config-ready-reset", "config-status-zero", "config-status-one",
     "config-status-two",
     "manual-duplicate", "config-duplicate", "manual-two-reverse", "config-two-reverse",
+    "manual-reverse-up-handoff", "config-reverse-up-handoff",
   };
   for (guint i = 0; i < G_N_ELEMENTS (responses); i++)
     {

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -64,6 +64,12 @@ typedef enum {
   DOWN_BEFORE_SLEEP_ACK,
   REVERSE_BEFORE_SLEEP_ACK,
   STOP_DRAIN_CONTROL,
+  RESPONSE_EARLY,
+  RESPONSE_RETRY,
+  RESPONSE_EARLY_RESET,
+  RESPONSE_STATUS,
+  RESPONSE_DUPLICATE,
+  RESPONSE_ASYNC,
 } EventOrder;
 
 typedef struct {
@@ -105,6 +111,9 @@ static struct {
   guint8 packet_manual[2][GOODIX_FDT_BASE_LEN];
   guint8 last_down_payload[GOODIX_FDT_BASE_LEN];
   guint data_chunks;
+  guint early_attempt;
+  GBytes *first_response;
+  guint8 copied_response[4 + GOODIX_FDT_BASE_LEN];
   gboolean disposition_sent;
   gboolean ec_data;
   GError *error;
@@ -157,6 +166,8 @@ mock_submit (FpiUsbTransfer *transfer, guint timeout, GCancellable *cancel,
           first = &io.first_down;
           memcpy (io.last_down_payload, transfer->buffer + 5, GOODIX_FDT_BASE_LEN);
         }
+      else if (io.command == 0x36 || io.command == 0x90)
+        first = &io.first_response;
       if (first)
         {
           g_autoptr(GBytes) bytes = g_bytes_new (transfer->buffer,
@@ -235,7 +246,8 @@ response_case (const Scenario *scenario)
          scenario->event_order == RESPONSE_DEADLINE ||
          scenario->event_order == DUPLICATE_SLEEP_AFTER_EC_ACK ||
          scenario->event_order == EC_LATE_ACK ||
-         scenario->event_order == EC_LATE_DATA;
+          scenario->event_order == EC_LATE_DATA ||
+          scenario->event_order >= RESPONSE_EARLY;
 }
 
 static void
@@ -355,6 +367,68 @@ complete_usb (gpointer unused)
           io.cancellations++;
           error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED,
                                         "Scheduled event cancellation");
+        }
+    }
+  else if (scenario->event_order == RESPONSE_DUPLICATE && io.command == 0xae &&
+           io.sends[0xae] == 2 && io.duplicates < 2)
+    {
+      if (io.duplicates++ == 0)
+        ack_reply (transfer, scenario->standalone_arm);
+      else
+        {
+          guint8 payload[4 + GOODIX_FDT_BASE_LEN];
+          memset (payload, 0x77, sizeof (payload));
+          reply (transfer, scenario->standalone_arm >> 4,
+                 (scenario->standalone_arm & 0xf) >> 1,
+                 payload, scenario->standalone_arm == 0x90 ? 1 : sizeof (payload));
+        }
+      test_clock_us += 75 * 1000;
+    }
+  else if (scenario->event_order >= RESPONSE_EARLY &&
+           io.command == scenario->standalone_arm)
+    {
+      guint8 payload[4 + GOODIX_FDT_BASE_LEN];
+      gboolean early = scenario->event_order == RESPONSE_EARLY ||
+                       (scenario->event_order == RESPONSE_EARLY_RESET && io.sends[io.command] == 1);
+
+      for (guint i = 0; i < sizeof (payload); i++)
+        payload[i] = i + 1;
+      if (io.command == 0x90)
+        payload[0] = scenario->ec_status;
+      if (scenario->event_order == RESPONSE_ASYNC && io.events < 2)
+        reverse_event (transfer, io.events);
+      else if (early && !io.ec_data && io.early_attempt != io.sends[io.command])
+        {
+          io.early_attempt = io.sends[io.command];
+          reply (transfer, io.command >> 4, (io.command & 0xf) >> 1,
+                 payload, io.command == 0x90 ? 1 : sizeof (payload));
+          test_clock_us += 350 * 1000;
+          io.data_chunks++;
+        }
+      else if ((!io.ec_data && scenario->event_order == RESPONSE_EARLY_RESET &&
+                io.sends[io.command] == 1) ||
+               (io.ec_data && scenario->event_order == RESPONSE_RETRY &&
+                io.sends[io.command] == 1))
+        {
+          test_clock_us += io.timeout * 1000;
+          error = g_error_new_literal (G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_TIMED_OUT,
+                                       "Scheduled response-command timeout");
+        }
+      else if (!io.ec_data)
+        {
+          if (io.timeout != (early ? 150 : 500))
+            g_test_fail ();
+          ack_reply (transfer, io.command);
+          io.ec_data = TRUE;
+        }
+      else
+        {
+          /* An early response must avoid this receive entirely. */
+          if (early)
+            g_test_fail ();
+          reply (transfer, io.command >> 4, (io.command & 0xf) >> 1,
+                 payload, io.command == 0x90 ? 1 : sizeof (payload));
+          io.data_chunks++;
         }
     }
   else if (!io.ec_data)
@@ -486,14 +560,18 @@ complete_usb (gpointer unused)
            * has no attempt number; both carry identical command/status bytes. */
           ack_reply (transfer, io.command);
           guint expected_timeout = scenario->event_order == EC_LATE_ACK &&
-                                   io.command == scenario->standalone_arm ? 150 : ack_budget (io.command);
+                                    io.command == scenario->standalone_arm ? 150 : ack_budget (io.command);
+          if (scenario->event_order == RESPONSE_DUPLICATE && io.command == 0xae && io.sends[0xae] == 2)
+            expected_timeout = 50;
           if (response_case (scenario) && io.timeout != expected_timeout)
-            g_test_fail ();
+              g_test_fail ();
           if (io.command == 0xae)
             {
               if (scenario->event_order == LATE_EVEN_ACK && io.timeout != ack_budget (io.command) / 4)
                 g_test_fail ();
               io.expected_acks++;
+              if (scenario->event_order == RESPONSE_DUPLICATE && io.sends[0xae] == 2 && io.timeout != 50)
+                g_test_fail ();
             }
           io.ec_data = io.command == 0xae || scenario->event_order == MULTICELL_DATA ||
                        (response_case (scenario) && io.command == scenario->standalone_arm);
@@ -524,7 +602,8 @@ complete_usb (gpointer unused)
             }
           else
             {
-              if (io.timeout != (scenario->event_order == EC_LATE_ACK ? 500 : 150))
+              if (io.timeout != (scenario->event_order == EC_LATE_ACK ||
+                                 io.sends[io.command] > 1 ? 500 : 150))
                 g_test_fail ();
               io.data_chunks++;
               if (scenario->event_order == RESPONSE_DEADLINE)
@@ -734,17 +813,35 @@ response_handler (FpiSsm *ssm, FpDevice *dev)
         gsize length;
         g_autoptr(GError) error = NULL;
 
-        if (!goodix_parse_reply_exact (dev, io.command >> 4, (io.command & 0xf) >> 1,
-                                      &payload, &length, &error))
+        if (io.command == 0x90)
+          {
+            if (!goodix_cmd_parse_config_reply (dev))
+              g_test_fail ();
+            if (io.scenario->event_order == RESPONSE_DUPLICATE)
+              goodix_cmd_ec_control (ssm, dev, FALSE);
+            else
+              fpi_ssm_mark_completed (ssm);
+          }
+        else if (!goodix_cmd_parse_fdt_manual_reply (dev, &payload, &length, &error))
           fpi_ssm_mark_failed (ssm, g_steal_pointer (&error));
         else
           {
             g_assert_cmpuint (length, ==, io.command == 0x90 ? 1 : 4 + GOODIX_FDT_BASE_LEN);
             for (guint i = 0; i < length; i++)
               g_assert_cmpuint (payload[i], ==, i + 1);
-            fpi_ssm_mark_completed (ssm);
+            memcpy (io.copied_response, payload, length);
+            if (io.scenario->event_order == RESPONSE_DUPLICATE)
+              goodix_cmd_ec_control (ssm, dev, FALSE);
+            else
+              fpi_ssm_mark_completed (ssm);
           }
       }
+      break;
+    case 4:
+      if (io.scenario->standalone_arm == 0x36)
+        for (guint i = 0; i < sizeof (io.copied_response); i++)
+          g_assert_cmpuint (io.copied_response[i], ==, i + 1);
+      fpi_ssm_mark_completed (ssm);
       break;
     }
 }
@@ -826,7 +923,7 @@ test_scenario (gconstpointer user_data)
     {
       ssm = scenario->event_order == MULTICELL_DATA
         ? fpi_ssm_new (dev, data_handler, 2)
-        : response_case (scenario) ? fpi_ssm_new (dev, response_handler, 4)
+        : response_case (scenario) ? fpi_ssm_new (dev, response_handler, 5)
         : fpi_ssm_new (dev, arm_handler,
                        scenario->event_order == SAME_COMMAND_PRECEDENCE ? 4 : 3);
       self->profile9_fdt.owner = ssm;
@@ -902,7 +999,8 @@ test_scenario (gconstpointer user_data)
                          !response_case (scenario)) ||
     scenario->event_order == EVENT_BEFORE_ARM_ACK ||
     scenario->event_order == EVENT_COMPLETES_DURING_CANCEL;
-  gboolean duplicate = (scenario->standalone_arm && scenario->event_order != MULTICELL_DATA) ||
+  gboolean duplicate = (scenario->standalone_arm && scenario->event_order != MULTICELL_DATA &&
+                         scenario->event_order < RESPONSE_EARLY) ||
     scenario->event_order == DUPLICATE_SLEEP_BEFORE_EC_ACK ||
     scenario->event_order == DUPLICATE_SLEEP_AFTER_EC_ACK;
   if (rearm_case (scenario))
@@ -984,9 +1082,25 @@ test_scenario (gconstpointer user_data)
             g_test_fail ();
         }
     }
-  if (response_case (scenario) &&
-      (io.sends[scenario->standalone_arm] != 1 || io.data_chunks != 1 || io.events || io.dispatches))
+  if (response_case (scenario) && scenario->event_order < RESPONSE_EARLY &&
+      (io.sends[scenario->standalone_arm] != (scenario->event_order == RESPONSE_DEADLINE ? 2 : 1) ||
+       io.data_chunks != (scenario->event_order == RESPONSE_DEADLINE ? 2 : 1) || io.events || io.dispatches))
     g_test_fail ();
+  if (scenario->event_order >= RESPONSE_EARLY &&
+      (io.sends[scenario->standalone_arm] !=
+       (scenario->event_order == RESPONSE_RETRY || scenario->event_order == RESPONSE_EARLY_RESET ? 2 : 1) ||
+       io.events != (scenario->event_order == RESPONSE_ASYNC ? 2 : 0) || io.dispatches))
+    g_test_fail ();
+  if (scenario->event_order == RESPONSE_EARLY_RESET && io.data_chunks != 2)
+    g_test_fail ();
+  if (scenario->event_order == RESPONSE_ASYNC)
+    for (guint i = 0; i < GOODIX_PROFILE9_FDT_AREA_COUNT; i++)
+      if (self->profile9_fdt.base_down[2 * i] != 51 + i ||
+          self->profile9_fdt.base_down[2 * i + 1] != 51 + i ||
+          self->profile9_fdt.base_manual[2 * i] != 50 + i ||
+          self->profile9_fdt.base_manual[2 * i + 1] != 50 + i ||
+          self->fdt_prior_down[i] != 50 + i || !self->pending_fdt_packet_len)
+        g_test_fail ();
   if (polling_case (scenario) &&
       (io.even_followups != io.sends[scenario->timeout_command] ||
        (scenario->timeout_command == 0xae && io.sends[0xae] != 1)))
@@ -1031,6 +1145,7 @@ test_scenario (gconstpointer user_data)
   g_clear_pointer (&io.first_up, g_bytes_unref);
   g_clear_pointer (&io.first_sleep, g_bytes_unref);
   g_clear_pointer (&io.first_down, g_bytes_unref);
+  g_clear_pointer (&io.first_response, g_bytes_unref);
   g_clear_pointer (&self->captured_raw_image, g_free);
   g_clear_pointer (&self->rx.buf, g_free);
   goodix_milan_generation_invalidate (&self->milan_generation);
@@ -1088,6 +1203,32 @@ main (int argc, char **argv)
   static const Scenario drain_control = { 0, 0, 1, 1, TRUE, STOP_DRAIN_CONTROL };
 
   g_test_init (&argc, &argv, NULL);
+  static const Scenario responses[] = {
+    { 0, 0, 0, 1, TRUE, RESPONSE_EARLY, 0x36 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_EARLY, 0x90 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_RETRY, 0x36 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_RETRY, 0x90 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_EARLY_RESET, 0x36 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_EARLY_RESET, 0x90 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_STATUS, 0x90, 0 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_STATUS, 0x90, 1 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_STATUS, 0x90, 2 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_DUPLICATE, 0x36 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_DUPLICATE, 0x90 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_ASYNC, 0x36 },
+    { 0, 0, 0, 1, TRUE, RESPONSE_ASYNC, 0x90 },
+  };
+  const char *response_names[] = {
+    "manual-early", "config-early", "manual-response-retry", "config-response-retry",
+    "manual-ready-reset", "config-ready-reset", "config-status-zero", "config-status-one",
+    "config-status-two",
+    "manual-duplicate", "config-duplicate", "manual-two-reverse", "config-two-reverse",
+  };
+  for (guint i = 0; i < G_N_ELEMENTS (responses); i++)
+    {
+      g_autofree char *name = g_strdup_printf ("/goodix53x5/milan/transport/responses/%s", response_names[i]);
+      g_test_add_data_func (name, &responses[i], test_scenario);
+    }
   g_test_add_data_func ("/goodix53x5/milan/transport/stop-during-arm", &control, test_scenario);
   g_test_add_data_func ("/goodix53x5/milan/transport/event-before-sleep-ack", &drain, test_scenario);
   g_test_add_data_func ("/goodix53x5/milan/transport/event-completes-during-cancel", &event_race, test_scenario);


### PR DESCRIPTION
## Change

Align manual-FDT and configuration transactions with native response-event ownership:

- Retry one eligible send/ACK/response failure with the identical retained command payload.
- Reset response readiness before each attempt while retaining manual response cache contents.
- Accept responses before ACK and route delayed responses independently of subsequent waits.
- Treat configuration response arrival as completion regardless of its status byte; native signals its response event without testing that byte.
- Apply every asynchronous FDT base mutation before retaining the latest notification. Preserve the notification's received mode across subsequent arm commands so later dispatch does not reject an already-validated event.

Manual response cache remains distinct from the asynchronous manual base. Caller-owned output is not rewritten by a later duplicate. Deadlines are not extended by interleaved replies.

## Validation

Native instruction execution covers retry/readiness ownership, configuration status 0/1/2, early/late responses and independent FDT publication. Paired parent/current tests distinguish response recovery and real coordinator handoff across an arm-mode change.

Transport: 56 cases pass. Full offline release: nine suites, 232 cases pass. Tests check retry bytes, returned data, base history, notification dispatch and final ownership; they do not model physical USB scheduling.
