### PR TITLE
Keep Milan reception alive through EC-off and close handoff

### DIFF
--- a/drivers/goodix53x5/device/commands.c
+++ b/drivers/goodix53x5/device/commands.c
@@ -351,7 +351,10 @@ goodix_cmd_ec_control (FpiSsm *ssm, FpDevice *dev, gboolean on)
   guint8 payload_on[3] = { 0x01, 0x01, 0x00 };
   guint8 payload_off[3] = { 0x00, 0x00, 0x00 };
 
-  goodix_run_cmd (ssm, dev, 0xA, 0x7, on ? payload_on : payload_off, 3, FALSE);
+  if (on)
+    goodix_run_cmd (ssm, dev, 0xA, 0x7, payload_on, 3, FALSE);
+  else
+    goodix_run_cmd_ec_off (ssm, dev, payload_off, sizeof (payload_off));
 }
 
 /* ========================================================================

--- a/drivers/goodix53x5/device/session.c
+++ b/drivers/goodix53x5/device/session.c
@@ -674,14 +674,17 @@ goodix_cleanup_failed_open (FpDevice *dev)
 }
 
 static void
-goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
+goodix_open_complete_after_idle (FpDevice *dev, gpointer data)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
-
-  self->task_ssm = NULL;
+  GError *error = data;
 
   if (error)
     {
+      /* Reset/close ends the transport that could complete retained data.
+       * A completion winning idle cancellation may have just appended it. */
+      goodix_proto_rx_reset (&self->rx);
+      self->rx_idle_partial = FALSE;
       self->open_ref_powered = FALSE;
       goodix_milan_generation_invalidate (&self->milan_generation);
       goodix_milan_persistence_clear (dev);
@@ -721,6 +724,20 @@ goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
   goodix_debug_timing_open_done (self, dev, NULL);
   self->needs_reinit = FALSE;
   fpi_device_open_complete (dev, NULL);
+}
+
+static void
+goodix_open_ssm_done (FpiSsm *ssm, FpDevice *dev, GError *error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  self->task_ssm = NULL;
+  /* The SSM is freed on return. Transfer only its completion error to the
+   * join callback; the open action and idle owner retain the device. */
+  if (error)
+    goodix_idle_recv_stop (dev, goodix_open_complete_after_idle, error);
+  else
+    goodix_open_complete_after_idle (dev, NULL);
 }
 
 void

--- a/drivers/goodix53x5/device/session.c
+++ b/drivers/goodix53x5/device/session.c
@@ -754,6 +754,12 @@ goodix_start_open_ssm (FpDevice *dev)
  * Returns TRUE if a reinit sub-SSM was started (caller returns and the
  * parent advances when it completes), FALSE if no reinit was needed.
  */
+static void
+goodix_reinit_idle_joined (FpDevice *dev, gpointer data)
+{
+  goodix_maybe_start_reinit_subsm (data, dev);
+}
+
 gboolean
 goodix_maybe_start_reinit_subsm (FpiSsm   *ssm,
                                  FpDevice *dev)
@@ -763,6 +769,18 @@ goodix_maybe_start_reinit_subsm (FpiSsm   *ssm,
 
   if (!self->needs_reinit)
     return FALSE;
+
+  if (self->idle_rx_ssm)
+    {
+      /* Reinitialization also releases the interface; join the idle owner
+       * before either release or USB reset, just as close does. */
+      goodix_idle_recv_stop (dev, goodix_reinit_idle_joined, ssm);
+      return TRUE;
+    }
+
+  /* A USB reset ends the transport that could complete the retained packet. */
+  goodix_proto_rx_reset (&self->rx);
+  self->rx_idle_partial = FALSE;
 
   fp_info ("Reinitializing device after system sleep");
   self->action_epoch++;

--- a/drivers/goodix53x5/device/session.c
+++ b/drivers/goodix53x5/device/session.c
@@ -683,7 +683,8 @@ goodix_open_complete_after_idle (FpDevice *dev, gpointer data)
     {
       /* Reset/close ends the transport that could complete retained data.
        * A completion winning idle cancellation may have just appended it. */
-      goodix_proto_rx_reset (&self->rx);
+      if (self->rx.buf)
+        goodix_proto_rx_reset (&self->rx);
       self->rx_idle_partial = FALSE;
       self->open_ref_powered = FALSE;
       goodix_milan_generation_invalidate (&self->milan_generation);

--- a/drivers/goodix53x5/device/transport.c
+++ b/drivers/goodix53x5/device/transport.c
@@ -67,6 +67,7 @@ typedef struct
 typedef struct
 {
   GoodixCmd                 cmd;
+  gboolean                  idle_after_ack;
   FpiSsm                   *parent_ssm;
   GoodixProfile9FdtWaitMode cancelled_fdt_mode;
   gboolean                  retry_mode;
@@ -79,6 +80,84 @@ typedef struct
   guint                     ack_timeout_ms;
   guint                     response_timeout_ms;
 } GoodixCmdOperation;
+
+typedef struct
+{
+  FpDevice                *dev;
+  GCancellable            *cancel;
+  GoodixIdleJoinedCallback joined;
+  gpointer                 joined_data;
+} GoodixIdleRecv;
+
+static void
+goodix_idle_recv_free (GoodixIdleRecv *idle)
+{
+  g_object_unref (idle->cancel);
+  g_object_unref (idle->dev);
+  g_free (idle);
+}
+
+static void
+goodix_idle_recv_done (FpiSsm *ssm, FpDevice *dev, GError *error)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  GoodixIdleRecv *idle = fpi_ssm_get_data (ssm);
+
+  self->idle_rx_ssm = NULL;
+  self->rx_idle_partial = self->rx.len && !goodix_proto_rx_complete (&self->rx);
+  if (error && !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+    {
+      fp_dbg ("Idle receive stopped: %s", error->message);
+      self->needs_reinit = TRUE;
+    }
+  g_clear_error (&error);
+  fp_dbg ("Idle receive joined; partial=%d", self->rx_idle_partial);
+  if (idle->joined)
+    idle->joined (dev, idle->joined_data);
+}
+
+static void
+goodix_idle_recv_handler (FpiSsm *ssm, FpDevice *dev)
+{
+  GoodixIdleRecv *idle = fpi_ssm_get_data (ssm);
+
+  goodix_recv_start (ssm, dev, 0, idle->cancel);
+}
+
+static void
+goodix_idle_recv_start (FpDevice *dev)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  GoodixIdleRecv *idle = g_new0 (GoodixIdleRecv, 1);
+
+  g_assert (!self->rx_active && !self->idle_rx_ssm);
+  idle->dev = g_object_ref (dev);
+  idle->cancel = g_cancellable_new ();
+  self->idle_rx_ssm = fpi_ssm_new (dev, goodix_idle_recv_handler, 1);
+  fpi_ssm_set_data (self->idle_rx_ssm, idle, (GDestroyNotify) goodix_idle_recv_free);
+  fp_dbg ("Idle receive started after EC-off ACK");
+  fpi_ssm_start (self->idle_rx_ssm, goodix_idle_recv_done);
+}
+
+void
+goodix_idle_recv_stop (FpDevice *dev, GoodixIdleJoinedCallback joined,
+                       gpointer data)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  if (self->idle_rx_ssm)
+    {
+      GoodixIdleRecv *idle = fpi_ssm_get_data (self->idle_rx_ssm);
+      g_assert (!idle->joined);
+      idle->joined = joined;
+      idle->joined_data = data;
+      g_cancellable_cancel (idle->cancel);
+    }
+  else
+    {
+      joined (dev, data);
+    }
+}
 
 /* Native budgets count Sleep(1) ACK polls and 50-ms response waits. GUsb uses
  * elapsed milliseconds instead: retain the caller's nominal budget across
@@ -507,7 +586,8 @@ goodix_recv_start_full (FpiSsm                     *ssm,
   operation->cancelled_cb = cancelled_cb;
   operation->cancelled_data = cancelled_data;
 
-  goodix_proto_rx_reset (&self->rx);
+  if (!self->rx_idle_partial)
+    goodix_proto_rx_reset (&self->rx);
   self->rx_active = TRUE;
   self->rx_owner = ssm;
 
@@ -601,13 +681,14 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
       const guint8 *payload;
       gsize payload_len;
       gboolean expected_ack = FALSE;
+      gboolean idle_packet = self->idle_rx_ssm == transfer->ssm || self->rx_idle_partial;
 
       if (goodix_proto_rx_parse (&self->rx, &category, &command,
                                  &payload, &payload_len))
         {
           guint8 bit = category == 3 && command == 3 ? 1 :
                        category == 9 && command == 0 ? 2 : 0;
-          GoodixCmdOperation *current = self->cmd_ssm == transfer->ssm ?
+          GoodixCmdOperation *current = !idle_packet && self->cmd_ssm == transfer->ssm ?
                                         fpi_ssm_get_data (transfer->ssm) : NULL;
 
           if (bit)
@@ -634,9 +715,9 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
                   goto receive_more;
                 }
             }
-          else if (current && category == 3 && (command == 1 || command == 2) &&
-                   (current->response_bit ||
-                    (current->cmd.category == 3 && current->cmd.command <= 2)))
+          else if (category == 3 && (command == 1 || command == 2) &&
+                   (idle_packet || (current && (current->response_bit ||
+                                                (current->cmd.category == 3 && current->cmd.command <= 2)))))
             {
               GoodixFdtEventType type;
               GoodixProfile9FdtEvent event;
@@ -657,12 +738,29 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
               /* Every native parser mutation precedes replacement of the
                * latest worker notification, including during config/manual. */
               goodix_recv_apply_fdt_event (dev, type, &event);
-              self->pending_fdt_packet_len = self->rx.expected;
-              self->pending_fdt_mode = mode;
-              memcpy (self->pending_fdt_packet, self->rx.buf, self->rx.expected);
+              if (!idle_packet)
+                {
+                  self->pending_fdt_packet_len = self->rx.expected;
+                  self->pending_fdt_mode = mode;
+                  memcpy (self->pending_fdt_packet, self->rx.buf, self->rx.expected);
+                }
               goodix_proto_rx_reset (&self->rx);
               goto receive_more;
             }
+          if (idle_packet)
+            {
+              /* No active waiter: ordinary unclaimed packets have no result
+               * owner. EC data likewise has no native cache/event side effect. */
+              fp_dbg ("Idle receive consumed cat=0x%02x cmd=0x%02x", category, command);
+              goodix_proto_rx_reset (&self->rx);
+              goto receive_more;
+            }
+        }
+      else if (idle_packet)
+        {
+          goodix_rx_cb (transfer, dev, operation, fpi_device_error_new_msg (
+                          FP_DEVICE_ERROR_PROTO, "Invalid idle protocol packet"));
+          return;
         }
 
       /* Native EC has no response event. Optional category-A/command-7 data
@@ -709,7 +807,7 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
     {
       /* Preserve unrelated per-continuation data budgets. Scoped command waits
        * keep one deadline across interleaved packets and continuations. */
-      if (!operation->fixed_deadline)
+      if (!operation->fixed_deadline && self->idle_rx_ssm != transfer->ssm)
         operation->deadline_us = g_get_monotonic_time () + GOODIX_DATA_TIMEOUT * 1000LL;
       goto receive_more;
     }
@@ -717,6 +815,16 @@ goodix_rx_cb (FpiUsbTransfer *transfer,
 
 receive_more:
   {
+    if (self->rx.len == 0)
+      self->rx_idle_partial = FALSE;
+    if (self->idle_rx_ssm == transfer->ssm &&
+        g_cancellable_is_cancelled (operation->cancellable))
+      {
+        goodix_recv_operation_finish (dev, transfer->ssm, operation);
+        goodix_recv_operation_free (operation);
+        fpi_ssm_mark_completed (transfer->ssm);
+        return;
+      }
     guint timeout = operation->deadline_us ?
                     goodix_deadline_remaining (operation->deadline_us) : 0;
 
@@ -912,8 +1020,18 @@ goodix_cmd_ssm_done (FpiSsm   *ssm,
     }
   else
     {
+      if (operation->idle_after_ack)
+        goodix_idle_recv_start (dev);
       fpi_ssm_next_state (operation->parent_ssm);
     }
+}
+
+static void
+goodix_cmd_begin_after_idle (FpDevice *dev, gpointer data)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+
+  fpi_ssm_start (self->cmd_ssm, goodix_cmd_ssm_done);
 }
 
 static void
@@ -925,14 +1043,15 @@ goodix_run_cmd_full (FpiSsm                    *parent_ssm,
                      gsize                      payload_len,
                      gboolean                   expect_data,
                      GoodixProfile9FdtWaitMode  cancelled_mode,
-                     GoodixCmdResultCallback   callback)
+                     GoodixCmdResultCallback   callback,
+                     gboolean                  idle_after_ack)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   FpiSsm *cmd_ssm;
   GoodixCmdOperation *operation;
   GoodixCmd *cmd;
 
-  if (self->cmd_owner || self->rx_active)
+  if (self->cmd_owner || (self->rx_active && self->rx_owner != self->idle_rx_ssm))
     {
       fpi_ssm_mark_failed (
         parent_ssm,
@@ -946,6 +1065,7 @@ goodix_run_cmd_full (FpiSsm                    *parent_ssm,
   operation = g_new0 (GoodixCmdOperation, 1);
   operation->parent_ssm = parent_ssm;
   operation->result_cb = callback;
+  operation->idle_after_ack = idle_after_ack;
   operation->cancelled_fdt_mode = cancelled_mode;
   operation->response_bit = expect_data ?
                             (category == 3 && command == 3 ? 1 :
@@ -980,7 +1100,7 @@ goodix_run_cmd_full (FpiSsm                    *parent_ssm,
   fpi_ssm_set_data (cmd_ssm, operation,
                     (GDestroyNotify) goodix_cmd_operation_free);
   self->cmd_ssm = cmd_ssm;
-  fpi_ssm_start (cmd_ssm, goodix_cmd_ssm_done);
+  goodix_idle_recv_stop (dev, goodix_cmd_begin_after_idle, NULL);
 }
 
 void
@@ -994,7 +1114,15 @@ goodix_run_cmd (FpiSsm       *parent_ssm,
 {
   goodix_run_cmd_full (parent_ssm, dev, category, command, payload,
                        payload_len, expect_data,
-                       GOODIX_PROFILE9_FDT_WAIT_NONE, NULL);
+                       GOODIX_PROFILE9_FDT_WAIT_NONE, NULL, FALSE);
+}
+
+void
+goodix_run_cmd_ec_off (FpiSsm *ssm, FpDevice *dev,
+                       const guint8 *payload, gsize payload_len)
+{
+  goodix_run_cmd_full (ssm, dev, 0x0a, 7, payload, payload_len, FALSE,
+                       GOODIX_PROFILE9_FDT_WAIT_NONE, NULL, TRUE);
 }
 
 void
@@ -1004,7 +1132,7 @@ goodix_run_cmd_result (FpiSsm *ssm, FpDevice *dev,
                        gboolean expect_data, GoodixCmdResultCallback callback)
 {
   goodix_run_cmd_full (ssm, dev, category, command, payload, payload_len,
-                       expect_data, GOODIX_PROFILE9_FDT_WAIT_NONE, callback);
+                       expect_data, GOODIX_PROFILE9_FDT_WAIT_NONE, callback, FALSE);
 }
 
 void
@@ -1019,7 +1147,7 @@ goodix_run_cmd_drain_fdt_once (
 {
   g_return_if_fail (cancelled_mode != GOODIX_PROFILE9_FDT_WAIT_NONE);
   goodix_run_cmd_full (parent_ssm, dev, category, command, payload,
-                       payload_len, FALSE, cancelled_mode, NULL);
+                       payload_len, FALSE, cancelled_mode, NULL, FALSE);
 }
 
 gboolean

--- a/drivers/goodix53x5/device/transport.h
+++ b/drivers/goodix53x5/device/transport.h
@@ -22,6 +22,13 @@
 #include "driver-private.h"
 #include "device/commands.h"
 
+/* Optional receive lifetime ends only after its USB callback joins. */
+typedef void (*GoodixIdleJoinedCallback) (FpDevice *dev, gpointer data);
+void goodix_idle_recv_stop (FpDevice *dev, GoodixIdleJoinedCallback joined,
+                            gpointer data);
+void goodix_run_cmd_ec_off (FpiSsm *ssm, FpDevice *dev,
+                             const guint8 *payload, gsize payload_len);
+
 /* Timeouts in ms */
 #define GOODIX_ACK_TIMEOUT    2000
 #define GOODIX_DATA_TIMEOUT   5000

--- a/drivers/goodix53x5/driver-private.h
+++ b/drivers/goodix53x5/driver-private.h
@@ -111,6 +111,8 @@ struct _FpiDeviceGoodix53x5
   guint8  pending_fdt_packet[4 + 4 + GOODIX_FDT_BASE_LEN];
   gsize   pending_fdt_packet_len;
   GoodixProfile9FdtWaitMode pending_fdt_mode;
+  FpiSsm *idle_rx_ssm;
+  gboolean rx_idle_partial;
 
   /* Profile-9 FDT state persists across actions and hardware reinitialization. */
   GoodixProfile9FdtState profile9_fdt;

--- a/drivers/goodix53x5/goodix53x5.c
+++ b/drivers/goodix53x5/goodix53x5.c
@@ -25,6 +25,7 @@
 #include "device/enroll.h"
 #include "device/auth.h"
 #include "device/persistence.h"
+#include "device/transport.h"
 
 #include <string.h>
 #include <openssl/crypto.h>
@@ -47,7 +48,7 @@ goodix_open (FpDevice *dev)
 }
 
 static void
-goodix_close (FpDevice *dev)
+goodix_close_joined (FpDevice *dev, gpointer data)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
   GError *error = NULL;
@@ -61,6 +62,7 @@ goodix_close (FpDevice *dev)
   g_clear_pointer (&self->otp_data, g_free);
   g_clear_pointer (&self->fw_version, g_free);
   g_clear_pointer (&self->rx.buf, g_free);
+  self->rx_idle_partial = FALSE;
 #ifdef GOODIX53X5_DEBUG
   g_clear_pointer (&self->captured_image, g_free);
 #endif
@@ -80,6 +82,12 @@ goodix_close (FpDevice *dev)
   self->usb_interface_claimed = FALSE;
 
   fpi_device_close_complete (dev, error);
+}
+
+static void
+goodix_close (FpDevice *dev)
+{
+  goodix_idle_recv_stop (dev, goodix_close_joined, NULL);
 }
 
 static void

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -38,6 +38,7 @@ static GCancellable *test_action_cancellable (FpDevice *dev)
 #include "drivers/goodix53x5/device/scan.c"
 static gboolean idle_test_release (void);
 static gboolean idle_test_reset (void);
+static gboolean idle_test_claim (GError **error);
 static gboolean idle_test_usb_close (void);
 static void idle_test_open_complete (FpDevice *dev, GError *error);
 static void idle_test_close_complete (FpDevice *dev, GError *error);
@@ -49,7 +50,7 @@ static FpiSsm *idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handle
 #define fpi_device_close_complete idle_test_close_complete
 #include "drivers/goodix53x5/goodix53x5.c"
 #define g_usb_device_reset(device, error) idle_test_reset ()
-#define g_usb_device_claim_interface(device, interface, flags, error) TRUE
+#define g_usb_device_claim_interface(device, interface, flags, error) idle_test_claim (error)
 #define fpi_ssm_new_full idle_test_reinit_ssm
 /* The virtual fixture has no USB handle or outer open GTask. Keep the real
  * session SSM and completion owner, replacing only those platform seams. */
@@ -1505,6 +1506,7 @@ static guint idle_closes;
 static guint idle_resets;
 static gboolean idle_reinit_testing;
 static gboolean idle_open_testing;
+static gboolean idle_claim_failure;
 static guint idle_usb_closes;
 static guint idle_open_ssms_freed;
 static FpDevice *idle_device;
@@ -1527,12 +1529,24 @@ idle_test_release (void)
 }
 
 static gboolean
+idle_test_claim (GError **error)
+{
+  if (!idle_claim_failure)
+    return TRUE;
+  g_set_error_literal (error, G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_NO_DEVICE,
+                       "Early claim failure");
+  return FALSE;
+}
+
+static gboolean
 idle_test_usb_close (void)
 {
   g_assert_true (idle_open_testing);
   g_assert_null (io.pending);
   g_assert_null (FPI_DEVICE_GOODIX53X5 (idle_device)->idle_rx_ssm);
-  g_assert_cmpuint (idle_releases, ==, 1);
+  g_assert_cmpuint (idle_releases, ==, idle_claim_failure ? 0 : 1);
+  if (idle_claim_failure)
+    g_assert_null (FPI_DEVICE_GOODIX53X5 (idle_device)->rx.buf);
   idle_usb_closes++;
   return TRUE;
 }
@@ -1988,6 +2002,35 @@ test_idle_failed_open (gconstpointer user_data)
   idle_device = NULL;
   g_clear_object (&dev);
   g_assert_null (weak);
+  if (which == 5)
+    {
+      /* Also fail before the first receive: teardown must not allocate RX. */
+      guint writes = io.started_writes;
+
+      dev = g_object_new (FPI_TYPE_DEVICE_GOODIX53X5, NULL);
+      idle_device = dev;
+      self = FPI_DEVICE_GOODIX53X5 (dev);
+      g_assert_null (self->rx.buf);
+      self->open_recovery_attempted = TRUE;
+      idle_releases = 0;
+      idle_claim_failure = TRUE;
+      ssm = fpi_ssm_new_full (dev, goodix_open_ssm_handler, GOODIX_OPEN_NUM_STATES,
+                              GOODIX_OPEN_SLEEP, "early-failed-open");
+      self->task_ssm = ssm;
+      g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                             "*Device open failed: Early claim failure*");
+      fpi_ssm_start (ssm, goodix_open_ssm_done);
+      g_test_assert_expected_messages ();
+      g_assert_error (io.error, G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_NO_DEVICE);
+      g_assert_cmpstr (io.error->message, ==, "Early claim failure");
+      g_assert_cmpuint (io.completions, ==, 2);
+      g_assert_cmpuint (io.started_writes, ==, writes);
+      g_assert_null (io.pending);
+      g_assert_null (self->rx.buf);
+      g_clear_error (&io.error);
+      idle_device = NULL;
+      idle_claim_failure = FALSE;
+    }
   idle_open_testing = FALSE;
 }
 

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -36,6 +36,25 @@ static GCancellable *test_action_cancellable (FpDevice *dev)
 #include "drivers/goodix53x5/device/transport.c"
 #include "drivers/goodix53x5/device/commands.c"
 #include "drivers/goodix53x5/device/scan.c"
+static gboolean idle_test_release (void);
+static gboolean idle_test_reset (void);
+static void idle_test_close_complete (FpDevice *dev, GError *error);
+static FpiSsm *idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handler,
+                                    int states, int cleanup, const char *name);
+/* Exercise the real driver close, replacing only USB release and the outer
+ * action completion (this transport fixture has no libfprint current GTask). */
+#define g_usb_device_release_interface(device, interface, flags, error) idle_test_release ()
+#define fpi_device_close_complete idle_test_close_complete
+#include "drivers/goodix53x5/goodix53x5.c"
+#define g_usb_device_reset(device, error) idle_test_reset ()
+#define g_usb_device_claim_interface(device, interface, flags, error) TRUE
+#define fpi_ssm_new_full idle_test_reinit_ssm
+#include "drivers/goodix53x5/device/session.c"
+#undef fpi_ssm_new_full
+#undef g_usb_device_claim_interface
+#undef g_usb_device_reset
+#undef g_usb_device_release_interface
+#undef fpi_device_close_complete
 #undef goodix_milan_generation_prepare_setup
 #undef fpi_usb_transfer_submit
 #undef fpi_device_get_cancellable
@@ -390,7 +409,14 @@ complete_usb (gpointer unused)
       g_cancellable_cancel (action_cancel_token);
     }
 
-  if (transfer->endpoint == GOODIX_EP_OUT)
+  if (transfer->ssm == FPI_DEVICE_GOODIX53X5 (transfer->device)->idle_rx_ssm)
+    {
+      g_assert_nonnull (cancel);
+      g_assert_true (g_cancellable_is_cancelled (cancel));
+      error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED,
+                                   "Scheduled idle receive join");
+    }
+  else if (transfer->endpoint == GOODIX_EP_OUT)
     {
       EventOrder order = scenario->event_order;
       if (order == WRITE_STALLED_CANCEL && io.command == 0x34 && !io.action_cancelled)
@@ -1079,6 +1105,14 @@ parent_handler (FpiSsm *ssm, FpDevice *dev)
 }
 
 static void
+idle_joined (FpDevice *dev, gpointer data)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (dev);
+  g_assert_false (self->rx_active);
+  g_assert_null (self->idle_rx_ssm);
+}
+
+static void
 test_scenario (gconstpointer user_data)
 {
   const Scenario *scenario = user_data;
@@ -1190,6 +1224,18 @@ test_scenario (gconstpointer user_data)
         g_main_context_iteration (NULL, TRUE);
     }
 
+  if (self->idle_rx_ssm)
+    {
+      gboolean completed = FALSE;
+
+      /* Action completion no longer closes the handle-owned idle receiver.
+       * Exercise its explicit join before retaining the original owner checks. */
+      goodix_idle_recv_stop (dev, idle_joined, NULL);
+      g_idle_add (complete_usb, &completed);
+      while (!completed)
+        g_main_context_iteration (NULL, TRUE);
+      g_assert_null (self->idle_rx_ssm);
+    }
   g_assert_cmpuint (io.completions, ==, 1);
   g_assert_null (io.pending);
   g_assert_false (self->rx_active);
@@ -1442,6 +1488,309 @@ test_scenario (gconstpointer user_data)
   g_clear_object (&self->cancel);
 }
 
+static guint idle_releases;
+static guint idle_closes;
+static guint idle_resets;
+static gboolean idle_reinit_testing;
+static FpDevice *idle_device;
+
+static gboolean
+idle_test_release (void)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (idle_device);
+  g_assert_null (io.pending);
+  g_assert_null (self->idle_rx_ssm);
+  g_assert_false (self->rx_active);
+  if (idle_reinit_testing && idle_releases == 0)
+    {
+      g_assert_cmpuint (self->rx.len, ==, 0);
+      g_assert_cmpuint (self->rx.expected, ==, 0);
+      g_assert_false (self->rx_idle_partial);
+    }
+  idle_releases++;
+  return TRUE;
+}
+
+static void
+idle_test_close_complete (FpDevice *dev, GError *error)
+{
+  g_assert_true (dev == idle_device);
+  g_assert_no_error (error);
+  g_assert_cmpuint (idle_releases, ==, 1 + idle_resets);
+  idle_closes++;
+}
+
+static gboolean
+idle_test_reset (void)
+{
+  FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (idle_device);
+
+  g_assert_true (idle_reinit_testing);
+  g_assert_cmpuint (idle_releases, ==, 1);
+  g_assert_null (io.pending);
+  g_assert_null (self->idle_rx_ssm);
+  g_assert_false (self->rx_active);
+  g_assert_false (self->rx_idle_partial);
+  g_assert_cmpuint (self->rx.len, ==, 0);
+  idle_resets++;
+  return TRUE;
+}
+
+static FpiSsm *
+idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handler,
+                      int states, int cleanup, const char *name)
+{
+  g_assert_true (idle_reinit_testing);
+  g_assert_true (handler == goodix_open_ssm_handler);
+  /* Run the actual session reset, claim and PING states, stopping before
+   * firmware/TLS/calibration. No replacement reset or PING implementation. */
+  return fpi_ssm_new_full (dev, handler, GOODIX_OPEN_READ_FW_VERSION,
+                           GOODIX_OPEN_READ_FW_VERSION, name);
+}
+
+static void
+idle_test_reinit (FpiSsm *ssm, FpDevice *dev)
+{
+  g_assert_true (goodix_maybe_start_reinit_subsm (ssm, dev));
+}
+
+static void
+idle_test_complete (GError *error)
+{
+  FpiUsbTransfer *transfer = g_steal_pointer (&io.pending);
+  FpiUsbTransferCallback callback = io.callback;
+  gpointer data = io.user_data;
+  g_autoptr(GCancellable) cancel = g_steal_pointer (&io.cancel);
+
+  g_assert_nonnull (transfer);
+  if (!error && transfer->endpoint == GOODIX_EP_OUT)
+    transfer->actual_length = transfer->length;
+  callback (transfer, transfer->device, data, error);
+  fpi_usb_transfer_unref (transfer);
+}
+
+static void
+idle_test_command_done (FpiSsm *ssm, FpDevice *dev, GError *error)
+{
+  if (g_cancellable_is_cancelled (action_cancel_token))
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
+      g_assert_true (FPI_DEVICE_GOODIX53X5 (dev)->needs_reinit);
+      g_clear_error (&error);
+    }
+  else
+    g_assert_no_error (error);
+  g_assert_null (FPI_DEVICE_GOODIX53X5 (dev)->cmd_ssm);
+  io.completions++;
+}
+
+static void
+idle_test_ec (FpiSsm *ssm, FpDevice *dev)
+{
+  goodix_cmd_ec_control (ssm, dev, FALSE);
+}
+
+static void
+idle_test_ping (FpiSsm *ssm, FpDevice *dev)
+{
+  goodix_cmd_ping (ssm, dev);
+}
+
+static void
+test_idle_lifetime (gconstpointer user_data)
+{
+  guint which = GPOINTER_TO_UINT (user_data);
+  static const Scenario scenario = { .event_order = EVENT_CANCELLED };
+  FpDeviceClass *klass = g_type_class_ref (FPI_TYPE_DEVICE_GOODIX53X5);
+  FpDevice *dev;
+  FpDevice *weak;
+  FpiDeviceGoodix53x5 *self;
+  guint8 ec_data[] = { 1, 0 };
+  guint8 partial_payload[96] = { 0 };
+  gsize partial_length;
+  g_autofree guint8 *partial = goodix_proto_build_message (
+    9, 0, partial_payload, sizeof (partial_payload), TRUE, &partial_length);
+  guint8 fragment[64];
+  guint8 continuation[37] = { 0x91 };
+  gboolean handoff = which == 2 || which == 3 || which == 4 || which == 6 || which == 11;
+
+  memset (&io, 0, sizeof (io));
+  io.scenario = &scenario;
+  idle_releases = idle_closes = 0;
+  idle_resets = 0;
+  idle_reinit_testing = which == 11;
+  action_cancel_token = g_cancellable_new ();
+  klass->type = FP_DEVICE_TYPE_VIRTUAL;
+  dev = g_object_new (FPI_TYPE_DEVICE_GOODIX53X5, NULL);
+  g_type_class_unref (klass);
+  idle_device = dev;
+  weak = dev;
+  g_object_add_weak_pointer (G_OBJECT (dev), (gpointer *) &weak);
+  self = FPI_DEVICE_GOODIX53X5 (dev);
+  self->cancel = g_cancellable_new ();
+  fpi_ssm_start (fpi_ssm_new (dev, idle_test_ec, 1), idle_test_command_done);
+  idle_test_complete (NULL); /* EC write */
+  ack_reply (io.pending, 0xae);
+  idle_test_complete (NULL);
+
+  /* EC and its parent SSM are already gone, without any optional reply. */
+  g_assert_cmpuint (io.completions, ==, 1);
+  g_assert_nonnull (self->idle_rx_ssm);
+  g_assert_true (io.pending->ssm == self->idle_rx_ssm);
+  g_assert_true (self->rx_owner == self->idle_rx_ssm);
+  g_assert_cmpuint (io.timeout, ==, 0);
+  g_assert_true (io.cancel != action_cancel_token && io.cancel != self->cancel);
+
+  if (which == 1)
+    {
+      reply (io.pending, 0xa, 7, ec_data, sizeof (ec_data));
+      idle_test_complete (NULL);
+      g_assert_nonnull (io.pending);
+      g_assert_cmpuint (self->rx.len, ==, 0);
+      g_assert_cmpuint (self->command_response_ready, ==, 0);
+    }
+  if (which == 4 || which == 11)
+    {
+      g_assert_cmpuint (partial_length, ==, 100);
+      memcpy (fragment, partial, sizeof (fragment));
+      memcpy (continuation + 1, partial + sizeof (fragment), sizeof (continuation) - 1);
+      memcpy (io.pending->buffer, fragment, sizeof (fragment));
+      io.pending->actual_length = sizeof (fragment);
+      idle_test_complete (NULL);
+      g_assert_cmpuint (self->rx.len, ==, sizeof (fragment));
+      g_assert_cmpuint (io.timeout, ==, 0);
+    }
+  if (which == 9)
+    {
+      reverse_event (io.pending, 0);
+      idle_test_complete (NULL);
+      reverse_event (io.pending, 1);
+      idle_test_complete (NULL);
+      for (guint i = 0; i < GOODIX_PROFILE9_FDT_AREA_COUNT; i++)
+        {
+          g_assert_cmpuint (self->fdt_prior_down[i], ==, 50 + i);
+          g_assert_cmpuint (self->profile9_fdt.base_manual[2 * i], ==, 50 + i);
+          g_assert_cmpuint (self->profile9_fdt.base_down[2 * i], ==, 51 + i);
+        }
+      g_assert_cmpuint (self->pending_fdt_packet_len, ==, 0);
+      g_assert_null (self->profile9_fdt.owner);
+    }
+  if (which == 10)
+    {
+      guint8 manual[28] = { 0x80 };
+      reply (io.pending, 3, 3, manual, sizeof (manual));
+      idle_test_complete (NULL);
+      reply (io.pending, 9, 0, ec_data, 1);
+      idle_test_complete (NULL);
+      g_assert_cmpuint (self->command_response_ready, ==, 3);
+      g_assert_cmpmem (self->manual_response, sizeof (manual), manual, sizeof (manual));
+      g_assert_cmpuint (self->profile9_fdt.base_manual[0], ==, 0);
+    }
+  if (which == 5 || which == 8)
+    {
+      if (which == 5)
+        idle_test_complete (g_error_new_literal (G_USB_DEVICE_ERROR,
+                                                G_USB_DEVICE_ERROR_NO_DEVICE, "Removed idle reader"));
+      else
+        {
+          reply (io.pending, 0xa, 7, ec_data, sizeof (ec_data));
+          io.pending->buffer[5] ^= 1;
+          g_test_expect_message ("libfprint-goodix53x5", G_LOG_LEVEL_WARNING,
+                                 "*checksum validation failed*");
+          idle_test_complete (NULL);
+          g_test_assert_expected_messages ();
+        }
+      g_assert_null (io.pending);
+      g_assert_null (self->idle_rx_ssm);
+      g_assert_true (self->needs_reinit);
+    }
+  if (handoff)
+    {
+      guint writes = io.started_writes;
+      if (which == 11)
+        {
+          self->needs_reinit = TRUE;
+          self->usb_interface_claimed = TRUE;
+          fpi_ssm_start (fpi_ssm_new (dev, idle_test_reinit, 1), idle_test_command_done);
+          g_assert_cmpuint (idle_releases, ==, 0);
+          g_assert_cmpuint (idle_resets, ==, 0);
+          g_assert_cmpuint (self->rx.len, ==, sizeof (fragment));
+        }
+      else
+        fpi_ssm_start (fpi_ssm_new (dev, idle_test_ping, 1), idle_test_command_done);
+      g_assert_true (g_cancellable_is_cancelled (io.cancel));
+      g_assert_cmpuint (io.started_writes, ==, writes);
+      if (which == 6)
+        g_cancellable_cancel (action_cancel_token);
+      if (which == 3)
+        {
+          reply (io.pending, 0xa, 7, ec_data, sizeof (ec_data));
+          idle_test_complete (NULL); /* Completion wins idle cancellation. */
+        }
+      else
+        idle_test_complete (g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED, "Joined idle"));
+      g_assert_null (self->idle_rx_ssm);
+      g_assert_cmpuint (io.pending->endpoint, ==, GOODIX_EP_OUT);
+      if (which == 11)
+        {
+          g_assert_cmpuint (idle_resets, ==, 1);
+          g_assert_cmpuint (self->rx.len, ==, 0);
+          g_assert_false (self->rx_idle_partial);
+        }
+      if (which == 6)
+        {
+          /* Cancelled action must not start physical OUT or a fresh idle read. */
+          g_assert_true (g_cancellable_is_cancelled (io.cancel));
+          g_assert_cmpuint (io.started_writes, ==, writes);
+        }
+      idle_test_complete (which == 6 ? g_error_new_literal (
+        G_IO_ERROR, G_IO_ERROR_CANCELLED, "Cancelled command write") : NULL);
+      if (which == 4)
+        {
+          g_assert_true (self->rx_idle_partial);
+          g_assert_cmpuint (self->rx.len, ==, sizeof (fragment));
+          memcpy (io.pending->buffer, continuation, sizeof (continuation));
+          io.pending->actual_length = sizeof (continuation);
+          idle_test_complete (NULL);
+          g_assert_false (self->rx_idle_partial);
+          g_assert_cmpuint (self->command_response_ready, ==, 2);
+          g_assert_cmpuint (io.completions, ==, 1);
+        }
+      if (which != 6)
+        {
+          ack_reply (io.pending, 0);
+          idle_test_complete (NULL);
+        }
+      g_assert_cmpuint (io.completions, ==, 2);
+    }
+
+  /* Retain only the explicit idle device reference until the close joins. */
+  gboolean pending = self->idle_rx_ssm != NULL;
+  goodix_close (dev);
+  if (pending)
+    {
+      g_assert_cmpuint (idle_releases, ==, 0);
+      g_assert_cmpuint (idle_closes, ==, 0);
+      g_assert_nonnull (self->rx.buf);
+      g_object_unref (dev);
+      g_assert_nonnull (weak);
+      if (which == 7)
+        {
+          reply (io.pending, 0xa, 7, ec_data, sizeof (ec_data));
+          idle_test_complete (NULL);
+        }
+      else
+        idle_test_complete (g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED, "Close idle join"));
+    }
+  else
+    g_object_unref (dev);
+  g_assert_cmpuint (idle_closes, ==, 1);
+  g_assert_null (weak);
+  g_assert_null (io.pending);
+  g_clear_object (&action_cancel_token);
+  idle_device = NULL;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1493,6 +1842,14 @@ main (int argc, char **argv)
   static const Scenario drain_control = { 0, 0, 1, 1, TRUE, STOP_DRAIN_CONTROL };
 
   g_test_init (&argc, &argv, NULL);
+  const char *idle_names[] = { "ack-only-close", "tail", "handoff", "handoff-race",
+                              "partial-handoff", "removal", "action-cancel", "close-race", "bad-frame",
+                              "stopped-fdt", "response-caches", "partial-reinit" };
+  for (guint i = 0; i < G_N_ELEMENTS (idle_names); i++)
+    {
+      g_autofree char *name = g_strdup_printf ("/goodix53x5/milan/transport/idle/%s", idle_names[i]);
+      g_test_add_data_func (name, GUINT_TO_POINTER (i), test_idle_lifetime);
+    }
   static const Scenario cleanup_earlier = { 0x60, 2, 1, 2, FALSE, EARLIER_CLEANUP_ERROR };
   static const Scenario cleanup_protocol = { 0x60, 2, 1, 2, FALSE, CLEANUP_LATE_PROTO };
   g_test_add_data_func ("/goodix53x5/milan/transport/cleanup/earlier-error", &cleanup_earlier, test_scenario);

--- a/tests/test-goodix53x5-milan-transport.c
+++ b/tests/test-goodix53x5-milan-transport.c
@@ -38,6 +38,8 @@ static GCancellable *test_action_cancellable (FpDevice *dev)
 #include "drivers/goodix53x5/device/scan.c"
 static gboolean idle_test_release (void);
 static gboolean idle_test_reset (void);
+static gboolean idle_test_usb_close (void);
+static void idle_test_open_complete (FpDevice *dev, GError *error);
 static void idle_test_close_complete (FpDevice *dev, GError *error);
 static FpiSsm *idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handler,
                                     int states, int cleanup, const char *name);
@@ -49,7 +51,17 @@ static FpiSsm *idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handle
 #define g_usb_device_reset(device, error) idle_test_reset ()
 #define g_usb_device_claim_interface(device, interface, flags, error) TRUE
 #define fpi_ssm_new_full idle_test_reinit_ssm
+/* The virtual fixture has no USB handle or outer open GTask. Keep the real
+ * session SSM and completion owner, replacing only those platform seams. */
+#define g_usb_device_close(device, error) ((void) (device), idle_test_usb_close ())
+#define fpi_device_open_complete idle_test_open_complete
+#define fpi_device_action_is_cancelled(device) g_cancellable_is_cancelled (action_cancel_token)
+#define fpi_device_get_usb_device(device) ((GUsbDevice *) NULL)
 #include "drivers/goodix53x5/device/session.c"
+#undef fpi_device_get_usb_device
+#undef fpi_device_action_is_cancelled
+#undef fpi_device_open_complete
+#undef g_usb_device_close
 #undef fpi_ssm_new_full
 #undef g_usb_device_claim_interface
 #undef g_usb_device_reset
@@ -1492,6 +1504,9 @@ static guint idle_releases;
 static guint idle_closes;
 static guint idle_resets;
 static gboolean idle_reinit_testing;
+static gboolean idle_open_testing;
+static guint idle_usb_closes;
+static guint idle_open_ssms_freed;
 static FpDevice *idle_device;
 
 static gboolean
@@ -1501,7 +1516,7 @@ idle_test_release (void)
   g_assert_null (io.pending);
   g_assert_null (self->idle_rx_ssm);
   g_assert_false (self->rx_active);
-  if (idle_reinit_testing && idle_releases == 0)
+  if ((idle_reinit_testing || idle_open_testing) && idle_releases == 0)
     {
       g_assert_cmpuint (self->rx.len, ==, 0);
       g_assert_cmpuint (self->rx.expected, ==, 0);
@@ -1509,6 +1524,29 @@ idle_test_release (void)
     }
   idle_releases++;
   return TRUE;
+}
+
+static gboolean
+idle_test_usb_close (void)
+{
+  g_assert_true (idle_open_testing);
+  g_assert_null (io.pending);
+  g_assert_null (FPI_DEVICE_GOODIX53X5 (idle_device)->idle_rx_ssm);
+  g_assert_cmpuint (idle_releases, ==, 1);
+  idle_usb_closes++;
+  return TRUE;
+}
+
+static void
+idle_test_open_complete (FpDevice *dev, GError *error)
+{
+  g_assert_true (idle_open_testing);
+  g_assert_true (dev == idle_device);
+  g_assert_null (io.pending);
+  g_assert_null (FPI_DEVICE_GOODIX53X5 (dev)->idle_rx_ssm);
+  g_assert_null (io.error);
+  io.error = error;
+  io.completions++;
 }
 
 static void
@@ -1525,7 +1563,7 @@ idle_test_reset (void)
 {
   FpiDeviceGoodix53x5 *self = FPI_DEVICE_GOODIX53X5 (idle_device);
 
-  g_assert_true (idle_reinit_testing);
+  g_assert_true (idle_reinit_testing || idle_open_testing);
   g_assert_cmpuint (idle_releases, ==, 1);
   g_assert_null (io.pending);
   g_assert_null (self->idle_rx_ssm);
@@ -1540,7 +1578,7 @@ static FpiSsm *
 idle_test_reinit_ssm (FpDevice *dev, FpiSsmHandlerCallback handler,
                       int states, int cleanup, const char *name)
 {
-  g_assert_true (idle_reinit_testing);
+  g_assert_true (idle_reinit_testing || idle_open_testing);
   g_assert_true (handler == goodix_open_ssm_handler);
   /* Run the actual session reset, claim and PING states, stopping before
    * firmware/TLS/calibration. No replacement reset or PING implementation. */
@@ -1791,6 +1829,168 @@ test_idle_lifetime (gconstpointer user_data)
   idle_device = NULL;
 }
 
+static void
+idle_open_cleanup_entry (FpiSsm *ssm, FpDevice *dev)
+{
+  /* Admit the completed reference-capture boundary; all cleanup states and
+   * the failed-open completion/recovery owner below are production code. */
+  if (fpi_ssm_get_cur_state (ssm) == 0)
+    fpi_ssm_jump_to_state (ssm, GOODIX_OPEN_SLEEP);
+  else
+    goodix_open_ssm_handler (ssm, dev);
+}
+
+static void
+idle_open_data_free (gpointer data)
+{
+  g_assert_true (data == &idle_open_ssms_freed);
+  idle_open_ssms_freed++;
+}
+
+static void
+test_idle_failed_open (gconstpointer user_data)
+{
+  guint which = GPOINTER_TO_UINT (user_data);
+  gboolean recover = which < 3 || which == 6;
+  guint completion = which == 8 ? 0 : which >= 6 ? 3 : which % 3;
+  /* cancelled, partial completion, no idle, complete optional response */
+  static const Scenario scenario = { .event_order = EVENT_CANCELLED };
+  FpDeviceClass *klass = g_type_class_ref (FPI_TYPE_DEVICE_GOODIX53X5);
+  g_autoptr(FpDevice) dev = NULL;
+  FpiDeviceGoodix53x5 *self;
+  FpiSsm *ssm;
+  g_autoptr(GError) original = NULL;
+  FpDevice *weak;
+
+  memset (&io, 0, sizeof (io));
+  io.scenario = &scenario;
+  idle_releases = idle_closes = idle_resets = idle_usb_closes = idle_open_ssms_freed = 0;
+  idle_open_testing = TRUE;
+  idle_reinit_testing = FALSE;
+  action_cancel_token = g_cancellable_new ();
+  klass->type = FP_DEVICE_TYPE_VIRTUAL;
+  dev = g_object_new (FPI_TYPE_DEVICE_GOODIX53X5, NULL);
+  g_type_class_unref (klass);
+  weak = dev;
+  g_object_add_weak_pointer (G_OBJECT (dev), (gpointer *) &weak);
+  idle_device = dev;
+  self = FPI_DEVICE_GOODIX53X5 (dev);
+  self->cancel = g_cancellable_new ();
+  self->usb_interface_claimed = TRUE;
+  self->open_ref_powered = TRUE;
+  self->open_recovery_attempted = !(recover || which == 8);
+  ssm = fpi_ssm_new_full (dev, idle_open_cleanup_entry, GOODIX_OPEN_NUM_STATES,
+                          GOODIX_OPEN_SLEEP, "failed-open-cleanup");
+  self->task_ssm = ssm;
+  fpi_ssm_set_data (ssm, &idle_open_ssms_freed, idle_open_data_free);
+  fpi_ssm_start (ssm, goodix_open_ssm_done);
+  for (guint i = 0; i < 2; i++)
+    {
+      g_assert_cmpuint (io.command, ==, 0x60);
+      idle_test_complete (NULL);
+      idle_test_complete (g_error_new_literal (G_USB_DEVICE_ERROR,
+                                               G_USB_DEVICE_ERROR_TIMED_OUT,
+                                               "original sleep timeout"));
+    }
+  original = g_error_copy (fpi_ssm_get_error (ssm));
+  g_assert_error (original, G_USB_DEVICE_ERROR, G_USB_DEVICE_ERROR_TIMED_OUT);
+  g_assert_nonnull (strstr (original->message, "original sleep timeout"));
+  g_assert_cmpuint (io.sends[0x60], ==, 2);
+  g_assert_cmpuint (io.command, ==, 0xae);
+  idle_test_complete (NULL);
+  if (!recover)
+    g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+                           "*Device open failed:*original sleep timeout*");
+  if (completion == 2)
+    idle_test_complete (g_error_new_literal (G_USB_DEVICE_ERROR,
+                                            G_USB_DEVICE_ERROR_TIMED_OUT,
+                                            "later EC timeout"));
+  else
+    {
+      ack_reply (io.pending, 0xae);
+      idle_test_complete (NULL);
+      g_assert_cmpuint (idle_open_ssms_freed, ==, 1);
+      g_assert_null (self->task_ssm);
+      g_assert_cmpuint (idle_releases, ==, 0);
+      g_assert_cmpuint (idle_resets, ==, 0);
+      g_assert_cmpuint (idle_usb_closes, ==, 0);
+      g_assert_cmpuint (io.completions, ==, 0);
+      g_assert_true (g_cancellable_is_cancelled (io.cancel));
+      GoodixIdleRecv *idle = fpi_ssm_get_data (self->idle_rx_ssm);
+      GError *retained = idle->joined_data;
+      g_assert_error (retained, original->domain, original->code);
+      g_assert_cmpstr (retained->message, ==, original->message);
+      if (which == 8)
+        g_cancellable_cancel (action_cancel_token);
+      if (completion == 1)
+        {
+          guint8 payload[96] = { 0 };
+          gsize len;
+          g_autofree guint8 *packet = goodix_proto_build_message (
+            9, 0, payload, sizeof (payload), TRUE, &len);
+          g_assert_cmpuint (len, >, 64);
+          memcpy (io.pending->buffer, packet, 64);
+          io.pending->actual_length = 64;
+          idle_test_complete (NULL); /* Partial data wins cancellation. */
+        }
+      else if (completion == 3)
+        {
+          guint8 payload[] = { 1, 0 };
+          reply (io.pending, 0xa, 7, payload, sizeof (payload));
+          idle_test_complete (NULL); /* Complete optional reply wins cancellation. */
+        }
+      else
+        idle_test_complete (g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED,
+                                                "idle cancellation joined"));
+    }
+  g_assert_cmpuint (idle_releases, ==, 1);
+  g_assert_false (self->rx_idle_partial);
+  g_assert_cmpuint (self->rx.len, ==, 0);
+  if (recover)
+    {
+      g_assert_cmpuint (idle_resets, ==, 1);
+      g_assert_cmpuint (idle_usb_closes, ==, 0);
+      g_assert_cmpuint (io.completions, ==, 0);
+      g_assert_cmpuint (io.command, ==, 0);
+      idle_test_complete (NULL);
+      g_assert_cmpuint (io.timeout, ==, 2000);
+      ack_reply (io.pending, 0);
+      idle_test_complete (NULL);
+      g_assert_no_error (io.error);
+    }
+  else
+    {
+      g_test_assert_expected_messages ();
+      g_assert_cmpuint (idle_resets, ==, 0);
+      g_assert_cmpuint (idle_usb_closes, ==, 1);
+      g_assert_error (io.error, original->domain, original->code);
+      g_assert_cmpstr (io.error->message, ==, original->message);
+    }
+  g_assert_cmpuint (io.completions, ==, 1);
+  g_assert_cmpuint (idle_open_ssms_freed, ==, 1);
+  g_assert_null (io.pending);
+  g_assert_null (self->task_ssm);
+  g_clear_error (&io.error);
+  g_clear_pointer (&io.first_sleep, g_bytes_unref);
+  if (recover)
+    {
+      goodix_close (dev);
+      g_assert_cmpuint (idle_closes, ==, 1);
+    }
+  else
+    {
+      /* A failed open has already closed USB; release fixture allocations. */
+      g_clear_pointer (&self->rx.buf, g_free);
+      g_clear_object (&self->cancel);
+      g_assert_cmpuint (idle_closes, ==, 0);
+    }
+  g_clear_object (&action_cancel_token);
+  idle_device = NULL;
+  g_clear_object (&dev);
+  g_assert_null (weak);
+  idle_open_testing = FALSE;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1842,6 +2042,15 @@ main (int argc, char **argv)
   static const Scenario drain_control = { 0, 0, 1, 1, TRUE, STOP_DRAIN_CONTROL };
 
   g_test_init (&argc, &argv, NULL);
+  const char *failed_open_names[] = { "recovery-cancel", "recovery-partial-race", "recovery-no-idle",
+                                     "final-cancel", "final-partial-race", "final-no-idle",
+                                     "recovery-reply-race", "final-reply-race", "action-cancel-during-join" };
+  for (guint i = 0; i < G_N_ELEMENTS (failed_open_names); i++)
+    {
+      g_autofree char *name = g_strdup_printf ("/goodix53x5/milan/transport/failed-open/%s",
+                                              failed_open_names[i]);
+      g_test_add_data_func (name, GUINT_TO_POINTER (i), test_idle_failed_open);
+    }
   const char *idle_names[] = { "ack-only-close", "tail", "handoff", "handoff-race",
                               "partial-handoff", "removal", "action-cancel", "close-race", "bad-frame",
                               "stopped-fdt", "response-caches", "partial-reinit" };


### PR DESCRIPTION
## Change

Keep optional Milan reception active after EC-off acknowledgment, preserving ACK-only command completion while servicing trailing device replies.

- Give idle reception its own cancellable and device reference rather than borrowing a completed action or command.
- Cancel and join the idle callback before submitting the next command, releasing the interface, or resetting the device, including failed-open recovery and final teardown.
- Retain the original failed-open error across the join without retaining the completed open SSM. Recheck cancellation before recovery.
- Process completions that win the cancellation race exactly once. Preserve partial assembly across a same-transport handoff and discard it after joining at reset/teardown.
- Reuse independent response routing and FDT base mutations without reviving stopped worker notifications.

The native continuous reader remains active beyond deactivation. Optional EC data has no second success event or handshake side effect, so reception must not become a mandatory EC response wait. This change adds no post-ACK delay and leaves startup PING policy unchanged.

## Validation

- Twenty-one focused asynchronous additions cover optional reply absence/presence, command handoff, cancellation races, device lifetime, real close/reset, and failed-open recovery/final teardown. Both failed-open schedules fail on the parent implementation before the join correction.
- Nine release suites: **288 cases pass**.
- Debug transport/runtime: **102 + 17 cases pass**.
- ASan/UBSan with leak detection: **102 transport and 17 runtime cases pass**.
- Hardware UAT of the initial receive-lifetime implementation covers repeated locking, sleep/resume and hibernate/resume. Repeated-open PING latency is sub-millisecond without changing the PING timeout; receive diagnostics confirm trailing EC replies are consumed. The subsequent failed-open join correction has independent review and asynchronous test coverage, but is not yet installed for hardware UAT.

Independent contract/ownership review is complete. Final captured-data native/current parity validation remains pending capture finalization; this PR does not claim that gate has passed or establish exhaustive hardware parity.
