### PR TITLE
Preserve completed Milan authentication across cleanup errors

### DIFF
--- a/drivers/goodix53x5/device/auth.c
+++ b/drivers/goodix53x5/device/auth.c
@@ -600,6 +600,8 @@ goodix_verify_ssm_done (FpiSsm   *ssm,
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   FpiDeviceAction action = fpi_device_get_current_action (dev);
   gboolean updated = FALSE;
+  gboolean removed = FALSE;
+  gboolean cancelled;
 
   (void) ssm;
 
@@ -608,6 +610,24 @@ goodix_verify_ssm_done (FpiSsm   *ssm,
 #endif
   g_clear_pointer (&self->captured_raw_image, g_free);
 
+  g_object_get (dev, "removed", &removed, NULL);
+  cancelled = fpi_device_action_is_cancelled (dev) ||
+              (self->cancel && g_cancellable_is_cancelled (self->cancel));
+  if (error && self->scan_cleanup_only_error && self->pending_result_report &&
+      !cancelled && !removed)
+    {
+      /* Native deactivation attempts shutdown before update/storage, but its
+       * IOCTL result does not invalidate the completed comparison or admission.
+       * Scan and worker callbacks have joined before reaching this owner. */
+      fp_dbg ("Preserving completed authentication after cleanup failure: %s", error->message);
+      self->needs_reinit = TRUE;
+      g_clear_error (&error);
+    }
+  self->scan_cleanup_only_error = FALSE;
+  if (!error && cancelled)
+    error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED, "Authentication cancelled");
+  if (!error && removed)
+    error = fpi_device_error_new (FP_DEVICE_ERROR_REMOVED);
   if (!error)
     {
       if (!self->pending_result_report)
@@ -650,6 +670,7 @@ goodix_auth_start (FpDevice *dev)
   self->cancel = g_cancellable_new ();
   goodix_clear_pending_result_report (self);
   self->action_epoch++;
+  self->scan_cleanup_only_error = FALSE;
   if (self->action_epoch == 0)
     self->action_epoch++;
 #ifdef GOODIX53X5_DEBUG

--- a/drivers/goodix53x5/device/scan.c
+++ b/drivers/goodix53x5/device/scan.c
@@ -743,6 +743,37 @@ goodix_scan_coordinator_done (FpiSsm   *ssm,
 }
 
 void
+goodix_scan_note_command_error (FpiSsm *ssm, FpDevice *dev, const GError *error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  GoodixScanCoordinatorData *data;
+  gboolean ordinary;
+  gint state;
+
+  if (self->profile9_fdt.owner != ssm)
+    return;
+  state = fpi_ssm_get_cur_state (ssm);
+  if (state != GOODIX_SCAN_COORD_CLEANUP_SLEEP && state != GOODIX_SCAN_COORD_CLEANUP_EC_OFF)
+    {
+      self->scan_cleanup_only_error = FALSE;
+      return;
+    }
+  data = fpi_ssm_get_data (ssm);
+  ordinary = error->domain == G_USB_DEVICE_ERROR &&
+             (error->code == G_USB_DEVICE_ERROR_TIMED_OUT ||
+              error->code == G_USB_DEVICE_ERROR_IO ||
+              error->code == G_USB_DEVICE_ERROR_FAILED ||
+              error->code == G_USB_DEVICE_ERROR_NOT_SUPPORTED ||
+              error->code == G_USB_DEVICE_ERROR_INTERNAL);
+  if (!ordinary || data->stop_error || !data->cpu_done || data->cpu_outstanding)
+    self->scan_cleanup_only_error = FALSE;
+  else if (!fpi_ssm_get_error (ssm))
+    self->scan_cleanup_only_error = TRUE;
+  /* A preceding capture/processing error retains its first-error ownership.
+   * A later protocol, cancellation or removal failure revokes cleanup-only. */
+}
+
+void
 goodix_scan_start_coordinator_subsm (
   FpiSsm                       *parent_ssm,
   FpDevice                     *dev,
@@ -765,6 +796,7 @@ goodix_scan_start_coordinator_subsm (
     }
 
   data = g_new0 (GoodixScanCoordinatorData, 1);
+  self->scan_cleanup_only_error = FALSE;
   data->parent_ssm = parent_ssm;
   data->capture_ready = capture_ready;
   data->cycle_settled = cycle_settled;

--- a/drivers/goodix53x5/device/scan.h
+++ b/drivers/goodix53x5/device/scan.h
@@ -21,6 +21,9 @@
 
 #include "driver-private.h"
 
+/* Record command failure before the scan SSM retains its first error. */
+void goodix_scan_note_command_error (FpiSsm *ssm, FpDevice *dev, const GError *error);
+
 typedef enum
 {
   /* Authentication matched; stop without waiting for a later lift event. */

--- a/drivers/goodix53x5/device/transport.c
+++ b/drivers/goodix53x5/device/transport.c
@@ -23,6 +23,7 @@
 #include "driver-private.h"
 #include "device/transport.h"
 #include "device/calibration.h"
+#include "device/scan.h"
 
 #include <string.h>
 
@@ -905,6 +906,7 @@ goodix_cmd_ssm_done (FpiSsm   *ssm,
 
   if (error)
     {
+      goodix_scan_note_command_error (operation->parent_ssm, dev, error);
       goodix_mark_coordinator_io_failure (self, error);
       fpi_ssm_mark_failed (operation->parent_ssm, error);
     }

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -101,6 +101,9 @@ struct _FpiDeviceGoodix53x5
   /* Native response events reset per send; the manual cache survives reset.
    * Retain its four metadata bytes for existing Linux touch-flag consumers. */
   guint8 command_response_ready;
+  /* Current scan's first error is ordinary deactivation transport failure,
+   * after worker join. Only authentication may preserve a computed result. */
+  gboolean scan_cleanup_only_error;
   guint8 manual_response[4 + GOODIX_FDT_BASE_LEN];
   /* Parser mutations precede coalesced notification. The latest reverse event
    * retains the down base installed by its predecessor, not the arm payload. */

--- a/tests/test-goodix53x5-milan-runtime-auth.c
+++ b/tests/test-goodix53x5-milan-runtime-auth.c
@@ -277,3 +277,74 @@ test_malformed_current_print (void)
   clear_result (&result);
   close_device (device);
 }
+
+void
+test_auth_cleanup_results (gconstpointer user_data)
+{
+  guint row = GPOINTER_TO_UINT (user_data);
+  gboolean missing = row == 7;
+  gboolean failed_cleanup = row % 2 || row >= 6;
+  gboolean publish = row < 6;
+  gboolean matched = row < 4 || row >= 6;
+  gboolean update_expected = publish && row < 2;
+  gint32 score = matched ? 37 : 0;
+  g_autoptr(FpDevice) device = new_device ();
+  g_autoptr(GBytes) stored = generate_template (0);
+  g_autoptr(GBytes) update = generate_template (1);
+  g_autoptr(FpPrint) print = make_print (device, stored);
+  g_autoptr(GCancellable) cancel = g_cancellable_new ();
+  GBytes *gallery[] = { stored };
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (device);
+  AsyncResult result = { 0 };
+
+  reset_plan (&score, gallery, 1, update);
+  if (row >= 2 && row < 6)
+    plan.study_action = GOODIX_MILAN_STUDY_NONE;
+  pause_before_capture = missing;
+  pause_cycle_settled = !missing;
+  fp_device_verify (device, print, cancel, match_report, &result, NULL, verify_done, &result);
+  wait_paused ();
+  g_assert_cmpuint (result.reports, ==, 0);
+  g_assert_cmpuint (result.completions, ==, 0);
+  g_assert_cmpint (self->pending_result_report, ==, !missing);
+  g_autoptr(GBytes) before = get_print_template (print);
+  g_assert_true (g_bytes_equal (before, stored));
+
+  /* Scan provenance is the seam here; the USB suite proves its actual producer.
+   * All matching, update admission and deferred publication use real owners. */
+  self->scan_cleanup_only_error = failed_cleanup && row != 6;
+  if (failed_cleanup)
+    self->needs_reinit = TRUE;
+  if (row == 8)
+    {
+      g_cancellable_cancel (cancel);
+      wait_cancelled ();
+    }
+  if (row == 9)
+    fpi_device_remove (device);
+  if (failed_cleanup)
+    fpi_ssm_mark_failed (paused_ssm, g_error_new_literal (
+                          G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_TIMED_OUT,
+                          "Scheduled terminal transport failure"));
+  else
+    fpi_ssm_mark_completed (paused_ssm);
+  paused_ssm = NULL;
+  pause_before_capture = FALSE;
+  pause_cycle_settled = FALSE;
+  wait_done (&result);
+
+  /* Nonfatal assertions retain every baseline row's cleanup and evidence. */
+  if (result.completions != 1 || result.success != publish ||
+      result.reports != (publish ? 1 : 0) || result.updated != update_expected ||
+      (publish && result.matched != matched) ||
+      (failed_cleanup && !self->needs_reinit))
+    g_test_fail ();
+  g_autoptr(GBytes) after = get_print_template (print);
+  if (!g_bytes_equal (after, update_expected ? update : stored))
+    g_test_fail ();
+  clear_result (&result);
+  if (row == 9)
+    fp_device_close_sync (device, NULL, NULL);
+  else
+    close_device (device);
+}

--- a/tests/test-goodix53x5-milan-runtime-support.h
+++ b/tests/test-goodix53x5-milan-runtime-support.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "drivers_api.h"
+
 #include "fpi-print.h"
 #include "drivers/goodix53x5/device/scan.h"
 #include "drivers/goodix53x5/driver-private.h"
@@ -123,6 +124,7 @@ gboolean milan_runtime_harness_stale_error (const GError *error);
 
 void test_auth_gallery_outcomes (void);
 void test_auth_publication_contracts (void);
+void test_auth_cleanup_results (gconstpointer user_data);
 void test_malformed_current_print (void);
 void test_cancellation_no_publication (void);
 void test_enrollment_combine_retry (void);

--- a/tests/test-goodix53x5-milan-runtime.c
+++ b/tests/test-goodix53x5-milan-runtime.c
@@ -19,6 +19,16 @@ main (int    argc,
   g_test_init (&argc, &argv, NULL);
   g_mutex_init (&plan.mutex);
   g_cond_init (&plan.condition);
+  const char *cleanup_names[] = {
+    "update-clean", "update-cleanup-failure", "no-update-clean", "no-update-cleanup-failure",
+    "no-match-clean", "no-match-cleanup-failure", "earlier-error", "missing-result",
+    "cancelled-result", "removed-result",
+  };
+  for (guint i = 0; i < G_N_ELEMENTS (cleanup_names); i++)
+    {
+      g_autofree char *name = g_strdup_printf ("/goodix53x5/milan/runtime/cleanup/%s", cleanup_names[i]);
+      g_test_add_data_func (name, GUINT_TO_POINTER (i), test_auth_cleanup_results);
+    }
   g_test_add_func ("/goodix53x5/milan/runtime/auth-gallery-outcomes",
                    test_auth_gallery_outcomes);
   g_test_add_func ("/goodix53x5/milan/runtime/auth-publication-contracts",

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -61,6 +61,8 @@ typedef enum {
   SEND_STALL_RETRY,
   SEND_INTERNAL_RETRY,
   WRITE_STALLED_CANCEL,
+  EARLIER_CLEANUP_ERROR,
+  CLEANUP_LATE_PROTO,
   SAME_COMMAND_PRECEDENCE,
   MULTICELL_DATA,
   ACK_ZERO_THEN_ONE,
@@ -399,11 +401,12 @@ complete_usb (gpointer unused)
                                        "Action write cancelled before completion");
         }
       else if (io.command == 0x34 && io.sends[0x34] == 1 &&
-               order >= SEND_IO_RETRY && order <= SEND_INTERNAL_RETRY)
+               ((order >= SEND_IO_RETRY && order <= SEND_INTERNAL_RETRY) ||
+                order == EARLIER_CLEANUP_ERROR))
         {
           gint code = order == SEND_IO_RETRY ? G_USB_DEVICE_ERROR_IO :
             order == SEND_TIMEOUT_RETRY ? G_USB_DEVICE_ERROR_TIMED_OUT :
-            order == SEND_DISCONNECT ? G_USB_DEVICE_ERROR_NO_DEVICE :
+            order == SEND_DISCONNECT || order == EARLIER_CLEANUP_ERROR ? G_USB_DEVICE_ERROR_NO_DEVICE :
             order == SEND_CANCELLED ? G_USB_DEVICE_ERROR_CANCELLED :
             order == SEND_FAILED_RETRY ? G_USB_DEVICE_ERROR_FAILED :
             order == SEND_STALL_RETRY ? G_USB_DEVICE_ERROR_NOT_SUPPORTED : G_USB_DEVICE_ERROR_INTERNAL;
@@ -551,7 +554,9 @@ complete_usb (gpointer unused)
     }
   else if (!io.ec_data)
     {
-      if (scenario->event_order == EC_LATE_ACK && io.command == scenario->standalone_arm &&
+      if (scenario->event_order == CLEANUP_LATE_PROTO && io.command == 0xae)
+        reply (transfer, 0xb, 0, &io.command, 1);
+      else if (scenario->event_order == EC_LATE_ACK && io.command == scenario->standalone_arm &&
           io.duplicates == 0)
         {
           if (io.timeout != 500)
@@ -1210,7 +1215,7 @@ test_scenario (gconstpointer user_data)
                       io.packet_down[1][0], io.packet_manual[1][0]);
     }
   gboolean excluded_send = scenario->event_order == SEND_DISCONNECT ||
-    scenario->event_order == SEND_CANCELLED;
+    scenario->event_order == SEND_CANCELLED || scenario->event_order == EARLIER_CLEANUP_ERROR;
   gboolean malformed = scenario->event_order == ACK_EVEN_THEN_MALFORMED ||
                        scenario->event_order == ARM_CONFIG_PROTO;
   if (stop_state_case (scenario))
@@ -1301,6 +1306,17 @@ test_scenario (gconstpointer user_data)
         g_test_fail ();
   gboolean exhausted_arm = scenario->event_order == ARM_REPEAT_FAIL ||
                            scenario->event_order == ARM_FIRST_FAIL;
+  if (!scenario->standalone_arm &&
+      ((scenario->timeout_command == 0x60 && scenario->timeout_count == 2) ||
+       scenario->timeout_command == 0xae))
+    {
+      gboolean cleanup_only = scenario->event_order != EARLIER_CLEANUP_ERROR &&
+                              scenario->event_order != CLEANUP_LATE_PROTO;
+      if (self->scan_cleanup_only_error != cleanup_only)
+        g_test_fail ();
+    }
+  if ((cancelled || excluded_send) && self->scan_cleanup_only_error)
+    g_test_fail ();
   if (scenario->event_order == WRITE_STALLED_CANCEL &&
       (io.started_writes != 1 || io.precancelled_writes != 2 || io.cancelled_writes != 3))
     g_test_fail ();
@@ -1339,7 +1355,8 @@ test_scenario (gconstpointer user_data)
                     (self->needs_reinit != (io.cancelled_writes != 0)) ||
                     !g_error_matches (io.error, G_IO_ERROR, G_IO_ERROR_CANCELLED))) ||
       (excluded_send && !g_error_matches (io.error, G_USB_DEVICE_ERROR,
-                           scenario->event_order == SEND_DISCONNECT ?
+                           scenario->event_order == SEND_DISCONNECT ||
+                           scenario->event_order == EARLIER_CLEANUP_ERROR ?
                            G_USB_DEVICE_ERROR_NO_DEVICE : G_USB_DEVICE_ERROR_CANCELLED)) ||
       (!scenario->success && !exhausted_arm && !cancelled && !excluded_send && !malformed &&
        (!g_error_matches (io.error, G_USB_DEVICE_ERROR,
@@ -1413,6 +1430,10 @@ main (int argc, char **argv)
   static const Scenario drain_control = { 0, 0, 1, 1, TRUE, STOP_DRAIN_CONTROL };
 
   g_test_init (&argc, &argv, NULL);
+  static const Scenario cleanup_earlier = { 0x60, 2, 1, 2, FALSE, EARLIER_CLEANUP_ERROR };
+  static const Scenario cleanup_protocol = { 0x60, 2, 1, 2, FALSE, CLEANUP_LATE_PROTO };
+  g_test_add_data_func ("/goodix53x5/milan/transport/cleanup/earlier-error", &cleanup_earlier, test_scenario);
+  g_test_add_data_func ("/goodix53x5/milan/transport/cleanup/later-protocol", &cleanup_protocol, test_scenario);
   static const Scenario writes[] = {
     { 0, 0, 2, 1, TRUE, SEND_FAILED_RETRY },
     { 0, 0, 2, 1, TRUE, SEND_STALL_RETRY },


### PR DESCRIPTION
## Change

Separate completed authentication-result ownership from subsequent deactivation transport errors.

Preserve a valid pending match/no-match result and an independently admitted template update when the first failure occurs in sleep/EC cleanup after CPU work has completed. Continue joining all worker/transfer ownership before final publication. Retain cleanup diagnostics and next-operation reinitialization.

Earlier capture/processing errors, missing results, protocol corruption, cancellation and removal are not promoted to success. A later nonordinary error revokes cleanup-only classification. Enrollment's final-result gate is unchanged.

## Native contract

The exported native engine deactivation entry ignores the deactivation IOCTL result, then invokes study/update processing. Match and positive-update predicates remain independent of shutdown success. Verification returns its comparison result through a separate interface entry.

## Validation

Six actual native consumer controls cover match with update, match without update and no-match, each with successful/failed deactivation. Current transport tests establish cleanup-error provenance; runtime tests exercise deferred result/update publication and exclusion gates.

Full release: nine suites, 267 cases pass. Debug transport/runtime: 98 cases pass. Leak-enabled ASan/UBSan: 81 transport cases and all ten focused cleanup-result cases pass. These are split command/runtime-boundary proofs, not full physical-device execution.
