### PR TITLE
Preserve native Milan relation guards and defined affine arithmetic

### DIFF
--- a/drivers/goodix53x5/milan/match/geometry.c
+++ b/drivers/goodix53x5/milan/match/geometry.c
@@ -991,14 +991,22 @@ goodix_milan_estimate_relation (
                 (((int64_t) affine[3] * x +
                   (int64_t) affine[4] * y) >> 8) +
                 affine[5];
+              /* Native rejects mapped coordinates before subtraction, then
+               * bounds each residual before evaluating its square. */
+              if (transformed_x <= -INT64_C(0x100000000) ||
+                  transformed_x >= INT64_C(0x100000000) ||
+                  transformed_y <= -INT64_C(0x100000000) ||
+                  transformed_y >= INT64_C(0x100000000))
+                continue;
               int64_t dx = transformed_x -
                            (uint16_t) prior_records[matches[i].prior_index].refined_x;
               int64_t dy = transformed_y -
                            (uint16_t) prior_records[matches[i].prior_index].refined_y;
+              if (dx < -640 || dx > 640 || dy < -640 || dy > 640)
+                continue;
               int64_t squared = dx * dx + dy * dy;
 
-              if (llabs (dx) < 0x281 && llabs (dy) < 0x281 &&
-                  squared < 0x64000)
+              if (squared < 0x64000)
                 {
                   inliers++;
                   residual_sum += squared;

--- a/drivers/goodix53x5/milan/match/overlap.c
+++ b/drivers/goodix53x5/milan/match/overlap.c
@@ -361,7 +361,7 @@ milan_build_overlap_mask (const uint8_t source_mask[44 * 52],
                 (int64_t) adjusted_transform[1] * adjusted_transform[3];
   if (determinant == 0)
     return -1;
-  inverse[0] = (int32_t) (((int64_t) adjusted_transform[4] << 18) /
+  inverse[0] = (int32_t) (((int64_t) adjusted_transform[4] * INT64_C(0x40000)) /
                           determinant);
   inverse[1] = (int32_t) ((int64_t) adjusted_transform[3] * -0x40000 /
                           determinant);
@@ -371,7 +371,7 @@ milan_build_overlap_mask (const uint8_t source_mask[44 * 52],
                              adjusted_transform[2]) * 0x400) / determinant);
   inverse[3] = (int32_t) ((int64_t) adjusted_transform[1] * -0x40000 /
                           determinant);
-  inverse[4] = (int32_t) (((int64_t) adjusted_transform[0] << 18) /
+  inverse[4] = (int32_t) (((int64_t) adjusted_transform[0] * INT64_C(0x40000)) /
                           determinant);
   inverse[5] = (int32_t) ((((int64_t) adjusted_transform[3] *
                              adjusted_transform[2] -

--- a/drivers/goodix53x5/milan/match/overlap.c
+++ b/drivers/goodix53x5/milan/match/overlap.c
@@ -181,13 +181,13 @@ goodix_milan_match_bitmap_classes (
                 (int64_t) transform[1] * transform[3];
   if (determinant == 0)
     return -1;
-  inverse[0] = (int32_t) (((int64_t) transform[4] << 18) / determinant);
+  inverse[0] = (int32_t) (((int64_t) transform[4] * INT64_C(0x40000)) / determinant);
   inverse[1] = (int32_t) ((int64_t) transform[3] * -0x40000 / determinant);
   inverse[2] = (int32_t) ((((int64_t) transform[5] * transform[1] -
                             (int64_t) transform[4] * transform[2]) * 0x400) /
                           determinant);
   inverse[3] = (int32_t) ((int64_t) transform[1] * -0x40000 / determinant);
-  inverse[4] = (int32_t) (((int64_t) transform[0] << 18) / determinant);
+  inverse[4] = (int32_t) (((int64_t) transform[0] * INT64_C(0x40000)) / determinant);
   inverse[5] = (int32_t) ((((int64_t) transform[3] * transform[2] -
                             (int64_t) transform[5] * transform[0]) * 0x400) /
                           determinant);
@@ -440,7 +440,7 @@ milan_match_low_bitmap_compute (
                 (int64_t) adjusted_transform[1] * adjusted_transform[3];
   if (determinant == 0)
     return -1;
-  inverse[0] = (int32_t) (((int64_t) adjusted_transform[4] << 18) /
+  inverse[0] = (int32_t) (((int64_t) adjusted_transform[4] * INT64_C(0x40000)) /
                           determinant);
   inverse[1] = (int32_t) ((int64_t) adjusted_transform[3] * -0x40000 /
                           determinant);
@@ -450,7 +450,7 @@ milan_match_low_bitmap_compute (
                              adjusted_transform[2]) * 0x400) / determinant);
   inverse[3] = (int32_t) ((int64_t) adjusted_transform[1] * -0x40000 /
                           determinant);
-  inverse[4] = (int32_t) (((int64_t) adjusted_transform[0] << 18) /
+  inverse[4] = (int32_t) (((int64_t) adjusted_transform[0] * INT64_C(0x40000)) /
                           determinant);
   inverse[5] = (int32_t) ((((int64_t) adjusted_transform[3] *
                              adjusted_transform[2] -


### PR DESCRIPTION
## Change

Preserve native relation-estimation rejection order and use defined C arithmetic for signed affine scaling.

- Reject mapped coordinates outside strict `(-2^32, 2^32)` before target subtraction.
- Reject residual components outside inclusive `[-640, 640]` before squaring; retain the strict radial threshold of `0x64000`.
- Replace six widened signed left shifts in affine inverse calculations with multiplication by `2^18`. Every input is `int32_t`, so the product fits `int64_t`; division and rounding are unchanged.

The mapped/residual predicates and evaluation order are verified in the native relation owner. Bounded multiplication avoids evaluating signed squares for rejected candidates. Signed scaling has range `[-2^49, 2^49 - 2^18]`, preserving the intended numerical result for negative coefficients without undefined left shift.

## Validation

The existing complete-enrollment runtime case exposes the pre-correction signed operations under UBSan. No fixture changes or new test cases are included.

- Full offline release: nine suites, **267 cases pass**.
- Debug runtime: **17 cases pass**.
- Full runtime under AddressSanitizer, UndefinedBehaviorSanitizer and enabled leak detection: **17 cases pass**, without suppressions.

Existing native matching/study/preprocessing golden suites pass. This is a bounded arithmetic correction, not a claim of exhaustive matcher parity.
